### PR TITLE
fix(PAIUpgrade): correct hardcoded skill path after v3→v4 migration

### DIFF
--- a/Releases/v4.0.0/.claude/skills/Utilities/PAIUpgrade/Tools/Anthropic.ts
+++ b/Releases/v4.0.0/.claude/skills/Utilities/PAIUpgrade/Tools/Anthropic.ts
@@ -79,7 +79,7 @@ interface State {
 
 // Config
 const HOME = homedir();
-const SKILL_DIR = join(HOME, '.claude', 'skills', 'PAIUpgrade');
+const SKILL_DIR = join(HOME, '.claude', 'skills', 'Utilities', 'PAIUpgrade');
 const STATE_DIR = join(SKILL_DIR, 'State');
 const STATE_FILE = join(STATE_DIR, 'last-check.json');
 const SOURCES_FILE = join(SKILL_DIR, 'sources.json');

--- a/Releases/v4.0.1/.claude/skills/Utilities/PAIUpgrade/Tools/Anthropic.ts
+++ b/Releases/v4.0.1/.claude/skills/Utilities/PAIUpgrade/Tools/Anthropic.ts
@@ -79,7 +79,7 @@ interface State {
 
 // Config
 const HOME = homedir();
-const SKILL_DIR = join(HOME, '.claude', 'skills', 'PAIUpgrade');
+const SKILL_DIR = join(HOME, '.claude', 'skills', 'Utilities', 'PAIUpgrade');
 const STATE_DIR = join(SKILL_DIR, 'State');
 const STATE_FILE = join(STATE_DIR, 'last-check.json');
 const SOURCES_FILE = join(SKILL_DIR, 'sources.json');

--- a/Releases/v4.0.2/.claude/skills/Utilities/PAIUpgrade/Tools/Anthropic.ts
+++ b/Releases/v4.0.2/.claude/skills/Utilities/PAIUpgrade/Tools/Anthropic.ts
@@ -79,7 +79,7 @@ interface State {
 
 // Config
 const HOME = homedir();
-const SKILL_DIR = join(HOME, '.claude', 'skills', 'PAIUpgrade');
+const SKILL_DIR = join(HOME, '.claude', 'skills', 'Utilities', 'PAIUpgrade');
 const STATE_DIR = join(SKILL_DIR, 'State');
 const STATE_FILE = join(STATE_DIR, 'last-check.json');
 const SOURCES_FILE = join(SKILL_DIR, 'sources.json');

--- a/Releases/v4.0.3/.claude/skills/Utilities/PAIUpgrade/Tools/Anthropic.ts
+++ b/Releases/v4.0.3/.claude/skills/Utilities/PAIUpgrade/Tools/Anthropic.ts
@@ -79,7 +79,7 @@ interface State {
 
 // Config
 const HOME = homedir();
-const SKILL_DIR = join(HOME, '.claude', 'skills', 'PAIUpgrade');
+const SKILL_DIR = join(HOME, '.claude', 'skills', 'Utilities', 'PAIUpgrade');
 const STATE_DIR = join(SKILL_DIR, 'State');
 const STATE_FILE = join(STATE_DIR, 'last-check.json');
 const SOURCES_FILE = join(SKILL_DIR, 'sources.json');


### PR DESCRIPTION
## Summary

- **Bug**: `Anthropic.ts` line 82 uses hardcoded path `join(HOME, '.claude', 'skills', 'PAIUpgrade')`, but in v4 the skill was moved to `skills/Utilities/PAIUpgrade/`
- **Impact**: ENOENT on `sources.json` — completely breaks the upgrade check tool for all v4 users
- **Fix**: Update path to `join(HOME, '.claude', 'skills', 'Utilities', 'PAIUpgrade')` across all v4 releases (v4.0.0–v4.0.3)

## Details

In the v3→v4 migration, PAIUpgrade was relocated from `skills/PAIUpgrade/` to `skills/Utilities/PAIUpgrade/` as part of the skill directory reorganization. However, the `SKILL_DIR` constant in `Anthropic.ts` was not updated to reflect the new path.

This means every call to `sources.json`, `State/last-check.json`, and `Logs/run-history.jsonl` fails with ENOENT, making the upgrade checker non-functional.

### Before (broken)
```typescript
const SKILL_DIR = join(HOME, '.claude', 'skills', 'PAIUpgrade');
```

### After (fixed)
```typescript
const SKILL_DIR = join(HOME, '.claude', 'skills', 'Utilities', 'PAIUpgrade');
```

## Files changed

- `Releases/v4.0.0/.claude/skills/Utilities/PAIUpgrade/Tools/Anthropic.ts`
- `Releases/v4.0.1/.claude/skills/Utilities/PAIUpgrade/Tools/Anthropic.ts`
- `Releases/v4.0.2/.claude/skills/Utilities/PAIUpgrade/Tools/Anthropic.ts`
- `Releases/v4.0.3/.claude/skills/Utilities/PAIUpgrade/Tools/Anthropic.ts`

## Test plan

- [ ] Verify `sources.json` is found at the corrected path
- [ ] Run upgrade check tool — confirm no ENOENT errors
- [ ] Confirm `State/last-check.json` and `Logs/run-history.jsonl` resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)