### PR TITLE
feat: add skill description audit tool and design checklist

### DIFF
--- a/Releases/v3.0/.claude/skills/CreateSkill/DesignChecklist.md
+++ b/Releases/v3.0/.claude/skills/CreateSkill/DesignChecklist.md
@@ -1,0 +1,96 @@
+# Skill Design Checklist
+
+Reference checklist for skill creation. Load during any CreateSkill workflow.
+
+---
+
+## 1. The Front Matter Formula
+
+```
+description: {What it does -- concrete, specific}. USE WHEN {trigger phrases separated by commas}.
+```
+
+- The description is Level 1 -- it determines whether the skill fires AT ALL
+- Every character counts. Max 1,024 characters (Anthropic hard limit)
+- The "what" portion must disambiguate from ALL other skills in the index
+- Triggers must be exact phrases a user would type, not semantic descriptions
+
+**Good:** `Convert, parse, and summarize document files. USE WHEN .docx, .pdf, parse document, extract text from file.`
+
+**Bad:** `Helps with document processing. USE WHEN documents, files, processing.`
+
+---
+
+## 2. The Three Tests
+
+Run all three before shipping any skill:
+
+1. **Triggering Test** -- Open a fresh terminal, type a trigger phrase naturally. Does the skill appear in the loaded skills list? Test at least 3 trigger phrases.
+2. **Functional Test** -- Run the skill 4-5 times with different inputs. Does it produce correct output each time?
+3. **Benchmark Test** -- Could this be a simple script instead? Skills add cognitive overhead to every session (Level 1 loads at startup). If a bash script or TS file achieves 90% of the value, it should NOT be a skill.
+
+---
+
+## 3. Character Budget
+
+| Target | Usage |
+|--------|-------|
+| Under 300 chars | Most skills |
+| 300-600 chars | Skills with many trigger phrases |
+| 600-1,024 chars | Multi-capability skills (rare) |
+| Over 1,024 chars | IMPOSSIBLE -- hard limit, will be truncated |
+
+**Wasted characters to eliminate:**
+- `SkillSearch('x') for docs.` -- model already knows how to find skill docs; this burns Level 1 budget on model-facing guidance
+- Filler words: "helps with", "assists in", "provides support for"
+- Redundant triggers that are substrings of each other
+
+Every word in the description must earn its place.
+
+---
+
+## 4. Trigger Quality Rules
+
+- Exact phrases > semantic matching (the model matches triggers literally first)
+- Include file types when relevant (`.docx`, `.pdf`, `YouTube URL`)
+- Include tool/platform names (`wrangler`, `Bright Data`, `Apify`)
+- Include both formal AND casual phrasing (`scrape URL` AND `web scraping`)
+- No overlap with other skills -- check existing skill descriptions before finalizing
+- Never use generic English words alone (`help`, `do`, `make`, `run`)
+
+**Validation step:** For each trigger, ask: "If a user types ONLY this phrase, should this skill -- and no other -- fire?" If the answer is no, the trigger is too broad.
+
+---
+
+## 5. Five Design Patterns
+
+| Pattern | When | Example |
+|---------|------|---------|
+| Sequential | Steps must run in order | Research -> Extract -> Summarize |
+| Multi-MCP | Orchestrates multiple external tool servers | Browser + API + Database |
+| Iterative Refinement | Output improves over rounds | Draft -> Review -> Revise |
+| Conditional Branching | Different paths based on input type | URL vs file vs text |
+| Domain-Specific Intelligence | Deep domain knowledge baked in | Security assessment, legal analysis |
+
+Most skills are Sequential or Conditional Branching. Reach for Multi-MCP and Iterative Refinement only when the task genuinely requires them.
+
+---
+
+## 6. Anti-Patterns
+
+**Description anti-patterns:**
+- "Helps with projects" -- could apply to ANY skill, zero signal
+- Buzzwords without specifics -- "management", "workflows", "processing" alone
+- Descriptions that fit 5+ other skills unchanged
+- Adding `SkillSearch('x') for docs.` to the description
+
+**Trigger anti-patterns:**
+- Single common English words (`help`, `do`, `create` without qualifier)
+- Triggers that are subsets of another skill's triggers
+- Semantic-only triggers with no exact phrase match (`when the user wants to organize things`)
+
+**Structural anti-patterns:**
+- Duplicating functionality that exists in another skill (check the index first)
+- Building a skill for something a 10-line bash script handles
+- SKILL.md over 100 lines without using the dynamic loading pattern
+- Context files buried in subdirectories instead of skill root

