### PR TITLE
feat: hook test harness + SecurityValidator patterns template

### DIFF
--- a/Releases/v4.0.2/.claude/PAI/PAISECURITYSYSTEM/patterns.example.yaml
+++ b/Releases/v4.0.2/.claude/PAI/PAISECURITYSYSTEM/patterns.example.yaml
@@ -1,0 +1,127 @@
+# PAI Security Patterns — Default Template
+#
+# SecurityValidator.hook.ts loads patterns in this order:
+#   1. PAI/USER/PAISECURITYSYSTEM/patterns.yaml  (your custom rules)
+#   2. PAI/PAISECURITYSYSTEM/patterns.example.yaml  (this file — defaults)
+#
+# To customize: copy this file to PAI/USER/PAISECURITYSYSTEM/patterns.yaml
+# and modify to match your environment and security requirements.
+#
+# Without a patterns file, SecurityValidator is completely fail-open
+# (all operations allowed) — adding patterns activates security enforcement.
+#
+# Pattern syntax: YAML-escaped regex (double-escape backslashes)
+# Example: "rm\\s+-rf" matches "rm -rf" with any whitespace
+
+version: "1.0"
+
+philosophy:
+  mode: "defensive"
+  principle: "Block catastrophic, confirm destructive, alert suspicious, allow everything else"
+
+bash:
+  # Trusted: fast-path allow, no logging (reduces noise)
+  trusted:
+    - pattern: "^(ls|cat|head|tail|echo|pwd|whoami|date|wc|file|which|type)\\b"
+      reason: "Safe read-only commands"
+    - pattern: "^git\\s+(status|log|diff|branch|remote|show|tag)"
+      reason: "Git read operations"
+    - pattern: "^(npm|yarn|pnpm|bun)\\s+(test|run|exec|list|info)"
+      reason: "Package manager read/run operations"
+    - pattern: "^(python|node|bun|deno|ruby)\\s+"
+      reason: "Script execution (validated by file access)"
+    - pattern: "^grep|^rg|^find|^fd\\s"
+      reason: "Search commands"
+
+  # Blocked: hard block, exit(2) — catastrophic operations
+  blocked:
+    - pattern: "rm\\s+-rf\\s+/"
+      reason: "Filesystem destruction: rm -rf /"
+    - pattern: "rm\\s+-rf\\s+~"
+      reason: "Home directory destruction"
+    - pattern: "rm\\s+-rf\\s+\\*"
+      reason: "Wildcard deletion from current directory"
+    - pattern: "mkfs\\."
+      reason: "Filesystem format"
+    - pattern: "dd\\s+.*of=/dev/"
+      reason: "Direct disk write"
+    - pattern: ":(){ :|:& };:"
+      reason: "Fork bomb"
+    - pattern: "chmod\\s+777\\s+/etc/"
+      reason: "Dangerous permission change on /etc"
+    - pattern: "curl.*\\|\\s*(bash|sh|zsh)"
+      reason: "Pipe from internet to shell"
+    - pattern: "wget.*\\|\\s*(bash|sh|zsh)"
+      reason: "Pipe download to shell"
+    - pattern: "\\beval\\b.*\\$\\("
+      reason: "Dynamic eval of command substitution"
+
+  # Confirm: prompt user before executing
+  confirm:
+    - pattern: "git\\s+push\\s+--force"
+      reason: "Force push can lose remote commits"
+    - pattern: "git\\s+push\\s+-f\\b"
+      reason: "Force push (short flag)"
+    - pattern: "git\\s+reset\\s+--hard"
+      reason: "Hard reset discards uncommitted changes"
+    - pattern: "git\\s+clean\\s+-fd"
+      reason: "Removes untracked files and directories"
+    - pattern: "DROP\\s+TABLE|DROP\\s+DATABASE"
+      reason: "Database destruction"
+    - pattern: "TRUNCATE\\s+TABLE"
+      reason: "Table data deletion"
+    - pattern: "rm\\s+-rf\\s+\\S+"
+      reason: "Recursive force delete"
+    - pattern: "docker\\s+(system|volume)\\s+prune"
+      reason: "Docker cleanup removes stopped containers/volumes"
+
+  # Alert: log but allow — suspicious but not dangerous
+  alert:
+    - pattern: "sudo\\s+"
+      reason: "Elevated privileges requested"
+    - pattern: "chmod\\s+[0-7]+"
+      reason: "Permission change"
+    - pattern: "chown\\s+"
+      reason: "Ownership change"
+    - pattern: "\\bkill\\s+-9\\b"
+      reason: "Force kill process"
+    - pattern: "\\bnohup\\b"
+      reason: "Background process (survives shell exit)"
+
+paths:
+  # zeroAccess: cannot read or write — secrets and credentials
+  zeroAccess:
+    - "~/.ssh/id_*"
+    - "~/.ssh/id_rsa"
+    - "~/.ssh/id_ed25519"
+    - "~/.ssh/config"
+    - "~/.aws/credentials"
+    - "~/.aws/config"
+    - "~/.gnupg/private-keys*"
+    - "~/.config/gh/hosts.yml"
+    - "~/.netrc"
+    - "**/.env.local"
+    - "**/.env.production"
+
+  # readOnly: can read, cannot write
+  readOnly:
+    - "/etc/passwd"
+    - "/etc/shadow"
+    - "/etc/hosts"
+    - "/etc/sudoers"
+
+  # confirmWrite: can read, writing requires confirmation
+  confirmWrite:
+    - "~/.bashrc"
+    - "~/.zshrc"
+    - "~/.profile"
+    - "~/.gitconfig"
+    - "~/.claude/settings.json"
+
+  # noDelete: can read and write, cannot delete
+  noDelete:
+    - "~/.claude/CLAUDE.md"
+    - "~/.claude/settings.json"
+    - "~/.claude/hooks/"
+
+projects: {}

