### PR TITLE
fix(telos): correct stale path to UpdateTelos.ts in Update workflow

### DIFF
--- a/Releases/v4.0.2/.claude/skills/Telos/Workflows/Update.md
+++ b/Releases/v4.0.2/.claude/skills/Telos/Workflows/Update.md
@@ -78,7 +78,7 @@ This is the main command you'll use. It takes three parameters:
 - Content to add (the actual text)
 - Description of the change (for the changelog)
 
-!`FILE="$1"; CONTENT="$2"; DESCRIPTION="$3"; bun ~/.claude/commands/update-telos.ts "$FILE" "$CONTENT" "$DESCRIPTION"`
+!`FILE="$1"; CONTENT="$2"; DESCRIPTION="$3"; bun ~/.claude/skills/Telos/Tools/UpdateTelos.ts "$FILE" "$CONTENT" "$DESCRIPTION"`
 
 ## List Valid TELOS Files
 !`echo "Valid TELOS files:
@@ -140,7 +140,7 @@ Use the update-telos command with:
 
 Example:
 ```bash
-bun ~/.claude/commands/update-telos.ts "BOOKS.md" "- *Project Hail Mary* by Andy Weir" "Added favorite book: Project Hail Mary"
+bun ~/.claude/skills/Telos/Tools/UpdateTelos.ts "BOOKS.md" "- *Project Hail Mary* by Andy Weir" "Added favorite book: Project Hail Mary"
 ```
 
 ## Step 4: Confirm and Engage
@@ -286,7 +286,7 @@ The TypeScript implementation handles:
 - Content appending (preserves existing content)
 - Pacific Time timezone for consistency
 
-The script is at: `~/.claude/commands/update-telos.ts`
+The script is at: `~/.claude/skills/Telos/Tools/UpdateTelos.ts`
 
 All backups are stored in: `~/.claude/PAI/USER/TELOS/Backups/`
 

--- a/Releases/v4.0.3/.claude/skills/Telos/Workflows/Update.md
+++ b/Releases/v4.0.3/.claude/skills/Telos/Workflows/Update.md
@@ -78,7 +78,7 @@ This is the main command you'll use. It takes three parameters:
 - Content to add (the actual text)
 - Description of the change (for the changelog)
 
-!`FILE="$1"; CONTENT="$2"; DESCRIPTION="$3"; bun ~/.claude/commands/update-telos.ts "$FILE" "$CONTENT" "$DESCRIPTION"`
+!`FILE="$1"; CONTENT="$2"; DESCRIPTION="$3"; bun ~/.claude/skills/Telos/Tools/UpdateTelos.ts "$FILE" "$CONTENT" "$DESCRIPTION"`
 
 ## List Valid TELOS Files
 !`echo "Valid TELOS files:
@@ -140,7 +140,7 @@ Use the update-telos command with:
 
 Example:
 ```bash
-bun ~/.claude/commands/update-telos.ts "BOOKS.md" "- *Project Hail Mary* by Andy Weir" "Added favorite book: Project Hail Mary"
+bun ~/.claude/skills/Telos/Tools/UpdateTelos.ts "BOOKS.md" "- *Project Hail Mary* by Andy Weir" "Added favorite book: Project Hail Mary"
 ```
 
 ## Step 4: Confirm and Engage
@@ -286,7 +286,7 @@ The TypeScript implementation handles:
 - Content appending (preserves existing content)
 - Pacific Time timezone for consistency
 
-The script is at: `~/.claude/commands/update-telos.ts`
+The script is at: `~/.claude/skills/Telos/Tools/UpdateTelos.ts`
 
 All backups are stored in: `~/.claude/PAI/USER/TELOS/Backups/`
 


### PR DESCRIPTION
## Summary

- The Telos Update workflow (`Workflows/Update.md`) references `~/.claude/commands/update-telos.ts`, but that path does not exist
- The actual implementation lives at `~/.claude/skills/Telos/Tools/UpdateTelos.ts`
- Updated all three stale path references (command invocation, example, and documentation footer) in v4.0.2 and v4.0.3

## Context

This is a follow-up to #764 which identified the same bug. That PR was closed as "addressed in v4.0.x" but the broken references persist identically in v4.0.0 through v4.0.3.

Verified by pulling the upstream `Update.md` from each release directory — all still reference the non-existent `~/.claude/commands/update-telos.ts` path.

## Test plan

- [x] `grep -rn 'commands/update-telos' Releases/v4.0.{2,3}/` returns zero matches after fix
- [x] All three references (line 81 command, line 143 example, line 289 docs) updated in both v4.0.2 and v4.0.3
- [ ] `bun ~/.claude/skills/Telos/Tools/UpdateTelos.ts` executes successfully with valid args

🤖 Generated with [Claude Code](https://claude.com/claude-code)