### PR TITLE
feat: add symlink-aware directory detection across tools and hooks

### DIFF
--- a/Releases/v3.0/.claude/hooks/LoadContext.hook.ts
+++ b/Releases/v3.0/.claude/hooks/LoadContext.hook.ts
@@ -487,7 +487,7 @@ async function main() {
           try {
             for (const entry of readdirSync(dir, { withFileTypes: true })) {
               const fullPath = join(dir, entry.name);
-              if (entry.isDirectory()) {
+              if (entry.isDirectory() || (entry.isSymbolicLink() && require('fs').statSync(fullPath).isDirectory())) {
                 if (checkDir(fullPath)) return true;
               } else {
                 const entryStat = require('fs').statSync(fullPath);

--- a/Releases/v3.0/.claude/skills/PAI/Tools/BannerMatrix.ts
+++ b/Releases/v3.0/.claude/skills/PAI/Tools/BannerMatrix.ts
@@ -17,7 +17,7 @@
  *   - Hacker terminal feel
  */
 
-import { readdirSync, existsSync, readFileSync } from "fs";
+import { readdirSync, existsSync, readFileSync, statSync } from "fs";
 import { join } from "path";
 import { spawnSync } from "child_process";
 
@@ -279,7 +279,7 @@ function countSkills(): number {
   let count = 0;
   try {
     for (const entry of readdirSync(skillsDir, { withFileTypes: true })) {
-      if (entry.isDirectory() && existsSync(join(skillsDir, entry.name, "SKILL.md"))) count++;
+      if ((entry.isDirectory() || (entry.isSymbolicLink() && statSync(join(skillsDir, entry.name)).isDirectory())) && existsSync(join(skillsDir, entry.name, "SKILL.md"))) count++;
     }
   } catch {}
   return count;

--- a/Releases/v3.0/.claude/skills/PAI/Tools/BannerNeofetch.ts
+++ b/Releases/v3.0/.claude/skills/PAI/Tools/BannerNeofetch.ts
@@ -10,7 +10,7 @@
  * Aesthetic: Modern tech startup (gh, npm, vercel) with gradient colors (blue->purple->cyan)
  */
 
-import { readdirSync, existsSync, readFileSync } from "fs";
+import { readdirSync, existsSync, readFileSync, statSync } from "fs";
 import { join } from "path";
 import { spawnSync } from "child_process";
 
@@ -254,7 +254,7 @@ function countSkills(): number {
   let count = 0;
   try {
     for (const entry of readdirSync(skillsDir, { withFileTypes: true })) {
-      if (entry.isDirectory() && existsSync(join(skillsDir, entry.name, "SKILL.md"))) count++;
+      if ((entry.isDirectory() || (entry.isSymbolicLink() && statSync(join(skillsDir, entry.name)).isDirectory())) && existsSync(join(skillsDir, entry.name, "SKILL.md"))) count++;
     }
   } catch {}
   return count || 66;

--- a/Releases/v3.0/.claude/skills/PAI/Tools/BannerRetro.ts
+++ b/Releases/v3.0/.claude/skills/PAI/Tools/BannerRetro.ts
@@ -15,7 +15,7 @@
  * - Amber/green phosphor CRT terminals
  */
 
-import { readdirSync, existsSync, readFileSync } from "fs";
+import { readdirSync, existsSync, readFileSync, statSync } from "fs";
 import { join } from "path";
 import { spawnSync } from "child_process";
 
@@ -326,7 +326,7 @@ function countSkills(): number {
   let count = 0;
   try {
     for (const entry of readdirSync(skillsDir, { withFileTypes: true })) {
-      if (entry.isDirectory() && existsSync(join(skillsDir, entry.name, "SKILL.md"))) count++;
+      if ((entry.isDirectory() || (entry.isSymbolicLink() && statSync(join(skillsDir, entry.name)).isDirectory())) && existsSync(join(skillsDir, entry.name, "SKILL.md"))) count++;
     }
   } catch {}
   return count;

--- a/Releases/v3.0/.claude/skills/PAI/Tools/LoadSkillConfig.ts
+++ b/Releases/v3.0/.claude/skills/PAI/Tools/LoadSkillConfig.ts
@@ -14,7 +14,7 @@
  *   bun ~/.claude/skills/PAI/Tools/LoadSkillConfig.ts <skill-dir> <filename>
  */
 
-import { readFileSync, existsSync, readdirSync } from 'fs';
+import { readFileSync, existsSync, readdirSync, statSync } from 'fs';
 import { join, basename } from 'path';
 import { homedir } from 'os';
 import { parse as parseYaml } from 'yaml';
@@ -231,7 +231,7 @@ export function listCustomizedSkills(): string[] {
 
   const dirs = readdirSync(CUSTOMIZATION_DIR, { withFileTypes: true });
   return dirs
-    .filter(d => d.isDirectory())
+    .filter(d => d.isDirectory() || (d.isSymbolicLink() && statSync(join(CUSTOMIZATION_DIR, d.name)).isDirectory()))
     .map(d => d.name)
     .filter(name => hasCustomizations(name));
 }

--- a/Releases/v3.0/.claude/skills/PAI/Tools/NeofetchBanner.ts
+++ b/Releases/v3.0/.claude/skills/PAI/Tools/NeofetchBanner.ts
@@ -15,7 +15,7 @@
  *   - Neon glow feel
  */
 
-import { readdirSync, existsSync, readFileSync } from "fs";
+import { readdirSync, existsSync, readFileSync, statSync } from "fs";
 import { join } from "path";
 import { spawnSync } from "child_process";
 
@@ -342,7 +342,7 @@ function countSkills(): number {
   let count = 0;
   try {
     for (const entry of readdirSync(skillsDir, { withFileTypes: true })) {
-      if (entry.isDirectory() && existsSync(join(skillsDir, entry.name, "SKILL.md"))) count++;
+      if ((entry.isDirectory() || (entry.isSymbolicLink() && statSync(join(skillsDir, entry.name)).isDirectory())) && existsSync(join(skillsDir, entry.name, "SKILL.md"))) count++;
     }
   } catch {}
   return count;


### PR DESCRIPTION
Extend directory scanning in 7 files to follow symlinks that resolve to directories. This supports PAI installations where skills, hooks, or tool directories use symbolic links.

Pattern: entry.isDirectory() || (entry.isSymbolicLink() && statSync(fullPath).isDirectory())