### PR TITLE
fix: replace hardcoded user paths with tilde notation in Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -119,7 +119,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun /Users/daniel/.claude/hooks/load-dynamic-requirements.ts"
+            "command": "bun ~/.claude/hooks/load-dynamic-requirements.ts"
           }
         ]
       }
@@ -129,7 +129,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun /Users/daniel/.claude/hooks/session-start-hook.ts"
+            "command": "bun ~/.claude/hooks/session-start-hook.ts"
           }
         ]
       }
@@ -139,7 +139,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun /Users/daniel/.claude/hooks/stop-hook.ts"
+            "command": "bun ~/.claude/hooks/stop-hook.ts"
           }
         ]
       }
@@ -149,7 +149,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun /Users/daniel/.claude/hooks/subagent-stop-hook.ts"
+            "command": "bun ~/.claude/hooks/subagent-stop-hook.ts"
           }
         ]
       }
@@ -160,7 +160,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun /Users/daniel/.claude/hooks/context-compression-hook.ts"
+            "command": "bun ~/.claude/hooks/context-compression-hook.ts"
           }
         ]
       }
@@ -168,7 +168,7 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "bash /Users/daniel/.claude/statusline-command.sh"
+    "command": "bash ~/.claude/statusline-command.sh"
   },
   "feedbackSurveyState": {
     "lastShownTime": 1754071370324


### PR DESCRIPTION
## Summary
- Replace absolute paths starting with `/Users/daniel/` with tilde shorthand `~/` in Claude settings
- Makes configuration more portable across different user environments

## Changes
- Updated hook command paths in `.claude/settings.json` to use `~/` instead of hardcoded user directory
- Affects 5 hook commands and the statusline command

🤖 Generated with [Claude Code](https://claude.ai/code)