--- a/Releases/v3.0/.claude/skills/PAI/Tools/AuditSkills.ts
+++ b/Releases/v3.0/.claude/skills/PAI/Tools/AuditSkills.ts
@@ -1,0 +1,490 @@
+#!/usr/bin/env bun
+/**
+ * AuditSkills.ts — READ-ONLY diagnostic tool for PAI skill descriptions.
+ *
+ * Scans all SKILL.md files under ~/.claude/skills, extracts YAML front matter,
+ * and reports on description quality, formula compliance, trigger collisions,
+ * and actionable recommendations.
+ *
+ * Usage:  bun run ~/.claude/skills/PAI/Tools/AuditSkills.ts
+ *
+ * This tool does NOT modify any files.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, basename, dirname } from "node:path";
+import { homedir } from "node:os";
+
+// ─── Configuration ──────────────────────────────────────────────────────────
+
+const SKILLS_ROOT = join(homedir(), ".claude", "skills");
+const MAX_DESC_CHARS = 1024;
+const COLLISION_THRESHOLD = 3;
+
+const VAGUE_WORDS = new Set([
+  "workflows",
+  "management",
+  "processing",
+  "operations",
+  "handling",
+  "utilities",
+  "tools",
+  "services",
+  "system",
+  "stuff",
+  "things",
+]);
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+interface SkillAudit {
+  name: string;
+  path: string;
+  description: string;
+  charCount: number;
+  hasFormula: boolean;
+  triggerPhrases: string[];
+  triggerCount: number;
+  hasSkillSearchSuffix: boolean;
+  isVague: boolean;
+  issues: string[];
+}
+
+// ─── Front Matter Extraction ────────────────────────────────────────────────
+
+function extractFrontMatter(
+  content: string
+): { name: string; description: string } | null {
+  const fmRegex = /^---\s*\n([\s\S]*?)\n---/;
+  const match = content.match(fmRegex);
+  if (!match) return null;
+
+  const fmBlock = match[1];
+
+  // Extract name field — handles both quoted and unquoted values
+  const nameMatch = fmBlock.match(/^name:\s*(.+)$/m);
+  const name = nameMatch ? nameMatch[1].trim().replace(/^['"]|['"]$/g, "") : "";
+
+  // Extract description field — handles multi-line (indented continuation)
+  const descMatch = fmBlock.match(/^description:\s*(.+(?:\n(?![\w]).*?)*)$/m);
+  const description = descMatch
+    ? descMatch[1]
+        .replace(/\n\s+/g, " ")
+        .trim()
+        .replace(/^['"]|['"]$/g, "")
+    : "";
+
+  if (!name && !description) return null;
+  return { name, description };
+}
+
+// ─── Trigger Phrase Extraction ──────────────────────────────────────────────
+
+function extractTriggerPhrases(description: string): string[] {
+  const useWhenMatch = description.match(/USE WHEN\s+(.+?)(?:\.|$)/i);
+  if (!useWhenMatch) return [];
+
+  let triggerSection = useWhenMatch[1];
+
+  // Strip trailing SkillSearch(...) or similar suffixes before parsing
+  triggerSection = triggerSection.replace(/\s*SkillSearch\(.+?\).*$/i, "");
+
+  // Split on commas, "OR", semicolons
+  const phrases = triggerSection
+    .split(/,|(?:\s+OR\s+)/i)
+    .map((p) => p.trim().toLowerCase())
+    .filter((p) => p.length > 0 && !p.startsWith("skillsearch"));
+
+  return phrases;
+}
+
+// ─── Vagueness Detection ────────────────────────────────────────────────────
+
+function isDescriptionVague(description: string): boolean {
+  // Extract the "what" portion — everything before "USE WHEN"
+  const whatPortion = description.split(/USE WHEN/i)[0].trim();
+  if (!whatPortion) return false;
+
+  // Remove trailing period
+  const cleaned = whatPortion.replace(/\.\s*$/, "").trim().toLowerCase();
+
+  // Tokenize into meaningful words (skip the skill name if it appears)
+  const words = cleaned
+    .split(/\s+/)
+    .filter((w) => w.length > 2);
+
+  if (words.length === 0) return false;
+
+  // Vague = the description's "what" contains ONLY a noun + a vague word
+  // e.g., "Sales workflows." (2 words, 1 is vague) vs "Sales proposal generation workflows." (4 words)
+  if (words.length <= 2) {
+    return words.some((w) => VAGUE_WORDS.has(w));
+  }
+
+  return false;
+}
+
+// ─── SkillSearch Suffix Detection ───────────────────────────────────────────
+
+function hasSkillSearchSuffix(description: string): boolean {
+  return /SkillSearch\s*\(/i.test(description);
+}
+
+// ─── Formula Check ──────────────────────────────────────────────────────────
+
+function followsFormula(description: string): boolean {
+  return /USE WHEN/i.test(description);
+}
+
+// ─── Discover SKILL.md Files ────────────────────────────────────────────────
+
+function discoverSkillFiles(): string[] {
+  const paths: string[] = [];
+
+  function walkDir(dir: string, depth: number): void {
+    if (depth > 3) return; // prevent deep recursion
+    try {
+      const entries = readdirSync(dir);
+      for (const entry of entries) {
+        const fullPath = join(dir, entry);
+        try {
+          const stat = statSync(fullPath);
+          if (stat.isDirectory()) {
+            // Check for SKILL.md directly inside
+            const skillMdPath = join(fullPath, "SKILL.md");
+            try {
+              statSync(skillMdPath);
+              paths.push(skillMdPath);
+            } catch {
+              // No SKILL.md here, recurse
+            }
+            walkDir(fullPath, depth + 1);
+          }
+        } catch {
+          // Skip inaccessible entries
+        }
+      }
+    } catch {
+      // Skip inaccessible directories
+    }
+  }
+
+  walkDir(SKILLS_ROOT, 0);
+
+  // Deduplicate
+  return [...new Set(paths)];
+}
+
+// ─── Audit a Single Skill ───────────────────────────────────────────────────
+
+function auditSkill(filePath: string): SkillAudit | null {
+  const content = readFileSync(filePath, "utf-8");
+  const fm = extractFrontMatter(content);
+  if (!fm) return null;
+
+  const dirName = basename(dirname(filePath));
+  const name = fm.name || dirName;
+  const description = fm.description;
+
+  if (!description) {
+    return {
+      name,
+      path: filePath,
+      description: "(empty)",
+      charCount: 0,
+      hasFormula: false,
+      triggerPhrases: [],
+      triggerCount: 0,
+      hasSkillSearchSuffix: false,
+      isVague: false,
+      issues: ["No description"],
+    };
+  }
+
+  const charCount = description.length;
+  const formula = followsFormula(description);
+  const triggers = extractTriggerPhrases(description);
+  const skillSearch = hasSkillSearchSuffix(description);
+  const vague = isDescriptionVague(description);
+
+  const issues: string[] = [];
+  if (charCount > MAX_DESC_CHARS) issues.push(`>${MAX_DESC_CHARS} chars`);
+  if (!formula) issues.push("No USE WHEN formula");
+  if (skillSearch) issues.push("SkillSearch suffix");
+  if (vague) issues.push("Vague description");
+
+  return {
+    name,
+    path: filePath,
+    description,
+    charCount,
+    hasFormula: formula,
+    triggerPhrases: triggers,
+    triggerCount: triggers.length,
+    hasSkillSearchSuffix: skillSearch,
+    isVague: vague,
+    issues,
+  };
+}
+
+// ─── Trigger Collision Detection ────────────────────────────────────────────
+
+interface Collision {
+  skillA: string;
+  skillB: string;
+  shared: string[];
+}
+
+// Stop words to ignore in collision detection — these appear in natural-language
+// trigger descriptions but carry no semantic signal for skill routing.
+const STOP_WORDS = new Set([
+  "a", "an", "the", "is", "are", "was", "were", "be", "been", "being",
+  "have", "has", "had", "do", "does", "did", "will", "would", "shall",
+  "should", "may", "might", "must", "can", "could", "to", "of", "in",
+  "for", "on", "with", "at", "by", "from", "as", "into", "through",
+  "during", "before", "after", "above", "below", "between", "out",
+  "off", "over", "under", "again", "further", "then", "once", "here",
+  "there", "when", "where", "why", "how", "all", "each", "every",
+  "both", "few", "more", "most", "other", "some", "such", "no", "nor",
+  "not", "only", "own", "same", "so", "than", "too", "very", "just",
+  "because", "but", "and", "or", "if", "while", "about", "up", "down",
+  "that", "this", "these", "those", "it", "its", "i", "me", "my",
+  "we", "our", "you", "your", "he", "him", "his", "she", "her",
+  "they", "them", "their", "what", "which", "who", "whom",
+  // Common trigger-description filler words
+  "user", "says", "any", "form", "requests", "request", "asks",
+  "mentions", "wants", "needs",
+]);
+
+/**
+ * Normalize a trigger phrase into meaningful keywords by stripping
+ * quotes, punctuation, stop words, and short tokens.
+ */
+function triggerKeywords(phrase: string): string[] {
+  return phrase
+    .replace(/['"()]/g, "")
+    .split(/\s+/)
+    .map((w) => w.toLowerCase().replace(/[^a-z0-9-]/g, ""))
+    .filter((w) => w.length > 2 && !STOP_WORDS.has(w));
+}
+
+function detectCollisions(audits: SkillAudit[]): Collision[] {
+  const collisions: Collision[] = [];
+
+  for (let i = 0; i < audits.length; i++) {
+    for (let j = i + 1; j < audits.length; j++) {
+      const a = audits[i];
+      const b = audits[j];
+
+      if (a.triggerPhrases.length === 0 || b.triggerPhrases.length === 0) {
+        continue;
+      }
+
+      // First pass: exact phrase-level overlap (strongest signal)
+      const setA = new Set(a.triggerPhrases);
+      const setB = new Set(b.triggerPhrases);
+      const phraseOverlap = [...setA].filter((p) => setB.has(p));
+
+      if (phraseOverlap.length >= COLLISION_THRESHOLD) {
+        collisions.push({
+          skillA: a.name,
+          skillB: b.name,
+          shared: phraseOverlap,
+        });
+        continue;
+      }
+
+      // Second pass: keyword-level overlap (filter stop words)
+      const kwA = new Set(a.triggerPhrases.flatMap(triggerKeywords));
+      const kwB = new Set(b.triggerPhrases.flatMap(triggerKeywords));
+      const keywordOverlap = [...kwA].filter((w) => kwB.has(w));
+
+      if (keywordOverlap.length >= COLLISION_THRESHOLD) {
+        collisions.push({
+          skillA: a.name,
+          skillB: b.name,
+          shared: keywordOverlap,
+        });
+      }
+    }
+  }
+
+  return collisions;
+}
+
+// ─── Output Formatting ─────────────────────────────────────────────────────
+
+function padRight(str: string, len: number): string {
+  return str.length >= len ? str.substring(0, len) : str + " ".repeat(len - str.length);
+}
+
+function padLeft(str: string, len: number): string {
+  return str.length >= len ? str.substring(0, len) : " ".repeat(len - str.length) + str;
+}
+
+function renderTable(audits: SkillAudit[]): string {
+  const lines: string[] = [];
+
+  // Header
+  const header = `${padRight("Skill", 28)} ${padLeft("Chars", 6)}  ${padRight("Formula", 8)} ${padLeft("Triggers", 9)}  Issues`;
+  const separator = "\u2500".repeat(80);
+
+  lines.push(header);
+  lines.push(separator);
+
+  // Sort by name
+  const sorted = [...audits].sort((a, b) =>
+    a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+  );
+
+  for (const skill of sorted) {
+    const formulaStr = skill.hasFormula ? "\u2713" : "\u2717";
+    const issueStr =
+      skill.issues.length === 0
+        ? "\u2705 Clean"
+        : skill.issues.map((i) => `\u26A0\uFE0F  ${i}`).join(", ");
+
+    const line = `${padRight(skill.name, 28)} ${padLeft(String(skill.charCount), 6)}  ${padRight(formulaStr, 8)} ${padLeft(String(skill.triggerCount), 9)}  ${issueStr}`;
+    lines.push(line);
+  }
+
+  return lines.join("\n");
+}
+
+function renderCollisions(collisions: Collision[]): string {
+  if (collisions.length === 0) return "No trigger collisions detected.";
+
+  return collisions
+    .map(
+      (c) =>
+        `${c.skillA} <-> ${c.skillB}: [${c.shared.join(", ")}] (${c.shared.length} shared)`
+    )
+    .join("\n");
+}
+
+function renderRecommendations(audits: SkillAudit[]): string {
+  const recs: string[] = [];
+
+  // SkillSearch suffix
+  const withSS = audits.filter((a) => a.hasSkillSearchSuffix);
+  if (withSS.length > 0) {
+    recs.push(
+      `Remove SkillSearch suffix from ${withSS.length} skill(s): ${withSS.map((a) => a.name).join(", ")}`
+    );
+  }
+
+  // Vague descriptions
+  const vague = audits.filter((a) => a.isVague);
+  if (vague.length > 0) {
+    recs.push(
+      `Rewrite vague descriptions: ${vague.map((a) => a.name).join(", ")}`
+    );
+  }
+
+  // Missing formula
+  const noFormula = audits.filter((a) => !a.hasFormula);
+  if (noFormula.length > 0) {
+    recs.push(
+      `Add USE WHEN trigger formula to ${noFormula.length} skill(s): ${noFormula.map((a) => a.name).join(", ")}`
+    );
+  }
+
+  // Over limit
+  const overLimit = audits.filter((a) => a.charCount > MAX_DESC_CHARS);
+  if (overLimit.length > 0) {
+    recs.push(
+      `Shorten descriptions over ${MAX_DESC_CHARS} chars: ${overLimit.map((a) => `${a.name} (${a.charCount})`).join(", ")}`
+    );
+  }
+
+  // Low trigger count
+  const lowTriggers = audits.filter(
+    (a) => a.hasFormula && a.triggerCount < 3
+  );
+  if (lowTriggers.length > 0) {
+    recs.push(
+      `Add more trigger phrases (< 3) to: ${lowTriggers.map((a) => `${a.name} (${a.triggerCount})`).join(", ")}`
+    );
+  }
+
+  // Empty descriptions
+  const empty = audits.filter((a) => a.charCount === 0);
+  if (empty.length > 0) {
+    recs.push(
+      `Add descriptions to: ${empty.map((a) => a.name).join(", ")}`
+    );
+  }
+
+  if (recs.length === 0) {
+    return "All skill descriptions look healthy. No action needed.";
+  }
+
+  return recs.map((r) => `\u2022 ${r}`).join("\n");
+}
+
+// ─── Main ───────────────────────────────────────────────────────────────────
+
+function main(): void {
+  const boxTop    = "\u2554" + "\u2550".repeat(62) + "\u2557";
+  const boxTitle  = "\u2551" + padRight("", 17) + "SKILL DESCRIPTION AUDIT" + padRight("", 22) + "\u2551";
+  const boxBottom = "\u255A" + "\u2550".repeat(62) + "\u255D";
+
+  console.log();
+  console.log(boxTop);
+  console.log(boxTitle);
+  console.log(boxBottom);
+  console.log();
+
+  // Discover skill files
+  const skillFiles = discoverSkillFiles();
+  console.log(`Found ${skillFiles.length} SKILL.md files in ${SKILLS_ROOT}\n`);
+
+  // Audit each skill
+  const audits: SkillAudit[] = [];
+  for (const filePath of skillFiles) {
+    const audit = auditSkill(filePath);
+    if (audit) audits.push(audit);
+  }
+
+  if (audits.length === 0) {
+    console.log("No skills with parseable front matter found.");
+    return;
+  }
+
+  // Render main table
+  console.log(renderTable(audits));
+  console.log();
+
+  // Summary stats
+  const totalSkills = audits.length;
+  const cleanSkills = audits.filter((a) => a.issues.length === 0).length;
+  const totalIssues = audits.reduce((sum, a) => sum + a.issues.length, 0);
+  const avgChars = Math.round(
+    audits.reduce((sum, a) => sum + a.charCount, 0) / totalSkills
+  );
+
+  console.log(
+    `\u2550\u2550\u2550 SUMMARY \u2550\u2550\u2550`
+  );
+  console.log(
+    `Total skills: ${totalSkills}  |  Clean: ${cleanSkills}  |  Issues: ${totalIssues}  |  Avg chars: ${avgChars}`
+  );
+  console.log();
+
+  // Trigger collisions
+  console.log(
+    `\u2550\u2550\u2550 TRIGGER COLLISIONS \u2550\u2550\u2550`
+  );
+  const collisions = detectCollisions(audits);
+  console.log(renderCollisions(collisions));
+  console.log();
+
+  // Recommendations
+  console.log(
+    `\u2550\u2550\u2550 RECOMMENDATIONS \u2550\u2550\u2550`
+  );
+  console.log(renderRecommendations(audits));
+  console.log();
+}
+
+main();


### PR DESCRIPTION
## Summary

- **AuditSkills.ts** — Read-only Bun CLI that scans all `SKILL.md` files and reports description quality: character count (flags >1,024), `USE WHEN` formula compliance, trigger phrase count, `SkillSearch` suffix detection, vagueness flags, and trigger collisions between skills. Zero dependencies beyond Node built-ins.
- **DesignChecklist.md** — Level 3 reference doc for `CreateSkill` covering the front matter formula, three shipping tests, character budget rules, trigger quality guidelines, five design patterns, and anti-patterns.

## Context

Inspired by the video **["Skills Are Broken. Here's Why."](https://www.youtube.com/watch?v=JhOD4NqTsKE)** — PAI's three-level loading architecture is sound, but Level 1 description quality varies widely. Many descriptions waste characters on `SkillSearch('x') for docs.` suffixes and use vague one-word capabilities like "management" or "processing" without specifics.

Key findings from the video:
- Descriptions under ~1,000 chars are the make-or-break for skill invocation reliability
- The `{what it does}. USE WHEN {triggers}.` formula is the most effective pattern
- Trigger phrases should be exact matches users would type, not semantic descriptions
- `SkillSearch` suffixes in descriptions are wasted Level 1 characters

The audit tool surfaces these issues for human-guided fixes. The checklist prevents regression during future skill creation.

## Test plan

- [ ] Run `bun ~/.claude/skills/PAI/Tools/AuditSkills.ts` — produces formatted table with zero errors
- [ ] Verify audit tool is strictly read-only (no file writes in source)
- [ ] Read `DesignChecklist.md` — covers all 6 sections (formula, tests, budget, triggers, patterns, anti-patterns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)