### PR TITLE
feat(voice): cross-platform Linux support for VoiceServer v4.0.3

### DIFF
--- a/Releases/v4.0.3/.claude/VoiceServer/server.ts
+++ b/Releases/v4.0.3/.claude/VoiceServer/server.ts
@@ -16,7 +16,11 @@
 
 import { serve } from "bun";
 import { spawn } from "child_process";
-import { homedir } from "os";
+import { homedir, platform } from "os";
+
+// Platform detection for cross-platform audio and notification support
+const IS_MACOS = platform() === 'darwin';
+const IS_LINUX = platform() === 'linux';
 import { join } from "path";
 import { existsSync, readFileSync } from "fs";
 
@@ -369,14 +373,41 @@ async function generateSpeech(
   return await response.arrayBuffer();
 }
 
-// Play audio using afplay (macOS)
+// Speak text directly using espeak-ng (no API, no credits, instant offline fallback)
+async function speakWithEspeak(text: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('espeak-ng', ['-s', '150', '-v', 'en', text]);
+    proc.on('error', reject);
+    proc.on('exit', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`espeak-ng exited with code ${code}`));
+    });
+  });
+}
+
+// Play audio using platform-appropriate player (macOS: afplay, Linux: auto-detect)
 async function playAudio(audioBuffer: ArrayBuffer, volume: number = FALLBACK_VOLUME): Promise<void> {
   const tempFile = `/tmp/voice-${Date.now()}.mp3`;
 
   await Bun.write(tempFile, audioBuffer);
 
   return new Promise((resolve, reject) => {
-    const proc = spawn('/usr/bin/afplay', ['-v', volume.toString(), tempFile]);
+    let proc;
+
+    if (IS_MACOS) {
+      proc = spawn('/usr/bin/afplay', ['-v', volume.toString(), tempFile]);
+    } else if (IS_LINUX) {
+      const player = findLinuxPlayer();
+      if (!player) {
+        reject(new Error('No audio player found. Install gstreamer1.0-tools, mpv, or pulseaudio-utils'));
+        return;
+      }
+      const args = getLinuxPlayerArgs(player, tempFile, volume);
+      proc = spawn(player, args);
+    } else {
+      reject(new Error(`Unsupported platform: ${platform()}`));
+      return;
+    }
 
     proc.on('error', (error) => {
       console.error('Error playing audio:', error);
@@ -388,10 +419,38 @@ async function playAudio(audioBuffer: ArrayBuffer, volume: number = FALLBACK_VOL
       if (code === 0) {
         resolve();
       } else {
-        reject(new Error(`afplay exited with code ${code}`));
+        reject(new Error(`Audio player exited with code ${code}`));
       }
     });
   });
+}
+
+// Find the best available Linux audio player
+function findLinuxPlayer(): string | null {
+  const candidates = ['gst-play-1.0', 'mpv', 'ffplay', 'paplay'];
+  for (const cmd of candidates) {
+    try {
+      const result = Bun.spawnSync(['which', cmd]);
+      if (result.exitCode === 0) return cmd;
+    } catch { /* not found, try next */ }
+  }
+  return null;
+}
+
+// Get appropriate args for each Linux audio player
+function getLinuxPlayerArgs(player: string, file: string, volume: number): string[] {
+  switch (player) {
+    case 'gst-play-1.0':
+      return ['--volume', volume.toString(), file];
+    case 'mpv':
+      return ['--no-video', '--no-terminal', `--volume=${Math.round(volume * 100)}`, file];
+    case 'ffplay':
+      return ['-nodisp', '-autoexit', '-volume', Math.round(volume * 100).toString(), file];
+    case 'paplay':
+      return ['--volume', Math.round(volume * 65536).toString(), file];
+    default:
+      return [file];
+  }
 }
 
 // Spawn a process safely
@@ -419,7 +478,7 @@ function spawnSafe(command: string, args: string[]): Promise<void> {
 // ==========================================================================
 
 /**
- * Send macOS notification with voice.
+ * Send desktop notification with voice (cross-platform: macOS + Linux).
  *
  * Voice settings resolution (3-tier):
  *   1. callerVoiceSettings provided → use directly (pass-through)
@@ -454,7 +513,23 @@ async function sendNotification(
   const { cleaned, emotion } = extractEmotionalMarker(safeMessage);
   safeMessage = cleaned;
 
-  // Generate and play voice using ElevenLabs
+  // Display desktop notification FIRST (immediate, non-blocking)
+  if (voiceConfig.desktopNotifications) {
+    try {
+      if (IS_MACOS) {
+        const escapedTitle = escapeForAppleScript(safeTitle);
+        const escapedMessage = escapeForAppleScript(safeMessage);
+        const script = `display notification "${escapedMessage}" with title "${escapedTitle}" sound name ""`;
+        await spawnSafe('/usr/bin/osascript', ['-e', script]);
+      } else if (IS_LINUX) {
+        await spawnSafe('notify-send', [safeTitle, safeMessage, '--app-name=PAI']);
+      }
+    } catch (error) {
+      console.error("Notification display error:", error);
+    }
+  }
+
+  // Generate and play voice after (blocking, waits for audio to finish)
   let voicePlayed = false;
   let voiceError: string | undefined;
 
@@ -507,20 +582,21 @@ async function sendNotification(
       await playAudio(audioBuffer, resolvedVolume);
       voicePlayed = true;
     } catch (error: any) {
-      console.error("Failed to generate/play speech:", error);
-      voiceError = error.message || "TTS generation failed";
-    }
-  }
-
-  // Display macOS notification (can be disabled via settings.json: notifications.desktop.enabled: false)
-  if (voiceConfig.desktopNotifications) {
-    try {
-      const escapedTitle = escapeForAppleScript(safeTitle);
-      const escapedMessage = escapeForAppleScript(safeMessage);
-      const script = `display notification "${escapedMessage}" with title "${escapedTitle}" sound name ""`;
-      await spawnSafe('/usr/bin/osascript', ['-e', script]);
-    } catch (error) {
-      console.error("Notification display error:", error);
+      console.error("ElevenLabs TTS failed:", error.message);
+      // Fallback to espeak-ng on Linux (handles quota exceeded, no API key, etc.)
+      if (IS_LINUX) {
+        try {
+          console.log('🔊 Falling back to espeak-ng...');
+          await speakWithEspeak(safeMessage);
+          voicePlayed = true;
+          console.log('✅ espeak-ng fallback succeeded');
+        } catch (espeakError: any) {
+          console.error("espeak-ng fallback also failed:", espeakError);
+          voiceError = error.message || "TTS generation failed";
+        }
+      } else {
+        voiceError = error.message || "TTS generation failed";
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Adds platform detection (`IS_MACOS`, `IS_LINUX`) to VoiceServer in `Releases/v4.0.3/`
- Auto-detects Linux audio players (`gst-play-1.0`, `mpv`, `ffplay`, `paplay`)
- Adds `espeak-ng` offline TTS fallback when ElevenLabs fails (quota exceeded, network issues)
- Uses `notify-send` for Linux desktop notifications (alongside `osascript` on macOS)
- Reorders: desktop notification fires first (non-blocking), then voice generation (blocking)

macOS behavior is completely unchanged. All changes are additive and gated behind platform detection.

## Motivation

The v4.0.3 VoiceServer only works on macOS due to hardcoded `/usr/bin/afplay` and `/usr/bin/osascript`. Linux users get silent failures with no audio playback or desktop notifications.

## Test plan

- [ ] macOS: Verify `afplay` and `osascript` still work as before
- [ ] Linux: Verify audio plays via auto-detected player (mpv, paplay, etc.)
- [ ] Linux: Verify `notify-send` shows desktop notification
- [ ] ElevenLabs quota exceeded: Verify `espeak-ng` fallback speaks the message
- [ ] Health endpoint still returns correct status