### PR TITLE
fix: Add PAI_DIR fallback to 26 runtime files with hardcoded $HOME/.claude paths

### DIFF
--- a/Releases/v3.0/.claude/hooks/LoadContext.hook.ts
+++ b/Releases/v3.0/.claude/hooks/LoadContext.hook.ts
@@ -520,7 +520,7 @@ async function main() {
     if (needsRebuild) {
       console.error('🔨 Rebuilding SKILL.md (components changed)...');
       try {
-        execSync('bun ~/.claude/skills/PAI/Tools/RebuildPAI.ts', {
+        execSync(`bun ${paiDir}/skills/PAI/Tools/RebuildPAI.ts`, {
           cwd: paiDir,
           stdio: 'pipe',
           timeout: 5000

--- a/Releases/v3.0/.claude/hooks/handlers/RebuildSkill.ts
+++ b/Releases/v3.0/.claude/hooks/handlers/RebuildSkill.ts
@@ -24,7 +24,8 @@ import { join } from 'path';
 import { spawn } from 'child_process';
 
 export async function handleRebuildSkill(): Promise<void> {
-  const CORE_DIR = join(process.env.HOME!, '.claude/skills/PAI');
+  const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
+  const CORE_DIR = join(BASE_DIR, 'skills/PAI');
   const COMPONENTS_DIR = join(CORE_DIR, 'Components');
   const SKILL_MD = join(CORE_DIR, 'SKILL.md');
   const BUILD_SCRIPT = join(CORE_DIR, 'Tools/RebuildPAI.ts');
@@ -69,7 +70,7 @@ function rebuild(buildScript: string): Promise<void> {
     }, 10000);
 
     const child = spawn('bun', [buildScript], {
-      cwd: join(process.env.HOME!, '.claude/skills/PAI'),
+      cwd: CORE_DIR,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 

--- a/Releases/v3.0/.claude/hooks/lib/identity.ts
+++ b/Releases/v3.0/.claude/hooks/lib/identity.ts
@@ -10,7 +10,8 @@ import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 
 const HOME = process.env.HOME!;
-const SETTINGS_PATH = join(HOME, '.claude/settings.json');
+const BASE_DIR = process.env.PAI_DIR || join(HOME, '.claude');
+const SETTINGS_PATH = join(BASE_DIR, 'settings.json');
 
 // Default identity (fallback if settings.json doesn't have identity section)
 const DEFAULT_IDENTITY = {

--- a/Releases/v3.0/.claude/lib/migration/scanner.ts
+++ b/Releases/v3.0/.claude/lib/migration/scanner.ts
@@ -38,6 +38,7 @@ const HOME = homedir();
  * Standard locations to check for PAI installations
  */
 export const STANDARD_LOCATIONS = [
+  ...(process.env.PAI_DIR ? [process.env.PAI_DIR] : []),
   join(HOME, '.claude'),
   join(HOME, '.claude-BACKUP'),
   join(HOME, '.claude-old'),

--- a/Releases/v3.0/.claude/skills/Agents/Tools/ComposeAgent.ts
+++ b/Releases/v3.0/.claude/skills/Agents/Tools/ComposeAgent.ts
@@ -34,10 +34,11 @@ import Handlebars from "handlebars";
 
 // Paths
 const HOME = process.env.HOME || "~";
-const BASE_TRAITS_PATH = `${HOME}/.claude/skills/Agents/Data/Traits.yaml`;
-const USER_TRAITS_PATH = `${HOME}/.claude/skills/PAI/USER/SKILLCUSTOMIZATIONS/Agents/Traits.yaml`;
-const TEMPLATE_PATH = `${HOME}/.claude/skills/Agents/Templates/DynamicAgent.hbs`;
-const CUSTOM_AGENTS_DIR = `${HOME}/.claude/custom-agents`;
+const BASE_DIR = process.env.PAI_DIR || `${HOME}/.claude`;
+const BASE_TRAITS_PATH = `${BASE_DIR}/skills/Agents/Data/Traits.yaml`;
+const USER_TRAITS_PATH = `${BASE_DIR}/skills/PAI/USER/SKILLCUSTOMIZATIONS/Agents/Traits.yaml`;
+const TEMPLATE_PATH = `${BASE_DIR}/skills/Agents/Templates/DynamicAgent.hbs`;
+const CUSTOM_AGENTS_DIR = `${BASE_DIR}/custom-agents`;
 
 // Types
 interface ProsodySettings {

--- a/Releases/v3.0/.claude/skills/Browser/Tools/Browse.ts
+++ b/Releases/v3.0/.claude/skills/Browser/Tools/Browse.ts
@@ -24,7 +24,7 @@ const VOICE_SERVER = 'http://localhost:8888/notify/personality'
 const STATE_FILE = '/tmp/browser-session.json'
 const DEFAULT_PORT = 9222
 const SESSION_TIMEOUT = 5000 // 5s to wait for session start
-const SETTINGS_PATH = `${process.env.HOME}/.claude/settings.json`
+const SETTINGS_PATH = `${process.env.PAI_DIR || process.env.HOME + '/.claude'}/settings.json`
 
 // ============================================
 // SETTINGS

--- a/Releases/v3.0/.claude/skills/CORE/ACTIONS/lib/runner.v2.ts
+++ b/Releases/v3.0/.claude/skills/CORE/ACTIONS/lib/runner.v2.ts
@@ -28,8 +28,9 @@ const ACTIONS_DIR = dirname(import.meta.dir);
  * Local LLM provider using PAI's Inference tool
  */
 async function createLocalLLM(): Promise<ActionCapabilities["llm"]> {
+  const paiDir = process.env.PAI_DIR || join(process.env.HOME!, ".claude");
   const inferenceModule = await import(
-    join(process.env.HOME!, ".claude/skills/PAI/Tools/Inference.ts")
+    join(paiDir, "skills/PAI/Tools/Inference.ts")
   );
   const { inference } = inferenceModule;
 

--- a/Releases/v3.0/.claude/skills/CORE/ACTIONS/social/post.action.ts
+++ b/Releases/v3.0/.claude/skills/CORE/ACTIONS/social/post.action.ts
@@ -44,9 +44,8 @@ const OutputSchema = z.object({
 type Input = z.infer<typeof InputSchema>;
 type Output = z.infer<typeof OutputSchema>;
 
-// TODO: Configure broadcast tool path for your installation
-// const BROADCAST_TOOL = `${process.env.HOME}/.claude/skills/Broadcast/Tools/Broadcast.ts`;
-const BROADCAST_TOOL = `${process.env.HOME}/.claude/skills/Broadcast/Tools/Broadcast.ts`;
+const BASE_DIR = process.env.PAI_DIR || `${process.env.HOME}/.claude`;
+const BROADCAST_TOOL = `${BASE_DIR}/skills/Broadcast/Tools/Broadcast.ts`;
 
 // Platform character limits
 const LIMITS: Record<string, number> = {

--- a/Releases/v3.0/.claude/skills/Evals/Tools/AlgorithmBridge.ts
+++ b/Releases/v3.0/.claude/skills/Evals/Tools/AlgorithmBridge.ts
@@ -159,7 +159,8 @@ export function formatForISC(result: AlgorithmEvalResult): string {
 export async function updateISCWithResult(result: AlgorithmEvalResult): Promise<void> {
   const status = result.passed ? 'DONE' : 'BLOCKED';
 
-  await $`bun run ~/.claude/skills/THEALGORITHM/Tools/ISCManager.ts update --row ${result.isc_row} --status ${status} --note "${formatForISC(result)}"`.quiet();
+  const paiDir = process.env.PAI_DIR || `${process.env.HOME}/.claude`;
+  await $`bun run ${paiDir}/skills/THEALGORITHM/Tools/ISCManager.ts update --row ${result.isc_row} --status ${status} --note "${formatForISC(result)}"`.quiet();
 }
 
 // CLI interface

--- a/Releases/v3.0/.claude/skills/PAI/ACTIONS/lib/runner.v2.ts
+++ b/Releases/v3.0/.claude/skills/PAI/ACTIONS/lib/runner.v2.ts
@@ -29,8 +29,9 @@ const USER_ACTIONS_DIR = join(ACTIONS_DIR, "..", "USER", "ACTIONS");
  * Local LLM provider using PAI's Inference tool
  */
 async function createLocalLLM(): Promise<ActionCapabilities["llm"]> {
+  const paiDir = process.env.PAI_DIR || join(process.env.HOME!, ".claude");
   const inferenceModule = await import(
-    join(process.env.HOME!, ".claude/skills/PAI/Tools/Inference.ts")
+    join(paiDir, "skills/PAI/Tools/Inference.ts")
   );
   const { inference } = inferenceModule;
 

--- a/Releases/v3.0/.claude/skills/PAI/Tools/ActivityParser.ts
+++ b/Releases/v3.0/.claude/skills/PAI/Tools/ActivityParser.ts
@@ -21,7 +21,7 @@ import * as path from "path";
 // Configuration
 // ============================================================================
 
-const CLAUDE_DIR = path.join(process.env.HOME!, ".claude");
+const CLAUDE_DIR = process.env.PAI_DIR || path.join(process.env.HOME!, ".claude");
 const MEMORY_DIR = path.join(CLAUDE_DIR, "MEMORY");
 const USERNAME = process.env.USER || require("os").userInfo().username;
 const PROJECTS_DIR = path.join(CLAUDE_DIR, "projects", `-Users-${USERNAME}--claude`);  // Claude Code native storage

--- a/Releases/v3.0/.claude/skills/PAI/Tools/Banner.ts
+++ b/Releases/v3.0/.claude/skills/PAI/Tools/Banner.ts
@@ -13,7 +13,7 @@ import { join } from "path";
 import { spawnSync } from "child_process";
 
 const HOME = process.env.HOME!;
-const CLAUDE_DIR = join(HOME, ".claude");
+const CLAUDE_DIR = process.env.PAI_DIR || join(HOME, ".claude");
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Terminal Width Detection

--- a/Releases/v3.0/.claude/skills/PAI/Tools/BannerMatrix.ts
+++ b/Releases/v3.0/.claude/skills/PAI/Tools/BannerMatrix.ts
@@ -22,7 +22,7 @@ import { join } from "path";
 import { spawnSync } from "child_process";
 
 const HOME = process.env.HOME!;
-const CLAUDE_DIR = join(HOME, ".claude");
+const CLAUDE_DIR = process.env.PAI_DIR || join(HOME, ".claude");
 
 // =============================================================================
 // Terminal Width Detection

--- a/Releases/v3.0/.claude/skills/PAI/Tools/BannerNeofetch.ts
+++ b/Releases/v3.0/.claude/skills/PAI/Tools/BannerNeofetch.ts
@@ -15,7 +15,7 @@ import { join } from "path";
 import { spawnSync } from "child_process";
 
 const HOME = process.env.HOME!;
-const CLAUDE_DIR = join(HOME, ".claude");
+const CLAUDE_DIR = process.env.PAI_DIR || join(HOME, ".claude");
 
 // ═══════════════════════════════════════════════════════════════════════
 // Terminal Width Detection

--- a/Releases/v3.0/.claude/skills/PAI/Tools/BannerRetro.ts
+++ b/Releases/v3.0/.claude/skills/PAI/Tools/BannerRetro.ts
@@ -20,7 +20,7 @@ import { join } from "path";
 import { spawnSync } from "child_process";
 
 const HOME = process.env.HOME!;
-const CLAUDE_DIR = join(HOME, ".claude");
+const CLAUDE_DIR = process.env.PAI_DIR || join(HOME, ".claude");
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Terminal Width Detection

--- a/Releases/v3.0/.claude/skills/PAI/Tools/FeatureRegistry.ts
+++ b/Releases/v3.0/.claude/skills/PAI/Tools/FeatureRegistry.ts
@@ -55,7 +55,7 @@ interface FeatureRegistry {
   };
 }
 
-const REGISTRY_DIR = join(process.env.HOME || '', '.claude', 'MEMORY', 'progress');
+const REGISTRY_DIR = join(process.env.PAI_DIR || join(process.env.HOME || '', '.claude'), 'MEMORY', 'progress');
 
 function getRegistryPath(project: string): string {
   return join(REGISTRY_DIR, `${project}-features.json`);

--- a/Releases/v3.0/.claude/skills/PAI/Tools/LearningPatternSynthesis.ts
+++ b/Releases/v3.0/.claude/skills/PAI/Tools/LearningPatternSynthesis.ts
@@ -24,7 +24,7 @@ import * as path from "path";
 // Configuration
 // ============================================================================
 
-const CLAUDE_DIR = path.join(process.env.HOME!, ".claude");
+const CLAUDE_DIR = process.env.PAI_DIR || path.join(process.env.HOME!, ".claude");
 const LEARNING_DIR = path.join(CLAUDE_DIR, "MEMORY", "LEARNING");
 const RATINGS_FILE = path.join(LEARNING_DIR, "SIGNALS", "ratings.jsonl");
 const SYNTHESIS_DIR = path.join(LEARNING_DIR, "SYNTHESIS");

--- a/Releases/v3.0/.claude/skills/PAI/Tools/LoadSkillConfig.ts
+++ b/Releases/v3.0/.claude/skills/PAI/Tools/LoadSkillConfig.ts
@@ -35,7 +35,7 @@ interface ExtendManifest {
 
 // Constants
 const HOME = homedir();
-const CUSTOMIZATION_DIR = join(HOME, '.claude', 'skills', 'PAI', 'USER', 'SKILLCUSTOMIZATIONS');
+const CUSTOMIZATION_DIR = join(process.env.PAI_DIR || join(HOME, '.claude'), 'skills', 'PAI', 'USER', 'SKILLCUSTOMIZATIONS');
 
 /**
  * Deep merge two objects recursively

--- a/Releases/v3.0/.claude/skills/PAI/Tools/NeofetchBanner.ts
+++ b/Releases/v3.0/.claude/skills/PAI/Tools/NeofetchBanner.ts
@@ -20,7 +20,7 @@ import { join } from "path";
 import { spawnSync } from "child_process";
 
 const HOME = process.env.HOME!;
-const CLAUDE_DIR = join(HOME, ".claude");
+const CLAUDE_DIR = process.env.PAI_DIR || join(HOME, ".claude");
 
 // ═══════════════════════════════════════════════════════════════════════
 // Terminal Width Detection

--- a/Releases/v3.0/.claude/skills/PAI/Tools/RebuildPAI.ts
+++ b/Releases/v3.0/.claude/skills/PAI/Tools/RebuildPAI.ts
@@ -13,11 +13,12 @@ import { readdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 
 const HOME = process.env.HOME!;
-const PAI_DIR = join(HOME, ".claude/skills/PAI");
+const BASE_DIR = process.env.PAI_DIR || join(HOME, ".claude");
+const PAI_DIR = join(BASE_DIR, "skills/PAI");
 const COMPONENTS_DIR = join(PAI_DIR, "Components");
 const ALGORITHM_DIR = join(COMPONENTS_DIR, "Algorithm");
 const OUTPUT_FILE = join(PAI_DIR, "SKILL.md");
-const SETTINGS_PATH = join(HOME, ".claude/settings.json");
+const SETTINGS_PATH = join(BASE_DIR, "settings.json");
 
 /**
  * Load identity variables from settings.json for template resolution

--- a/Releases/v3.0/.claude/skills/PAI/Tools/SessionHarvester.ts
+++ b/Releases/v3.0/.claude/skills/PAI/Tools/SessionHarvester.ts
@@ -25,7 +25,7 @@ import { getLearningCategory, isLearningCapture } from "../../../hooks/lib/learn
 // Configuration
 // ============================================================================
 
-const CLAUDE_DIR = path.join(process.env.HOME!, ".claude");
+const CLAUDE_DIR = process.env.PAI_DIR || path.join(process.env.HOME!, ".claude");
 // Derive the project slug dynamically from CLAUDE_DIR (works on macOS and Linux)
 // macOS: /Users/daniel/.claude → -Users-daniel--claude
 // Linux: /home/daniel/.claude → -home-daniel--claude

--- a/Releases/v3.0/.claude/skills/PAI/Tools/SessionProgress.ts
+++ b/Releases/v3.0/.claude/skills/PAI/Tools/SessionProgress.ts
@@ -44,7 +44,7 @@ interface SessionProgress {
 }
 
 // Progress files are now in STATE/progress/ (consolidated from MEMORY/PROGRESS/)
-const PROGRESS_DIR = join(process.env.HOME || '', '.claude', 'MEMORY', 'STATE', 'progress');
+const PROGRESS_DIR = join(process.env.PAI_DIR || join(process.env.HOME || '', '.claude'), 'MEMORY', 'STATE', 'progress');
 
 function getProgressPath(project: string): string {
   return join(PROGRESS_DIR, `${project}-progress.json`);

--- a/Releases/v3.0/.claude/skills/PAIUpgrade/Tools/Anthropic.ts
+++ b/Releases/v3.0/.claude/skills/PAIUpgrade/Tools/Anthropic.ts
@@ -79,7 +79,8 @@ interface State {
 
 // Config
 const HOME = homedir();
-const SKILL_DIR = join(HOME, '.claude', 'skills', 'PAIUpgrade');
+const BASE_DIR = process.env.PAI_DIR || join(HOME, '.claude');
+const SKILL_DIR = join(BASE_DIR, 'skills', 'PAIUpgrade');
 const STATE_DIR = join(SKILL_DIR, 'State');
 const STATE_FILE = join(STATE_DIR, 'last-check.json');
 const SOURCES_FILE = join(SKILL_DIR, 'sources.json');

--- a/Releases/v3.0/.claude/skills/Recon/Tools/BountyPrograms.ts
+++ b/Releases/v3.0/.claude/skills/Recon/Tools/BountyPrograms.ts
@@ -46,7 +46,8 @@ interface BountyProgramsResult {
 const CHAOS_BOUNTY_URL = "https://raw.githubusercontent.com/projectdiscovery/public-bugbounty-programs/main/chaos-bugbounty-list.json";
 
 // Local cache path
-const CACHE_DIR = `${process.env.HOME}/.claude/skills/Recon/Data`;
+const BASE_DIR = process.env.PAI_DIR || `${process.env.HOME}/.claude`;
+const CACHE_DIR = `${BASE_DIR}/skills/Recon/Data`;
 const CACHE_FILE = `${CACHE_DIR}/BountyPrograms.json`;
 const CACHE_MAX_AGE_HOURS = 24;
 

--- a/Releases/v3.0/.claude/skills/Telos/Tools/UpdateTelos.ts
+++ b/Releases/v3.0/.claude/skills/Telos/Tools/UpdateTelos.ts
@@ -38,7 +38,8 @@ import { readFileSync, writeFileSync, copyFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { getPrincipal } from '../../../hooks/lib/identity';
 
-const TELOS_DIR = join(process.env.HOME!, '.claude', 'context', 'life', 'telos');
+const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
+const TELOS_DIR = join(BASE_DIR, 'context', 'life', 'telos');
 const BACKUPS_DIR = join(TELOS_DIR, 'backups');
 const UPDATES_FILE = join(TELOS_DIR, 'updates.md');
 

--- a/Releases/v3.0/.claude/skills/WebAssessment/BugBountyTool/src/config.ts
+++ b/Releases/v3.0/.claude/skills/WebAssessment/BugBountyTool/src/config.ts
@@ -16,12 +16,12 @@ export const CONFIG = {
     yeswehack: 'data/yeswehack_data.json',
   },
 
-  // Local paths
+  // Local paths (resolved at runtime via PAI_DIR)
   paths: {
-    root: '~/.claude/skills/hacking/bug-bounties',
-    state: '~/.claude/skills/hacking/bug-bounties/state.json',
-    cache: '~/.claude/skills/hacking/bug-bounties/cache',
-    logs: '~/.claude/skills/hacking/bug-bounties/logs',
+    root: `${process.env.PAI_DIR || (process.env.HOME + '/.claude')}/skills/hacking/bug-bounties`,
+    state: `${process.env.PAI_DIR || (process.env.HOME + '/.claude')}/skills/hacking/bug-bounties/state.json`,
+    cache: `${process.env.PAI_DIR || (process.env.HOME + '/.claude')}/skills/hacking/bug-bounties/cache`,
+    logs: `${process.env.PAI_DIR || (process.env.HOME + '/.claude')}/skills/hacking/bug-bounties/logs`,
   },
 
   // GitHub API


### PR DESCRIPTION
## Summary

- 26 files in `Releases/v3.0/.claude/` hardcode `$HOME/.claude` without checking `PAI_DIR`, breaking installations that use a non-default location
- Adds the standard `process.env.PAI_DIR || join(HOME, '.claude')` fallback pattern — the same pattern already used by hooks like `AlgorithmTracker`, `SessionSummary`, and `algorithm.ts`
- Files that already had `PAI_DIR` are left untouched

## Problem

Issue #694 identified that `CLAUDE_CONFIG_DIR` wasn't respected. The fix in #696 addressed only `INSTALL.ts`. The remaining 26 runtime files (hooks, skills, tools, actions, lib) still resolve paths via `$HOME/.claude` directly, ignoring `PAI_DIR` from `settings.json`.

This means any PAI installation not at `~/.claude` (e.g. project-scoped `.claude/` directories) has broken path resolution at runtime across banners, skill configs, action runners, session progress, feature registry, and more.

## Changes

**Pattern applied consistently:**
```typescript
// Before (hardcoded):
const CLAUDE_DIR = join(HOME, ".claude");

// After (respects PAI_DIR):
const CLAUDE_DIR = process.env.PAI_DIR || join(HOME, ".claude");
```

**Affected areas:**
- `hooks/` — LoadContext, RebuildSkill handler, identity lib
- `lib/migration/` — scanner now checks PAI_DIR location first
- `skills/PAI/Tools/` — Banner variants, ActivityParser, FeatureRegistry, SessionProgress, SessionHarvester, LearningPatternSynthesis, LoadSkillConfig, RebuildPAI
- `skills/` — Agents/ComposeAgent, Browser/Browse, Evals/AlgorithmBridge, PAIUpgrade/Anthropic, Recon/BountyPrograms, Telos/UpdateTelos, WebAssessment/config
- `ACTIONS/` — CORE and PAI runner.v2 (Inference import), social/post.action

Closes #694