### PR TITLE
feat(installer): detect and suggest recommended CLI utilities

### DIFF
--- a/Releases/v3.0/.claude/PAI-Install/cli/index.ts
+++ b/Releases/v3.0/.claude/PAI-Install/cli/index.ts
@@ -21,6 +21,7 @@ import {
   runRepository,
   runConfiguration,
   runVoiceSetup,
+  checkCliTools,
 } from "../engine/actions";
 import { runValidation, generateSummary } from "../engine/validate";
 import {
@@ -210,6 +211,9 @@ export async function runCLI(): Promise<void> {
         printError("\nSome critical checks failed. Please review and fix the issues above.");
       }
     }
+
+    // ── CLI Tool Recommendations (informational, non-blocking) ──
+    await checkCliTools(state, emit);
 
     // ── Summary ──
     const summary = generateSummary(state);


### PR DESCRIPTION
## Summary

- Adds `checkCliTools()` to the installer engine that detects recommended Rust-based CLI tools: **fd**, **rg** (ripgrep), **bat**, **eza**, and **dust**
- Reports each tool's status with a clear check/cross indicator and description
- Suggests platform-appropriate install commands for missing tools (Homebrew on macOS, apt-get or cargo on Linux)
- Runs after validation completes, before the final summary — purely informational, never auto-installs

## Motivation

PAI's AI Steering Rules recommend these fast Rust-based CLI utilities over legacy POSIX tools, and the statusline script already depends on `fd`. But the installer didn't check if they were installed, leaving users to discover missing dependencies at runtime.

Closes #630

## What's detected

| Tool | Command | Purpose |
|------|---------|---------|
| fd | `fd` | Fast file finder (replaces `find`) |
| ripgrep | `rg` | Fast recursive search (replaces `grep`) |
| bat | `bat` | Syntax-highlighted `cat` |
| eza | `eza` | Modern `ls` replacement |
| dust | `dust` | Intuitive disk usage (replaces `du`) |

## Design decisions

- **Non-blocking**: Missing tools are reported but installation never happens automatically
- **Not a formal install step**: Runs as a post-validation informational check — no changes to step definitions or types
- **Platform-aware**: Detects macOS+Homebrew, Linux+apt-get, or falls back to `cargo install`
- **Uses existing patterns**: Same `emit()` event system as all other installer actions

## Test plan

- [ ] Run installer on macOS with all tools installed — should show all checkmarks
- [ ] Run installer on macOS with some tools missing — should suggest `brew install ...`
- [ ] Run installer on Linux — should suggest apt-get or cargo install fallback
- [ ] Verify missing tools do NOT block installation completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)