### PR TITLE
fix(algorithm.ts): stopLoop terminal state guard + regex escaping

### DIFF
--- a/Releases/v4.0.3/.claude/PAI/Tools/algorithm.ts
+++ b/Releases/v4.0.3/.claude/PAI/Tools/algorithm.ts
@@ -350,7 +350,9 @@ function updateFrontmatter(path: string, updates: Record<string, unknown>): void
 
   for (const [key, value] of Object.entries(updates)) {
     const strVal = value === null ? "null" : String(value);
-    const regex = new RegExp(`^(${key}):.*$`, "m");
+    // Escape regex metacharacters in key to prevent injection
+    const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const regex = new RegExp(`^(${escapedKey}):.*$`, "m");
     if (regex.test(yamlBlock)) {
       yamlBlock = yamlBlock.replace(regex, `${key}: ${strVal}`);
     } else {
@@ -1438,6 +1440,11 @@ async function resumeLoop(prdPath: string): Promise<void> {
 function stopLoop(prdPath: string): void {
   const absPath = resolve(prdPath);
   const { frontmatter } = readPRD(absPath);
+  // Guard: don't overwrite terminal states (matches pauseLoop's pattern)
+  if (frontmatter.loopStatus === "completed" || frontmatter.loopStatus === "failed") {
+    console.log(`Loop already ${frontmatter.loopStatus} on ${frontmatter.id} — not modifying.`);
+    return;
+  }
   updateFrontmatter(absPath, { loopStatus: "stopped" });
   voiceNotify(`Loop stopped on ${frontmatter.id}.`);
   console.log(`\x1b[31m\u25A0 Stopped\x1b[0m Loop on ${frontmatter.id}`);


### PR DESCRIPTION
## Summary

Two surgical fixes in `algorithm.ts` (v4.0.3), following up on the invite from #808 review to resubmit against current code.

- **stopLoop() overwrites terminal states** — `algorithm stop -p COMPLETED_PRD` silently sets `loopStatus: "stopped"`, losing the "completed" or "failed" state. `pauseLoop()` already guards against this (`if loopStatus !== "running"`); `stopLoop()` was missing the same guard.
- **updateFrontmatter() regex injection** — YAML keys passed directly to `new RegExp()` without escaping. Current keys are safe internal strings, but any key with regex metacharacters (`.`, `[`, `(`) would cause silent regex errors. Added standard `[.*+?^${}()|[\]\\]` escaping.

## Changes

```diff
 function stopLoop(prdPath: string): void {
   const absPath = resolve(prdPath);
   const { frontmatter } = readPRD(absPath);
+  if (frontmatter.loopStatus === "completed" || frontmatter.loopStatus === "failed") {
+    console.log(`Loop already ${frontmatter.loopStatus} on ${frontmatter.id} — not modifying.`);
+    return;
+  }
   updateFrontmatter(absPath, { loopStatus: "stopped" });

   for (const [key, value] of Object.entries(updates)) {
     const strVal = value === null ? "null" : String(value);
-    const regex = new RegExp(`^(${key}):.*$`, "m");
+    const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const regex = new RegExp(`^(${escapedKey}):.*$`, "m");
```

## Test plan

- [x] `algorithm stop -p COMPLETED_PRD` — prints "already completed", does not modify
- [x] `algorithm stop -p FAILED_PRD` — prints "already failed", does not modify
- [x] `algorithm stop -p RUNNING_PRD` — stops normally (unchanged behavior)
- [x] `algorithm pause -p COMPLETED_PRD` — already guarded, behavior unchanged
- [x] File compiles without errors (`bun build --target bun algorithm.ts`)
- [x] No behavioral changes for normal operation — both fixes are edge case guards only

🤖 Generated with [Claude Code](https://claude.com/claude-code)