--- a/Releases/v4.0.2/.claude/hooks/tests/AgentExecutionGuard.test.ts
+++ b/Releases/v4.0.2/.claude/hooks/tests/AgentExecutionGuard.test.ts
@@ -1,0 +1,134 @@
+import { test, expect, describe } from 'bun:test';
+import { runHook, createTempDir, cleanupTempDir } from './harness';
+
+/**
+ * AgentExecutionGuard integration tests.
+ *
+ * Tests the guard logic for Task tool calls:
+ * - Background agents pass silently
+ * - Fast agents (Explore, haiku) pass silently
+ * - Foreground non-fast agents get a warning
+ *
+ * Pure logic — no external dependencies needed.
+ */
+
+describe('AgentExecutionGuard', () => {
+  const hook = 'hooks/AgentExecutionGuard.hook.ts';
+
+  test('passes when run_in_background is true', async () => {
+    const result = await runHook(hook, {
+      tool_name: 'Task',
+      tool_input: {
+        run_in_background: true,
+        subagent_type: 'Engineer',
+        description: 'Build feature',
+        prompt: 'Build the auth module',
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    // No warning output
+    expect(result.stdout).not.toContain('WARNING');
+  });
+
+  test('passes for Explore agent type (fast-tier)', async () => {
+    const result = await runHook(hook, {
+      tool_name: 'Task',
+      tool_input: {
+        subagent_type: 'Explore',
+        description: 'Find auth files',
+        prompt: 'Search for authentication code',
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toContain('WARNING');
+  });
+
+  test('passes for haiku model (fast-tier)', async () => {
+    const result = await runHook(hook, {
+      tool_name: 'Task',
+      tool_input: {
+        model: 'haiku',
+        subagent_type: 'general-purpose',
+        description: 'Quick lookup',
+        prompt: 'Find the config file',
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toContain('WARNING');
+  });
+
+  test('warns for foreground non-fast agent', async () => {
+    const result = await runHook(hook, {
+      tool_name: 'Task',
+      tool_input: {
+        subagent_type: 'Engineer',
+        description: 'Build entire feature',
+        prompt: 'Implement the full auth system with tests',
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    // Should contain warning about foreground agent
+    expect(result.stdout).toContain('WARNING');
+    expect(result.stdout).toContain('FOREGROUND AGENT');
+    expect(result.stdout).toContain('run_in_background');
+  });
+
+  test('warns when run_in_background is false', async () => {
+    const result = await runHook(hook, {
+      tool_name: 'Task',
+      tool_input: {
+        run_in_background: false,
+        subagent_type: 'general-purpose',
+        description: 'Research task',
+        prompt: 'Investigate the bug',
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('WARNING');
+  });
+
+  test('handles empty input gracefully', async () => {
+    const result = await runHook(hook, {
+      tool_name: 'Task',
+      tool_input: {},
+    });
+
+    expect(result.exitCode).toBe(0);
+    // Empty tool_input → no background, no fast agent → warning
+    expect(result.stdout).toContain('WARNING');
+  });
+
+  test('passes for FAST timing in prompt', async () => {
+    const result = await runHook(hook, {
+      tool_name: 'Task',
+      tool_input: {
+        subagent_type: 'general-purpose',
+        description: 'Quick check',
+        prompt: '## Scope\nTiming: FAST\n\nCheck if the file exists',
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toContain('WARNING');
+  });
+
+  test('always exits 0 (never blocks agents)', async () => {
+    // Even on violations, the guard only warns — never blocks
+    const result = await runHook(hook, {
+      tool_name: 'Task',
+      tool_input: {
+        subagent_type: 'Engineer',
+        description: 'Long running task',
+        prompt: 'Refactor the entire codebase',
+        max_turns: 50,
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/Releases/v4.0.2/.claude/hooks/tests/README.md
+++ b/Releases/v4.0.2/.claude/hooks/tests/README.md
@@ -1,0 +1,157 @@
+# PAI Hook Integration Tests
+
+> **Subprocess-based integration tests for PAI hooks using Bun.**
+
+## Quick Start
+
+```bash
+# Run all tests
+cd ~/.claude
+bun test hooks/tests/
+
+# Run a specific suite
+bun test hooks/tests/SecurityValidator.test.ts
+bun test hooks/tests/AgentExecutionGuard.test.ts
+```
+
+## Architecture
+
+Tests run each hook as a **real subprocess** — no mocks, no monkey-patching. This ensures tests validate the exact same code path that runs in production.
+
+```
+Test Suite
+    │
+    ├── Creates temp directory (isolated side effects)
+    ├── Writes test data (patterns, ratings, etc.)
+    │
+    └── runHook('hooks/HookName.hook.ts', stdinData, env)
+            │
+            ├── Spawns: bun hooks/HookName.hook.ts
+            ├── Pipes: JSON stdin (simulates Claude Code hook payload)
+            ├── Sets: PAI_DIR=tempDir (isolates from real state)
+            │
+            └── Captures: stdout, stderr, exitCode, duration, json
+```
+
+### Key Design Decisions
+
+1. **Real subprocesses** — Tests run the actual hook binary, not imported functions
+2. **Temp directories** — Every test gets a fresh temp dir via `PAI_DIR` env override
+3. **No mocks** — If a hook depends on external services (API, terminal), the test either:
+   - Uses a short timeout and accepts graceful failure, or
+   - Is marked as requiring a specific environment
+4. **Fail-open testing** — Verifies hooks fail gracefully (exit 0) when dependencies are missing
+
+## Test Harness API
+
+### `runHook(hookPath, stdinData, env?, timeout?)`
+
+Runs a hook as a subprocess with mock stdin.
+
+```typescript
+import { runHook, createTempDir, cleanupTempDir } from './harness';
+
+const result = await runHook(
+  'hooks/SecurityValidator.hook.ts',  // Relative to PAI_DIR
+  { tool_name: 'Bash', tool_input: { command: 'ls' } },  // Stdin JSON
+  { PAI_DIR: '/tmp/test-dir' },  // Extra env vars
+  5000  // Timeout in ms (default: 10000)
+);
+
+// Result shape:
+result.stdout    // string — captured stdout
+result.stderr    // string — captured stderr
+result.exitCode  // number — 0, 2, or -1 (timeout)
+result.duration  // number — ms elapsed
+result.json      // any — parsed last JSON line from stdout (null if not JSON)
+```
+
+### `createTempDir(prefix?)` / `cleanupTempDir(dir)`
+
+Create and cleanup temporary directories for test isolation.
+
+```typescript
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = createTempDir('pai-test-');
+  // Set up test data in tempDir...
+});
+
+afterEach(() => {
+  cleanupTempDir(tempDir);
+});
+```
+
+## Test Suites
+
+| Suite | Hook | Tests | Dependencies |
+|-------|------|-------|--------------|
+| SecurityValidator | `SecurityValidator.hook.ts` | 10 | `patterns.yaml` |
+| AgentExecutionGuard | `AgentExecutionGuard.hook.ts` | 8 | None |
+
+## Writing New Tests
+
+1. Create `hooks/tests/YourHook.test.ts`
+2. Import the harness: `import { runHook, createTempDir, cleanupTempDir } from './harness'`
+3. Use `PAI_DIR` env var to isolate from real state
+4. Test the hook's documented behavior (see hook's header comments)
+5. Always test: normal operation, edge cases, error handling, fail-open behavior
+
+### Template
+
+```typescript
+import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
+import { runHook, createTempDir, cleanupTempDir } from './harness';
+import { mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+describe('YourHook', () => {
+  const hook = 'hooks/YourHook.hook.ts';
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir('pai-yourhook-');
+    // Create required directories
+    mkdirSync(join(tempDir, 'MEMORY', 'STATE'), { recursive: true });
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tempDir);
+  });
+
+  test('does its thing', async () => {
+    const result = await runHook(hook, {
+      session_id: 'test-001',
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'echo hello' },
+    }, { PAI_DIR: tempDir });
+
+    expect(result.exitCode).toBe(0);
+  });
+
+  test('fails gracefully on error', async () => {
+    const result = await runHook(hook, {
+      // Intentionally malformed input
+    }, { PAI_DIR: tempDir });
+
+    expect(result.exitCode).toBe(0); // Fail-open
+  });
+});
+```
+
+## CI Integration
+
+These tests are designed for CI environments:
+
+- No external service dependencies (API keys, voice server, terminal)
+- Deterministic — no time-dependent logic
+- Fast — each suite completes in <5s
+- Isolated — temp dirs, no shared state
+
+```yaml
+# GitHub Actions example
+- name: Run PAI hook tests
+  run: bun test hooks/tests/
+```

--- a/Releases/v4.0.2/.claude/hooks/tests/SecurityValidator.test.ts
+++ b/Releases/v4.0.2/.claude/hooks/tests/SecurityValidator.test.ts
@@ -1,0 +1,249 @@
+import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
+import { runHook, createTempDir, cleanupTempDir } from './harness';
+import { writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * SecurityValidator integration tests.
+ *
+ * Tests the SecurityValidator hook against patterns.example.yaml.
+ * Each test runs the hook as a subprocess with mock stdin,
+ * verifying exit codes and stdout/stderr output.
+ *
+ * Requirements:
+ * - Bun runtime (bun:test)
+ * - patterns.example.yaml in PAI/PAISECURITYSYSTEM/
+ */
+
+describe('SecurityValidator', () => {
+  const hook = 'hooks/SecurityValidator.hook.ts';
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir('pai-secval-');
+
+    // Create directory structure
+    mkdirSync(join(tempDir, 'PAI', 'PAISECURITYSYSTEM'), { recursive: true });
+    mkdirSync(join(tempDir, 'PAI', 'USER', 'PAISECURITYSYSTEM'), { recursive: true });
+    mkdirSync(join(tempDir, 'MEMORY', 'SECURITY'), { recursive: true });
+    mkdirSync(join(tempDir, 'hooks', 'lib'), { recursive: true });
+
+    // Copy patterns.example.yaml as the active patterns file
+    // In real usage, users copy this to PAI/USER/PAISECURITYSYSTEM/patterns.yaml
+    writeFileSync(
+      join(tempDir, 'PAI', 'PAISECURITYSYSTEM', 'patterns.example.yaml'),
+      EXAMPLE_PATTERNS,
+      'utf-8'
+    );
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tempDir);
+  });
+
+  // ── Allow: Safe Commands ──
+
+  test('allows safe commands (ls, git status)', async () => {
+    const result = await runHook(hook, {
+      session_id: 'test-sv-001',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls -la' },
+    }, { PAI_DIR: tempDir });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.json?.continue).toBe(true);
+  });
+
+  test('allows git status', async () => {
+    const result = await runHook(hook, {
+      session_id: 'test-sv-002',
+      tool_name: 'Bash',
+      tool_input: { command: 'git status' },
+    }, { PAI_DIR: tempDir });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.json?.continue).toBe(true);
+  });
+
+  // ── Block: Catastrophic Commands ──
+
+  test('blocks rm -rf /', async () => {
+    const result = await runHook(hook, {
+      session_id: 'test-sv-010',
+      tool_name: 'Bash',
+      tool_input: { command: 'rm -rf /' },
+    }, { PAI_DIR: tempDir });
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('BLOCKED');
+  });
+
+  test('blocks dd write to disk', async () => {
+    const result = await runHook(hook, {
+      session_id: 'test-sv-011',
+      tool_name: 'Bash',
+      tool_input: { command: 'dd if=/dev/zero of=/dev/sda' },
+    }, { PAI_DIR: tempDir });
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('BLOCKED');
+  });
+
+  test('blocks chmod 777 on sensitive paths', async () => {
+    const result = await runHook(hook, {
+      session_id: 'test-sv-012',
+      tool_name: 'Bash',
+      tool_input: { command: 'chmod 777 /etc/passwd' },
+    }, { PAI_DIR: tempDir });
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('BLOCKED');
+  });
+
+  // ── Confirm: Destructive but Legitimate Commands ──
+
+  test('prompts confirmation for git push --force', async () => {
+    const result = await runHook(hook, {
+      session_id: 'test-sv-020',
+      tool_name: 'Bash',
+      tool_input: { command: 'git push --force origin main' },
+    }, { PAI_DIR: tempDir });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.json?.decision).toBe('ask');
+    expect(result.json?.message).toContain('SECURITY');
+  });
+
+  // ── Path Validation ──
+
+  test('blocks reading SSH private keys', async () => {
+    const result = await runHook(hook, {
+      session_id: 'test-sv-030',
+      tool_name: 'Read',
+      tool_input: { file_path: `${process.env.HOME}/.ssh/id_rsa` },
+    }, { PAI_DIR: tempDir });
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('BLOCKED');
+  });
+
+  // ── Fail-Open Behavior ──
+
+  test('allows operation when no patterns file exists', async () => {
+    // Create a temp dir WITHOUT patterns files
+    const emptyDir = createTempDir('pai-secval-empty-');
+    mkdirSync(join(emptyDir, 'hooks', 'lib'), { recursive: true });
+
+    const result = await runHook(hook, {
+      session_id: 'test-sv-040',
+      tool_name: 'Bash',
+      tool_input: { command: 'rm -rf /' },
+    }, { PAI_DIR: emptyDir });
+
+    // Without patterns, even dangerous commands are allowed (fail-open)
+    expect(result.exitCode).toBe(0);
+    expect(result.json?.continue).toBe(true);
+
+    cleanupTempDir(emptyDir);
+  });
+
+  test('handles empty tool_input gracefully', async () => {
+    const result = await runHook(hook, {
+      session_id: 'test-sv-041',
+      tool_name: 'Bash',
+      tool_input: {},
+    }, { PAI_DIR: tempDir });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.json?.continue).toBe(true);
+  });
+
+  // ── Performance ──
+
+  test('completes within 500ms', async () => {
+    const result = await runHook(hook, {
+      session_id: 'test-sv-050',
+      tool_name: 'Bash',
+      tool_input: { command: 'echo hello' },
+    }, { PAI_DIR: tempDir });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.duration).toBeLessThan(500);
+  });
+});
+
+// ── Example Patterns YAML ──
+// Minimal but functional patterns for testing
+
+const EXAMPLE_PATTERNS = `# PAI Security Patterns — Example Template
+# Copy to PAI/USER/PAISECURITYSYSTEM/patterns.yaml and customize.
+
+version: "1.0"
+
+philosophy:
+  mode: "defensive"
+  principle: "Block catastrophic, confirm destructive, alert suspicious, allow everything else"
+
+bash:
+  trusted:
+    - pattern: "^(ls|cat|echo|pwd|whoami|date|git\\\\s+(status|log|diff|branch))\\\\b"
+      reason: "Safe read-only commands"
+    - pattern: "^bun\\\\s+(test|run)"
+      reason: "Package manager operations"
+
+  blocked:
+    - pattern: "rm\\\\s+-rf\\\\s+/"
+      reason: "Filesystem destruction: rm -rf /"
+    - pattern: "rm\\\\s+-rf\\\\s+\\\\*"
+      reason: "Wildcard deletion from root"
+    - pattern: "mkfs\\\\."
+      reason: "Filesystem format"
+    - pattern: "dd\\\\s+.*of=/dev/"
+      reason: "Direct disk write"
+    - pattern: ":(){ :|:& };:"
+      reason: "Fork bomb"
+    - pattern: "chmod\\\\s+777\\\\s+/etc/"
+      reason: "Dangerous permission change on /etc"
+    - pattern: "curl.*\\\\|\\\\s*(bash|sh)"
+      reason: "Pipe from internet to shell"
+
+  confirm:
+    - pattern: "git\\\\s+push\\\\s+--force"
+      reason: "Force push can lose remote commits"
+    - pattern: "git\\\\s+reset\\\\s+--hard"
+      reason: "Hard reset discards uncommitted changes"
+    - pattern: "rm\\\\s+-rf\\\\s+\\\\S+"
+      reason: "Recursive force delete"
+    - pattern: "DROP\\\\s+TABLE|DROP\\\\s+DATABASE"
+      reason: "Database destruction"
+
+  alert:
+    - pattern: "sudo\\\\s+"
+      reason: "Elevated privileges requested"
+    - pattern: "chmod\\\\s+[0-7]+"
+      reason: "Permission change"
+
+paths:
+  zeroAccess:
+    - "~/.ssh/id_*"
+    - "~/.ssh/id_rsa"
+    - "~/.ssh/id_ed25519"
+    - "~/.aws/credentials"
+    - "~/.gnupg/private-keys*"
+
+  readOnly:
+    - "/etc/passwd"
+    - "/etc/shadow"
+    - "/etc/hosts"
+
+  confirmWrite:
+    - "~/.bashrc"
+    - "~/.zshrc"
+    - "~/.profile"
+
+  noDelete:
+    - "~/.claude/CLAUDE.md"
+    - "~/.claude/settings.json"
+
+projects: {}
+`;

--- a/Releases/v4.0.2/.claude/hooks/tests/harness.ts
+++ b/Releases/v4.0.2/.claude/hooks/tests/harness.ts
@@ -1,0 +1,117 @@
+/**
+ * harness.ts — Test harness for PAI hook integration tests
+ *
+ * Spawns hooks as subprocesses with mock stdin, captures stdout/stderr/exit code.
+ * Uses temp dirs for side effects to avoid polluting real state.
+ *
+ * Requirements: Bun runtime (bun:test)
+ *
+ * Usage in tests:
+ *   import { runHook, createTempDir, cleanupTempDir } from './harness';
+ *   const result = await runHook('hooks/MyHook.hook.ts', { prompt: 'hello' });
+ *   expect(result.exitCode).toBe(0);
+ */
+
+import { mkdirSync, existsSync, rmSync, mkdtempSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
+
+export interface HookResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  duration: number;
+  /** Parsed stdout as JSON (null if not valid JSON) */
+  json: any | null;
+}
+
+/**
+ * Run a hook as a subprocess with mock stdin data.
+ *
+ * @param hookPath - Relative path from BASE_DIR (e.g., 'hooks/ModeClassifier.hook.ts')
+ * @param stdinData - Object to serialize as JSON and pipe to stdin
+ * @param env - Extra environment variables (merged with process.env)
+ * @param timeout - Max execution time in ms (default 10s)
+ */
+export async function runHook(
+  hookPath: string,
+  stdinData: Record<string, unknown>,
+  env?: Record<string, string>,
+  timeout: number = 10000,
+): Promise<HookResult> {
+  const fullPath = join(BASE_DIR, hookPath);
+  const start = Date.now();
+
+  const proc = Bun.spawn(['bun', fullPath], {
+    stdin: new Blob([JSON.stringify(stdinData)]),
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: {
+      ...process.env,
+      // Prevent hooks from sending voice notifications during tests
+      CLAUDE_CODE_AGENT_TASK_ID: 'test-harness',
+      ...env,
+    },
+  });
+
+  // Race between process completion and timeout
+  const timeoutPromise = new Promise<never>((_, reject) =>
+    setTimeout(() => {
+      proc.kill();
+      reject(new Error(`Hook timed out after ${timeout}ms`));
+    }, timeout)
+  );
+
+  try {
+    const [stdout, stderr] = await Promise.race([
+      Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+      ]),
+      timeoutPromise,
+    ]);
+
+    await proc.exited;
+    const duration = Date.now() - start;
+
+    let json: any = null;
+    try {
+      // Hook stdout may contain multiple lines; parse the last JSON line
+      const jsonLines = stdout.trim().split('\n').filter(l => l.startsWith('{'));
+      if (jsonLines.length > 0) {
+        json = JSON.parse(jsonLines[jsonLines.length - 1]);
+      }
+    } catch { /* not JSON */ }
+
+    return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode: proc.exitCode ?? 1, duration, json };
+  } catch (err) {
+    return {
+      stdout: '',
+      stderr: err instanceof Error ? err.message : String(err),
+      exitCode: -1,
+      duration: Date.now() - start,
+      json: null,
+    };
+  }
+}
+
+/**
+ * Create a temporary directory for test side effects.
+ * Returns path. Must call cleanupTempDir after test.
+ */
+export function createTempDir(prefix: string = 'pai-test-'): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+/**
+ * Clean up a temporary directory.
+ */
+export function cleanupTempDir(dir: string): void {
+  try {
+    if (existsSync(dir)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  } catch { /* silent */ }
+}


### PR DESCRIPTION
## Summary

- **Test harness** (`hooks/tests/harness.ts`): Subprocess-based integration test runner for PAI hooks. Spawns hooks as real processes with mock stdin, captures stdout/stderr/exit codes, supports temp directory isolation via `PAI_DIR` env override.
- **SecurityValidator tests** (10 tests): Validates block/confirm/allow/fail-open behavior against `patterns.example.yaml` — covers safe commands, catastrophic commands, path validation, and performance.
- **AgentExecutionGuard tests** (8 tests): Validates guard logic for Task tool calls — background agents, fast-tier exemptions (Explore, haiku), foreground warnings.
- **`patterns.example.yaml`**: Default security patterns template. `SecurityValidator.hook.ts` references `PAI/PAISECURITYSYSTEM/patterns.example.yaml` as a fallback, but this file was missing — without it, SecurityValidator is completely fail-open (all operations allowed).
- **Test README**: Architecture docs, API reference, writing guide, and CI integration example.

**18 tests, 38 assertions, all passing** (Bun v1.3.9, ~2.7s).

## Motivation

PAI v4.0.2 has 21 hooks but no test infrastructure. Hooks are the security and reliability backbone — they deserve automated verification. This PR provides:

1. A **reusable harness** any hook can be tested with
2. **Example test suites** demonstrating the pattern
3. A **missing config file** (`patterns.example.yaml`) that activates SecurityValidator's security enforcement

## Test plan

- [x] `bun test hooks/tests/` — 18 pass, 0 fail, 38 assertions
- [x] SecurityValidator: safe commands allowed, catastrophic blocked (exit 2), destructive confirmed
- [x] AgentExecutionGuard: background pass, Explore pass, haiku pass, foreground warned
- [x] Fail-open: hooks degrade gracefully when dependencies missing
- [x] Performance: SecurityValidator completes in <500ms
- [x] Isolation: all tests use temp dirs, no shared state

🤖 Generated with [Claude Code](https://claude.com/claude-code)