### PR TITLE
feat(statusline): show absolute token count alongside context percentage

### DIFF
--- a/Releases/v3.0/.claude/statusline-command.sh
+++ b/Releases/v3.0/.claude/statusline-command.sh
@@ -714,12 +714,12 @@ calc_bar_width() {
             ;;
         mini)
             prefix_len=12   # "◉ CONTEXT: "
-            suffix_len=5    # " XXX%"
+            suffix_len=17   # " XX% │ XXXk/XXXk"
             bucket_size=2
             ;;
         normal)
             prefix_len=12   # "◉ CONTEXT: "
-            suffix_len=5    # " XXX%"
+            suffix_len=17   # " XX% │ XXXk/XXXk"
             bucket_size=1   # no spacing for dense display
             ;;
     esac
@@ -840,6 +840,9 @@ else
     display_pct="$raw_pct"
 fi
 
+# Calculate used tokens in K for display
+used_k=$((raw_pct * context_max / 100 / 1000))
+
 # Color based on scaled percentage (same thresholds work for scaled 0-100%)
 if [ "$display_pct" -ge 80 ]; then
     pct_color="$ROSE"                  # Red: 80%+ - getting full
@@ -865,11 +868,11 @@ case "$MODE" in
         ;;
     mini)
         bar=$(render_context_bar $bar_width $display_pct)
-        printf "${CTX_PRIMARY}◉${RESET} ${CTX_SECONDARY}CONTEXT:${RESET} ${bar} ${pct_color}${display_pct}%%${RESET}\n"
+        printf "${CTX_PRIMARY}◉${RESET} ${CTX_SECONDARY}CONTEXT:${RESET} ${bar} ${pct_color}${display_pct}%%${RESET} ${SLATE_600}│${RESET} ${CTX_SECONDARY}${used_k}k/${max_k}k${RESET}\n"
         ;;
     normal)
         bar=$(render_context_bar $bar_width $display_pct)
-        printf "${CTX_PRIMARY}◉${RESET} ${CTX_SECONDARY}CONTEXT:${RESET} ${bar} ${pct_color}${display_pct}%%${RESET}\n"
+        printf "${CTX_PRIMARY}◉${RESET} ${CTX_SECONDARY}CONTEXT:${RESET} ${bar} ${pct_color}${display_pct}%%${RESET} ${SLATE_600}│${RESET} ${CTX_SECONDARY}${used_k}k/${max_k}k${RESET}\n"
         ;;
 esac
 printf "${SLATE_600}────────────────────────────────────────────────────────────────────────${RESET}\n"


### PR DESCRIPTION
## Summary

- Context bar in mini/normal modes now shows `XX% │ XXXk/XXXk` (e.g., `42% │ 84k/200k`)
- Makes the context window ceiling visible at a glance — critical for distinguishing 200k vs 1M windows
- Uses the standard `│` separator consistent with all other statusline sections
- Bar width reduced by 12 buckets to accommodate token text (43 vs 55 in normal mode — still plenty for the gradient)
- Nano/micro modes unchanged (no room for the extra text at narrow widths)

## Before / After

**Before (normal mode):**
```
◉ CONTEXT: ⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁ 42%
```

**After (normal mode):**
```
◉ CONTEXT: ⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁ 42% │ 84k/200k
```

## Changes

3 surgical edits in `statusline-command.sh`:
1. **Compute `used_k`** from `raw_pct * context_max / 100 / 1000` (1 line)
2. **Adjust `suffix_len`** from 5 → 17 for mini/normal modes (2 lines)
3. **Append token display** to printf in mini/normal modes (2 lines)

## Test plan

- [ ] Verify normal mode shows `XX% │ XXXk/XXXk` after the gradient bar
- [ ] Verify mini mode shows the same format
- [ ] Verify nano/micro modes are unchanged (percentage only)
- [ ] Test with compaction threshold configured (scaled percentage + raw token count)
- [ ] Confirm bar still renders gradient correctly at reduced width

🤖 Generated with [Claude Code](https://claude.com/claude-code)