### PR TITLE
fix: consolidate PAI_DIR path resolution through hooks/lib/paths.ts

### DIFF
--- a/Releases/v3.0/.claude/hooks/AlgorithmTracker.hook.ts
+++ b/Releases/v3.0/.claude/hooks/AlgorithmTracker.hook.ts
@@ -24,6 +24,7 @@ import type { AlgorithmCriterion, AlgorithmPhase, AlgorithmState } from './lib/a
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { setPhaseTab } from './lib/tab-setter';
+import { getPaiDir } from './lib/paths';
 
 // ── Phase Detection from Voice Curls ──
 
@@ -91,7 +92,7 @@ function parseCriterion(text: string): { id: string; description: string } | nul
 
 // ── Session Activation (replaces SessionReactivator) ──
 
-const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
+const BASE_DIR = getPaiDir();
 
 function getSessionName(sid: string): string {
   try {

--- a/Releases/v3.0/.claude/hooks/AutoWorkCreation.hook.ts
+++ b/Releases/v3.0/.claude/hooks/AutoWorkCreation.hook.ts
@@ -26,6 +26,7 @@ import { mkdirSync, existsSync, readFileSync, writeFileSync, symlinkSync, unlink
 import { join } from 'path';
 import { getPSTComponents, getISOTimestamp } from './lib/time';
 import { generatePRDTemplate, generatePRDFilename } from './lib/prd-template';
+import { getPaiDir } from './lib/paths';
 interface HookInput {
   session_id: string;
   prompt?: string;
@@ -49,7 +50,7 @@ interface PromptClassification {
   is_new_topic: boolean;
 }
 
-const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
+const BASE_DIR = getPaiDir();
 const WORK_DIR = join(BASE_DIR, 'MEMORY', 'WORK');
 const STATE_DIR = join(BASE_DIR, 'MEMORY', 'STATE');
 // Session-scoped state files prevent parallel sessions from overwriting each other

--- a/Releases/v3.0/.claude/hooks/RatingCapture.hook.ts
+++ b/Releases/v3.0/.claude/hooks/RatingCapture.hook.ts
@@ -48,14 +48,14 @@ import { getIdentity, getPrincipal, getPrincipalName } from './lib/identity';
 import { getLearningCategory } from './lib/learning-utils';
 import { getISOTimestamp, getPSTComponents } from './lib/time';
 import { captureFailure } from '../skills/PAI/Tools/FailureCapture';
+import { getPaiDir } from './lib/paths';
 
 // ── Algorithm Format Reminder (absorbed from AlgorithmEnforcement) ──
 // Output IMMEDIATELY before any async work — this is blocking stdout injection.
 // Read Algorithm version dynamically from LATEST file (never hardcode)
 const ALGO_VERSION = (() => {
   try {
-    const paiDir = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
-    return readFileSync(join(paiDir, 'skills', 'PAI', 'Components', 'Algorithm', 'LATEST'), 'utf-8').trim();
+    return readFileSync(join(getPaiDir(), 'skills', 'PAI', 'Components', 'Algorithm', 'LATEST'), 'utf-8').trim();
   } catch { return 'v?.?.?'; }
 })();
 const ALGORITHM_REMINDER = `<user-prompt-submit-hook>
@@ -98,7 +98,7 @@ interface RatingEntry {
 
 // ── Shared Constants ──
 
-const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
+const BASE_DIR = getPaiDir();
 const SIGNALS_DIR = join(BASE_DIR, 'MEMORY', 'LEARNING', 'SIGNALS');
 const RATINGS_FILE = join(SIGNALS_DIR, 'ratings.jsonl');
 const TRENDING_SCRIPT = join(BASE_DIR, 'tools', 'TrendingAnalysis.ts');

--- a/Releases/v3.0/.claude/hooks/SecurityValidator.hook.ts
+++ b/Releases/v3.0/.claude/hooks/SecurityValidator.hook.ts
@@ -64,7 +64,7 @@ import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import { parse as parseYaml } from 'yaml';
-import { paiPath } from './lib/paths';
+import { paiPath, expandPath } from './lib/paths';
 
 // ========================================
 // Security Event Logging
@@ -269,14 +269,6 @@ function matchesPattern(command: string, pattern: string): boolean {
     // Invalid regex - try literal match
     return command.toLowerCase().includes(pattern.toLowerCase());
   }
-}
-
-function expandPath(path: string): string {
-  // Expand ~ to home directory
-  if (path.startsWith('~')) {
-    return path.replace('~', homedir());
-  }
-  return path;
 }
 
 function matchesPathPattern(filePath: string, pattern: string): boolean {

--- a/Releases/v3.0/.claude/hooks/SessionSummary.hook.ts
+++ b/Releases/v3.0/.claude/hooks/SessionSummary.hook.ts
@@ -52,8 +52,9 @@ import { writeFileSync, existsSync, readFileSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { getISOTimestamp } from './lib/time';
 import { setTabState, cleanupKittySession } from './lib/tab-setter';
+import { getPaiDir } from './lib/paths';
 
-const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
+const BASE_DIR = getPaiDir();
 const MEMORY_DIR = join(BASE_DIR, 'MEMORY');
 const STATE_DIR = join(MEMORY_DIR, 'STATE');
 const WORK_DIR = join(MEMORY_DIR, 'WORK');

--- a/Releases/v3.0/.claude/hooks/StopOrchestrator.hook.ts
+++ b/Releases/v3.0/.claude/hooks/StopOrchestrator.hook.ts
@@ -30,6 +30,7 @@ import { handleDocCrossRefIntegrity } from './handlers/DocCrossRefIntegrity';
 import { existsSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
+import { getPaiDir } from './lib/paths';
 
 interface HookInput {
   session_id: string;
@@ -43,7 +44,7 @@ interface HookInput {
  * One existsSync check. No regex. No transcript parsing.
  */
 function isMainSession(sessionId: string): boolean {
-  const paiDir = process.env.PAI_DIR || join(homedir(), '.claude');
+  const paiDir = getPaiDir();
   const kittySessionsDir = join(paiDir, 'MEMORY', 'STATE', 'kitty-sessions');
   if (!existsSync(kittySessionsDir)) return true; // Non-Kitty terminal: allow all sessions
   return existsSync(join(kittySessionsDir, `${sessionId}.json`));

--- a/Releases/v3.0/.claude/hooks/VoiceGate.hook.ts
+++ b/Releases/v3.0/.claude/hooks/VoiceGate.hook.ts
@@ -25,6 +25,7 @@
 import { existsSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
+import { getPaiDir } from './lib/paths';
 
 interface HookInput {
   tool_name: string;
@@ -46,7 +47,7 @@ function isMainSession(sessionId: string): boolean {
   }
 
   // Kitty detection via session files (backward-compatible)
-  const paiDir = process.env.PAI_DIR || join(homedir(), '.claude');
+  const paiDir = getPaiDir();
   const kittySessionsDir = join(paiDir, 'MEMORY', 'STATE', 'kitty-sessions');
   if (!existsSync(kittySessionsDir)) return true; // No session tracking dir → allow
   return existsSync(join(kittySessionsDir, `${sessionId}.json`));

--- a/Releases/v3.0/.claude/hooks/WorkCompletionLearning.hook.ts
+++ b/Releases/v3.0/.claude/hooks/WorkCompletionLearning.hook.ts
@@ -54,8 +54,9 @@ import { writeFileSync, existsSync, readFileSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { getISOTimestamp, getPSTDate } from './lib/time';
 import { getLearningCategory } from './lib/learning-utils';
+import { getPaiDir } from './lib/paths';
 
-const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
+const BASE_DIR = getPaiDir();
 const MEMORY_DIR = join(BASE_DIR, 'MEMORY');
 const STATE_DIR = join(MEMORY_DIR, 'STATE');
 const WORK_DIR = join(MEMORY_DIR, 'WORK');

--- a/Releases/v3.0/.claude/hooks/lib/algorithm-state.ts
+++ b/Releases/v3.0/.claude/hooks/lib/algorithm-state.ts
@@ -20,6 +20,7 @@
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
+import { getPaiDir } from './paths';
 
 // ── Types ──
 
@@ -131,7 +132,7 @@ export interface AlgorithmState {
 
 // ── Paths ──
 
-const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
+const BASE_DIR = getPaiDir();
 const ALGORITHMS_DIR = join(BASE_DIR, 'MEMORY', 'STATE', 'algorithms');
 const SESSION_NAMES_PATH = join(BASE_DIR, 'MEMORY', 'STATE', 'session-names.json');
 

--- a/Releases/v3.0/.claude/hooks/lib/notifications.ts
+++ b/Releases/v3.0/.claude/hooks/lib/notifications.ts
@@ -14,6 +14,7 @@ import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import { getIdentity } from './identity';
+import { getPaiDir } from './paths';
 
 // ============================================================================
 // Types
@@ -82,7 +83,7 @@ function expandEnvVars(content: string): string {
 
 export function getNotificationConfig(): NotificationConfig {
   try {
-    const paiDir = process.env.PAI_DIR || join(homedir(), '.claude');
+    const paiDir = getPaiDir();
     const settingsPath = join(paiDir, 'settings.json');
 
     if (existsSync(settingsPath)) {

--- a/Releases/v3.0/.claude/hooks/lib/paths.ts
+++ b/Releases/v3.0/.claude/hooks/lib/paths.ts
@@ -13,16 +13,15 @@ import { homedir } from 'os';
 import { join } from 'path';
 
 /**
- * Expand shell variables in a path string
- * Supports: $HOME, ${HOME}, ~
+ * Expand shell-style variables in a path string.
+ * Supports: ~, $VAR, ${VAR} (any env var, not just HOME).
+ * Tilde is only expanded at the start of the string (matching shell behavior).
  */
 export function expandPath(path: string): string {
-  const home = homedir();
-
   return path
-    .replace(/^\$HOME(?=\/|$)/, home)
-    .replace(/^\$\{HOME\}(?=\/|$)/, home)
-    .replace(/^~(?=\/|$)/, home);
+    .replace(/^~(?=\/|$)/, homedir())
+    .replace(/\$\{(\w+)\}/g, (_, v) => process.env[v] ?? '')
+    .replace(/\$(\w+)/g, (_, v) => process.env[v] ?? '');
 }
 
 /**

--- a/Releases/v3.0/.claude/skills/Art/Tools/Generate.ts
+++ b/Releases/v3.0/.claude/skills/Art/Tools/Generate.ts
@@ -17,6 +17,7 @@ import OpenAI from "openai";
 import { GoogleGenAI } from "@google/genai";
 import { writeFile, readFile } from "node:fs/promises";
 import { extname, resolve } from "node:path";
+import { getPaiDir } from "../../../hooks/lib/paths";
 
 // ============================================================================
 // Environment Loading
@@ -27,7 +28,7 @@ import { extname, resolve } from "node:path";
  * This ensures API keys are available regardless of how the CLI is invoked
  */
 async function loadEnv(): Promise<void> {
-  const paiDir = process.env.PAI_DIR || resolve(process.env.HOME!, '.claude');
+  const paiDir = getPaiDir();
   const envPath = resolve(paiDir, '.env');
   try {
     const envContent = await readFile(envPath, 'utf-8');
@@ -188,7 +189,7 @@ async function detectMimeType(filePath: string): Promise<string> {
 // ============================================================================
 
 // PAI directory for documentation paths
-const PAI_DIR = process.env.PAI_DIR || `${process.env.HOME}/.claude`;
+const PAI_DIR = getPaiDir();
 
 function showHelp(): void {
   console.log(`

--- a/Releases/v3.0/.claude/skills/Art/Tools/GenerateMidjourneyImage.ts
+++ b/Releases/v3.0/.claude/skills/Art/Tools/GenerateMidjourneyImage.ts
@@ -16,6 +16,7 @@ import { DiscordBotClient } from '../lib/discord-bot.js';
 import { MidjourneyClient, MidjourneyError } from '../lib/midjourney-client.js';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
+import { getPaiDir } from '../../../hooks/lib/paths';
 
 // ============================================================================
 // Environment Loading
@@ -26,7 +27,7 @@ import { resolve } from 'node:path';
  * This ensures API keys are available regardless of how the CLI is invoked
  */
 async function loadEnv(): Promise<void> {
-  const paiDir = process.env.PAI_DIR || resolve(process.env.HOME!, '.claude');
+  const paiDir = getPaiDir();
   const envPath = resolve(paiDir, '.env');
   try {
     const envContent = await readFile(envPath, 'utf-8');

--- a/Releases/v3.0/.claude/skills/PAI/Tools/FailureCapture.ts
+++ b/Releases/v3.0/.claude/skills/PAI/Tools/FailureCapture.ts
@@ -28,8 +28,9 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync } from 'fs';
 import { join, basename } from 'path';
 import { inference } from './Inference';
+import { getPaiDir } from '../../../hooks/lib/paths';
 
-const PAI_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
+const PAI_DIR = getPaiDir();
 
 interface FailureCaptureInput {
   transcriptPath: string;

--- a/Releases/v3.0/.claude/skills/PAI/Tools/GetCounts.ts
+++ b/Releases/v3.0/.claude/skills/PAI/Tools/GetCounts.ts
@@ -35,9 +35,10 @@
 
 import { readdirSync, existsSync, statSync } from "fs";
 import { join } from "path";
+import { getPaiDir } from "../../../hooks/lib/paths";
 
 const HOME = process.env.HOME!;
-const PAI_DIR = process.env.PAI_DIR || join(HOME, ".claude");
+const PAI_DIR = getPaiDir();
 
 interface Counts {
   skills: number;

--- a/Releases/v3.0/.claude/skills/PAI/Tools/OpinionTracker.ts
+++ b/Releases/v3.0/.claude/skills/PAI/Tools/OpinionTracker.ts
@@ -23,8 +23,9 @@
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
 import { join } from 'path';
+import { getPaiDir } from '../../../hooks/lib/paths';
 
-const PAI_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
+const PAI_DIR = getPaiDir();
 const OPINIONS_FILE = join(PAI_DIR, 'skills/PAI/USER/OPINIONS.md');
 const RELATIONSHIP_LOG = join(PAI_DIR, 'MEMORY/RELATIONSHIP');
 

--- a/Releases/v3.0/.claude/skills/PAI/Tools/RebuildPAI.ts
+++ b/Releases/v3.0/.claude/skills/PAI/Tools/RebuildPAI.ts
@@ -11,13 +11,13 @@
 
 import { readdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
+import { getPaiDir, paiPath, getSettingsPath } from "../../../hooks/lib/paths";
 
-const HOME = process.env.HOME!;
-const PAI_DIR = join(HOME, ".claude/skills/PAI");
-const COMPONENTS_DIR = join(PAI_DIR, "Components");
+const PAI_SKILL_DIR = paiPath("skills", "PAI");
+const COMPONENTS_DIR = join(PAI_SKILL_DIR, "Components");
 const ALGORITHM_DIR = join(COMPONENTS_DIR, "Algorithm");
-const OUTPUT_FILE = join(PAI_DIR, "SKILL.md");
-const SETTINGS_PATH = join(HOME, ".claude/settings.json");
+const OUTPUT_FILE = join(PAI_SKILL_DIR, "SKILL.md");
+const SETTINGS_PATH = getSettingsPath();
 
 /**
  * Load identity variables from settings.json for template resolution

--- a/Releases/v3.0/.claude/skills/PAI/Tools/RelationshipReflect.ts
+++ b/Releases/v3.0/.claude/skills/PAI/Tools/RelationshipReflect.ts
@@ -28,8 +28,9 @@
 import { readFileSync, writeFileSync, existsSync, readdirSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { execSync } from 'child_process';
+import { getPaiDir } from '../../../hooks/lib/paths';
 
-const PAI_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
+const PAI_DIR = getPaiDir();
 
 interface RelationshipNote {
   type: 'W' | 'B' | 'O';

--- a/Releases/v3.0/.claude/skills/PAI/Tools/algorithm.ts
+++ b/Releases/v3.0/.claude/skills/PAI/Tools/algorithm.ts
@@ -41,11 +41,12 @@ import { readFileSync, writeFileSync, existsSync, readdirSync, mkdirSync } from 
 import { resolve, basename, join, dirname } from "path";
 import { spawnSync, spawn } from "child_process";
 import { randomUUID } from "crypto";
+import { getPaiDir, paiPath } from "../../../hooks/lib/paths";
 
 // ─── Paths ───────────────────────────────────────────────────────────────────
 
 const HOME = process.env.HOME || "~";
-const BASE_DIR = process.env.PAI_DIR || join(HOME, ".claude");
+const BASE_DIR = getPaiDir();
 const ALGORITHMS_DIR = join(BASE_DIR, "MEMORY", "STATE", "algorithms");
 const SESSION_NAMES_PATH = join(BASE_DIR, "MEMORY", "STATE", "session-names.json");
 const PROJECTS_DIR = process.env.PROJECTS_DIR || join(HOME, "Projects");


### PR DESCRIPTION
## Summary

- **Enhanced `expandPath()`** in `hooks/lib/paths.ts` to handle arbitrary `$VAR`/`${VAR}` expansion (previously only `$HOME`/`${HOME}`/`~`)
- **Replaced 19 inline `process.env.PAI_DIR || join(…, '.claude')` patterns** across hooks and skills with centralized `getPaiDir()`/`paiPath()` imports
- **Removed duplicate `expandPath()`** from `SecurityValidator.hook.ts` (now imports from `hooks/lib/paths.ts`)
- **Fixed `RebuildPAI.ts`** to use `paiPath()`/`getSettingsPath()` instead of hardcoded `$HOME`-relative paths

## Problem

When `PAI_DIR` is set to a value containing `~` or `$HOME` (e.g., `~/my-pai` or `$HOME/.claude`), Claude Code doesn't expand these shell variables in `settings.json` env values. The centralized `expandPath()` in `hooks/lib/paths.ts` was designed to handle this, but 19 call sites bypassed it by reading `process.env.PAI_DIR` directly without expansion.

## Files Changed (19)

**Hooks:** AlgorithmTracker, AutoWorkCreation, RatingCapture, SecurityValidator, SessionSummary, StopOrchestrator, VoiceGate, WorkCompletionLearning

**Hooks/lib:** algorithm-state, notifications, paths

**Skills:** algorithm.ts, FailureCapture, GetCounts, OpinionTracker, RebuildPAI, RelationshipReflect, Generate (Art), GenerateMidjourneyImage (Art)

## Test plan

- [x] Verified zero remaining `process.env.PAI_DIR ||` patterns in `.ts` files
- [ ] Set `PAI_DIR=~/test-pai` and verify hooks resolve to expanded absolute path
- [ ] Set `PAI_DIR=$HOME/.claude` and verify expansion works
- [ ] Verify SecurityValidator path matching still works with imported `expandPath`

🤖 Generated with [Claude Code](https://claude.com/claude-code)