### PR TITLE
feat(VoiceServer): add Kokoro self-hosted TTS as OpenAI-compatible provider

### DIFF
--- a/Releases/v3.0/.claude/VoiceServer/server.ts
+++ b/Releases/v3.0/.claude/VoiceServer/server.ts
@@ -501,8 +501,11 @@ async function sendNotification(
   if (voiceEnabled && VOICE_ENABLED_GLOBAL) {
     try {
       if (TTS_PROVIDER === 'openai-compatible') {
-        // Kokoro / OpenAI-compatible path — voice_id in request body used as Kokoro voice name
-        const kokoroVoice = voiceId || TTS_VOICE;
+        // Kokoro / OpenAI-compatible path — voice_id in request body used as Kokoro voice name.
+        // Validate it looks like a Kokoro voice (e.g. "am_liam", "bf_emma") — silently ignore
+        // ElevenLabs placeholders like "YOUR_VOICE_ID_HERE" or opaque ElevenLabs IDs.
+        const isValidKokoroVoice = (v: string | null) => !!v && /^[a-z]{2}_[a-z]/.test(v);
+        const kokoroVoice = isValidKokoroVoice(voiceId) ? voiceId! : TTS_VOICE;
         console.log(`🎙️  Generating speech via Kokoro (voice: ${kokoroVoice})`);
         const audioBuffer = await generateSpeechOpenAI(safeMessage, kokoroVoice);
         await playAudio(audioBuffer, callerVolume ?? FALLBACK_VOLUME);


### PR DESCRIPTION
## Summary

Adds [Kokoro-FastAPI](https://github.com/remsky/Kokoro-FastAPI) as a self-hosted, cost-free TTS alternative to ElevenLabs. Kokoro exposes an OpenAI-compatible `/v1/audio/speech` endpoint, making this patch reusable for any OpenAI-compatible TTS service (e.g., OpenedAI-speech, Piper via wrapper).

ElevenLabs remains the default — this is a zero-breaking-change opt-in via `settings.json`.

**Related:** See #687 (Google Cloud TTS) — that PR adds a managed cloud provider; this adds a self-hosted provider. The two are complementary and independent.

---

## Motivation

ElevenLabs requires a paid API key and sends audio to an external cloud. Kokoro runs locally (CPU or GPU), has 67+ voices, and once deployed costs nothing per request. For PAI users who already run Docker, this is a natural fit.

---

## Changes

**`Releases/v3.0/.claude/VoiceServer/server.ts`**

| Area | Change |
|---|---|
| `LoadedVoiceConfig` interface | Added `ttsProvider`, `ttsBaseUrl`, `ttsVoice` fields |
| `loadVoiceConfig()` | Reads `daidentity.ttsProvider` + `daidentity.openaiCompatibleTts` from `settings.json` with env var fallback |
| Module-level constants | Added `TTS_PROVIDER`, `TTS_BASE_URL`, `TTS_VOICE`, `VOICE_ENABLED_GLOBAL` |
| `generateSpeechOpenAI()` | New function — calls OpenAI-compatible `/v1/audio/speech` endpoint |
| `sendNotification()` | Routes to Kokoro or ElevenLabs based on `TTS_PROVIDER`; ElevenLabs 3-tier resolution preserved intact |
| `/health` endpoint | Reports active provider, Kokoro URL/voice or ElevenLabs voice ID |
| Startup logs | Prints active provider on boot |

---

## Configuration

**`~/.claude/settings.json`** — add to `daidentity`:

```json
{
  "daidentity": {
    "ttsProvider": "openai-compatible",
    "openaiCompatibleTts": {
      "baseUrl": "http://your-kokoro-host:8880",
      "voice": "am_liam"
    }
  }
}
```

Omit `ttsProvider` (or set to `"elevenlabs"`) to keep existing behavior — no migration needed.

**Environment variable fallback** (optional, lower priority than `settings.json`):
```bash
TTS_PROVIDER=openai-compatible
TTS_BASE_URL=http://your-kokoro-host:8880
TTS_VOICE=am_liam
```

**Global mute toggle** (useful for silencing all TTS without restarting):
```bash
VOICE_ENABLED=false  # in ~/.env
```

---

## Kokoro Setup (Docker)

```yaml
# docker-compose.yml
services:
  kokoro:
    image: ghcr.io/remsky/kokoro-fastapi-cpu:v0.2.2
    ports:
      - "8880:8880"
    restart: unless-stopped
```

Browse voices at `http://your-host:8880/web/` — 67 voices across American/British English, French, Spanish, and Japanese.

---

## Testing

```bash
# Verify active provider
curl http://localhost:8888/health
# → {"tts_provider":"openai-compatible","kokoro_voice":"am_liam",...}

# Send a notification
curl -X POST http://localhost:8888/notify \
  -H "Content-Type: application/json" \
  -d '{"message": "Kokoro is working.", "voice_enabled": true}'

# Override voice per-request
curl -X POST http://localhost:8888/notify \
  -H "Content-Type: application/json" \
  -d '{"message": "Testing British voice.", "voice_id": "bf_emma", "voice_enabled": true}'
```

Tested against Kokoro-FastAPI v0.2.2 (CPU image) on Windows/Docker Desktop.

---

## Checklist

- [x] No breaking changes — ElevenLabs is unchanged and remains default
- [x] Zero new dependencies — uses native `fetch`
- [x] `settings.json`-first config, matches pattern from #687
- [x] Works with `voice_id` request field for per-request voice override
- [x] Preserves all existing features: pronunciation rules, emotional presets, 3-tier resolution, desktop notifications, rate limiting