### PR TITLE
feat: pai-governance-guard — structural authority separation pack

### DIFF
--- a/Packs/pai-governance-guard/INSTALL.md
+++ b/Packs/pai-governance-guard/INSTALL.md
@@ -1,0 +1,97 @@
+# pai-governance-guard -- Installation
+
+## Prerequisites
+
+- Claude Code CLI installed
+- Node.js >= 20 or Bun runtime
+- PAI directory at `~/.pai/` (or `$PAI_DIR`)
+
+## Step 1: Copy Hook Files
+
+Copy the governance source files to your PAI hooks directory:
+
+```bash
+# Create governance directory
+mkdir -p ~/.pai/hooks/governance
+
+# Copy hook entry point
+cp src/hooks/GovernanceGuard.hook.ts ~/.pai/hooks/GovernanceGuard.hook.ts
+
+# Copy governance modules
+cp src/governance/types.ts ~/.pai/hooks/governance/types.ts
+cp src/governance/canonical.ts ~/.pai/hooks/governance/canonical.ts
+cp src/governance/intent.ts ~/.pai/hooks/governance/intent.ts
+cp src/governance/policy-engine.ts ~/.pai/hooks/governance/policy-engine.ts
+cp src/governance/witness.ts ~/.pai/hooks/governance/witness.ts
+cp src/governance/yaml-parse.ts ~/.pai/hooks/governance/yaml-parse.ts
+```
+
+## Step 2: Choose and Install a Policy
+
+Copy one of the three policy presets to your PAI governance directory:
+
+```bash
+# Create governance memory directory
+mkdir -p ~/.pai/MEMORY/GOVERNANCE
+
+# Option A: Minimal (blocks destructive + credentials, allows everything else)
+cp policies/minimal.yaml ~/.pai/MEMORY/GOVERNANCE/governance-policy.yaml
+
+# Option B: Standard (deny-default, explicit allows) -- RECOMMENDED
+cp policies/standard.yaml ~/.pai/MEMORY/GOVERNANCE/governance-policy.yaml
+
+# Option C: Strict (read-only, denies everything else)
+cp policies/strict.yaml ~/.pai/MEMORY/GOVERNANCE/governance-policy.yaml
+```
+
+You can also place a project-specific policy at `.claude/governance-policy.yaml` in any project directory. Project-level policies take precedence over user-level policies.
+
+## Step 3: Register the Hook
+
+Add the governance-guard hook to your Claude Code settings. Merge the following into `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun run ~/.pai/hooks/GovernanceGuard.hook.ts",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+If you use Node.js instead of Bun, replace `bun run` with `node --import tsx`.
+
+**Important:** If you already have PreToolUse hooks (like SecurityValidator), add the governance-guard entry to the existing array. Both hooks will run for each tool call.
+
+## Step 4: Verify Installation
+
+Run the verification checklist in [VERIFY.md](VERIFY.md).
+
+## Policy Customization
+
+Edit your `governance-policy.yaml` to customize rules. See [references/policy-schema.md](references/policy-schema.md) for the full policy format documentation.
+
+**Hot reload:** Policy changes take effect on the next tool call -- no restart required.
+
+## Environment Variables
+
+| Variable | Description | Default |
+|---|---|---|
+| `PAI_DIR` | PAI root directory | `~/.pai` |
+| `GOVERNANCE_POLICY` | Explicit policy file path | Auto-resolved |
+
+## Uninstall
+
+1. Remove the hook entry from `~/.claude/settings.json`
+2. Delete `~/.pai/hooks/GovernanceGuard.hook.ts` and `~/.pai/hooks/governance/`
+3. Optionally delete `~/.pai/MEMORY/GOVERNANCE/` (contains witness logs)

--- a/Packs/pai-governance-guard/LICENSE
+++ b/Packs/pai-governance-guard/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 MetaCortex Dynamics LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Packs/pai-governance-guard/README.md
+++ b/Packs/pai-governance-guard/README.md
@@ -1,0 +1,123 @@
+# pai-governance-guard
+
+**Deterministic authorization layer for Claude Code** -- structural authority separation via PROPOSE/DECIDE/PROMOTE pipeline.
+
+**Pack ID:** `metacortex-governance-guard-core-v1.0.0`
+**Author:** MetaCortex-Dynamics
+**License:** MIT
+
+## What This Solves
+
+PAI's SecurityValidator catches known-dangerous commands (`rm -rf`, credential patterns, destructive git ops). Governance-guard addresses a different class of risk: **actions that aren't pattern-matchable as dangerous but exceed authorized scope.**
+
+- Creating accounts on external services
+- Sending API requests to third-party services the user never approved
+- Writing to directories outside the project scope
+- Invoking tools with side effects the user didn't request
+
+These actions pass SecurityValidator cleanly. They don't match any regex tier. But they exceed the user's intended authorization.
+
+## Architecture
+
+Three-phase pipeline as a Claude Code `PreToolUse` hook:
+
+```
+Tool Call --> PROPOSE --> DECIDE --> PROMOTE --> Execution
+                |           |          |
+            serialize    evaluate    gate
+            + hash       against    on
+            intent       policy     verdict
+                         (no LLM)
+```
+
+**PROPOSE** -- Serializes the tool call into a structured `ActionIntent` (tool name, action type, target, parameters). Binds with SHA-256 content hash.
+
+**DECIDE** -- Evaluates the intent against a user-defined YAML policy. Pure function. No LLM. No interpretation. Policy + intent = verdict (approve / deny / escalate). Default: deny.
+
+**PROMOTE** -- Approved actions proceed. Denied actions are blocked. Escalated actions prompt the user. Every decision is recorded in a hash-chained witness log.
+
+## How It Integrates With PAI
+
+This pack is a **companion to SecurityValidator**, not a replacement:
+
+| Layer | What It Catches | Mechanism |
+|---|---|---|
+| `validate-protected.ts` | Credential leaks in commits | Pattern matching on file content |
+| `SecurityValidator.hook.ts` | Known-dangerous commands | Regex tiers on bash commands |
+| **`governance-guard`** | Unauthorized-but-not-dangerous actions | Deterministic policy evaluation on structured intent |
+
+Both hooks fire on tool calls. Both must pass. SecurityValidator's hard blocks take precedence.
+
+## Action Classification
+
+Tool calls are classified into seven action types:
+
+| Type | Examples |
+|---|---|
+| `read` | `cat`, `ls`, `grep`, `Read` tool, `Glob` tool |
+| `write` | `Write` tool, `Edit` tool, output redirection |
+| `execute` | `npm`, `cargo`, `python`, `make` |
+| `network` | `curl`, `wget`, `ssh`, `WebFetch`, `WebSearch` |
+| `destructive` | `rm -rf`, `git reset --hard`, `DROP TABLE` |
+| `credential` | `.env`, `.ssh/`, `credentials`, `api_key` |
+| `unknown` | MCP tools, unrecognized tools |
+
+## Policy Presets
+
+Three YAML presets included:
+
+- **`minimal.yaml`** -- Default approve. Blocks destructive + credential access. Escalates network.
+- **`standard.yaml`** -- Default deny. Explicit allows for read, write-to-src, test/build execution. Escalates everything else.
+- **`strict.yaml`** -- Read-only. Denies all writes, execution, network, and destructive operations.
+
+## Witness Chain
+
+Every governance decision is recorded in a hash-chained JSONL log at `$PAI_DIR/MEMORY/GOVERNANCE/witness-YYYY-MM.jsonl`.
+
+Each record contains:
+- Sequence number, timestamp, session ID
+- Intent hash and verdict hash (SHA-256)
+- Decision (approve/deny/escalate)
+- Tool name, action type, target
+- `prev_hash` linking to the previous record
+- `record_hash` covering all fields (tamper-evident)
+
+Chain integrity can be verified with `verifyChain()`.
+
+## What This Does NOT Do
+
+- Does not replace SecurityValidator (complementary, not competitive)
+- Does not verify LLM intent accuracy (structural evaluation, not semantic)
+- Does not perform consequence analysis (evaluates against policy rules)
+- Witness chain is tamper-evident, not tamper-proof (filesystem deletion detectable but not preventable)
+
+## Zero Dependencies
+
+Custom YAML parser, Node built-in `crypto`. No npm packages at runtime. Matches PAI's principle of deterministic infrastructure.
+
+## Tests
+
+146 tests passing across 6 test files:
+- `canonical.test.ts` -- Hash computation, deterministic serialization
+- `yaml-parse.test.ts` -- YAML parser, all policy presets
+- `intent.test.ts` -- Action classification for all tool types
+- `policy-engine.test.ts` -- Rule matching, modal gates, policy loading
+- `witness.test.ts` -- Hash chain integrity, tamper detection
+- `integration.test.ts` -- End-to-end pipeline
+- `adversarial.test.ts` -- Spoofed hashes, path traversal, replay attacks, malformed YAML
+
+## Alignment With PAI Principles
+
+| PAI Principle | How governance-guard implements it |
+|---|---|
+| **#4: Scaffolding > Model** | Authorization decisions removed from the LLM entirely |
+| **#5: Deterministic Infrastructure** | Same policy + same intent = same verdict, every time |
+| **#7: Spec / Test / Evals First** | 146 tests including adversarial coverage |
+| **#8: UNIX Philosophy** | Does one thing (authorization), composes with existing layers |
+| **#9: ENG / SRE Principles** | Hash-chained witness log for incident reconstruction |
+
+---
+
+Built by [MetaCortex Dynamics](https://github.com/MetaCortex-Dynamics)
+
+**AI disclosure:** Architecture review and spec drafting assisted by Claude. All code reviewed, understood, and tested by the author. The PROPOSE/DECIDE/PROMOTE governance architecture is original work.

--- a/Packs/pai-governance-guard/VERIFY.md
+++ b/Packs/pai-governance-guard/VERIFY.md
@@ -1,0 +1,46 @@
+# pai-governance-guard -- Verification Checklist
+
+**If ANY checkbox fails, the pack is NOT correctly installed.**
+
+## File Verification
+
+- [ ] `~/.pai/hooks/GovernanceGuard.hook.ts` exists and is executable
+- [ ] `~/.pai/hooks/governance/types.ts` exists
+- [ ] `~/.pai/hooks/governance/canonical.ts` exists
+- [ ] `~/.pai/hooks/governance/intent.ts` exists
+- [ ] `~/.pai/hooks/governance/policy-engine.ts` exists
+- [ ] `~/.pai/hooks/governance/witness.ts` exists
+- [ ] `~/.pai/hooks/governance/yaml-parse.ts` exists
+
+## Policy Verification
+
+- [ ] `~/.pai/MEMORY/GOVERNANCE/governance-policy.yaml` exists
+- [ ] Policy file contains `version:` field
+- [ ] Policy file contains `default_decision:` field (approve, deny, or escalate)
+- [ ] Policy file contains `rules:` array with at least one rule
+
+## Hook Registration Verification
+
+- [ ] `~/.claude/settings.json` contains a `PreToolUse` hook entry
+- [ ] Hook entry has `"matcher": ""` (matches all tools)
+- [ ] Hook command points to `GovernanceGuard.hook.ts`
+
+## Functional Verification
+
+Test the pipeline by running Claude Code and observing governance decisions:
+
+- [ ] **Read operation**: Ask Claude to read a file. Should be **allowed** (all presets).
+- [ ] **Destructive operation**: Ask Claude to run `rm -rf /tmp/test-governance`. Should be **denied** (all presets).
+- [ ] **Network operation**: Ask Claude to fetch a URL. Should be **escalated** (minimal/standard) or **denied** (strict).
+
+## Witness Log Verification
+
+- [ ] `~/.pai/MEMORY/GOVERNANCE/` directory exists
+- [ ] After at least one tool call, a `witness-YYYY-MM.jsonl` file exists
+- [ ] Each line in the witness log is valid JSON
+- [ ] First record's `prev_hash` matches the GENESIS hash
+
+## Fail-Closed Verification
+
+- [ ] Temporarily rename the policy file. The next tool call should be **denied** (fail-closed behavior).
+- [ ] Restore the policy file. The next tool call should use the policy normally (hot reload).

--- a/Packs/pai-governance-guard/package.json
+++ b/Packs/pai-governance-guard/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@metacortex/governance-guard",
+  "version": "1.0.0",
+  "description": "Deterministic governance layer for Claude Code — PROPOSE/DECIDE/PROMOTE authorization pipeline",
+  "license": "MIT",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "test": "node --import tsx --test tests/**/*.test.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/Packs/pai-governance-guard/policies/minimal.yaml
+++ b/Packs/pai-governance-guard/policies/minimal.yaml
@@ -1,0 +1,25 @@
+version: "1.0"
+name: minimal
+description: "Blocks destructive and credential access. Allows everything else."
+default_decision: approve
+
+rules:
+  - id: block-destructive
+    action_type: destructive
+    decision: deny
+    reason: "Destructive operations require manual approval"
+
+  - id: block-credentials
+    action_type: credential
+    decision: deny
+    reason: "Credential access blocked by governance policy"
+
+  - id: escalate-network
+    action_type: network
+    decision: escalate
+    reason: "Network operations require confirmation"
+
+  - id: escalate-unknown
+    action_type: unknown
+    decision: escalate
+    reason: "Unknown action types require confirmation"

--- a/Packs/pai-governance-guard/policies/standard.yaml
+++ b/Packs/pai-governance-guard/policies/standard.yaml
@@ -1,0 +1,87 @@
+version: "1.0"
+name: standard
+description: "Deny-default with explicit allows for common development operations."
+default_decision: deny
+
+rules:
+  - id: allow-read
+    action_type: read
+    decision: approve
+    reason: "Read operations are safe"
+
+  - id: allow-write-src
+    action_type: write
+    target: "**/src/**"
+    decision: approve
+    reason: "Writing to source directories allowed"
+
+  - id: allow-write-tests
+    action_type: write
+    target: "**/tests/**"
+    decision: approve
+    reason: "Writing to test directories allowed"
+
+  - id: allow-write-test
+    action_type: write
+    target: "**/test/**"
+    decision: approve
+    reason: "Writing to test directories allowed"
+
+  - id: allow-execute-test
+    tool_name: "^Bash$"
+    action_type: execute
+    target: "npm test*"
+    decision: approve
+    reason: "Test execution allowed"
+
+  - id: allow-execute-build
+    tool_name: "^Bash$"
+    action_type: execute
+    target: "npm run build*"
+    decision: approve
+    reason: "Build execution allowed"
+
+  - id: allow-execute-lint
+    tool_name: "^Bash$"
+    action_type: execute
+    target: "npm run lint*"
+    decision: approve
+    reason: "Lint execution allowed"
+
+  - id: block-destructive
+    action_type: destructive
+    decision: deny
+    reason: "Destructive operations denied by policy"
+
+  - id: block-credentials
+    action_type: credential
+    decision: deny
+    reason: "Credential access denied by policy"
+
+  - id: escalate-network
+    action_type: network
+    decision: escalate
+    reason: "Network operations require confirmation"
+
+  - id: escalate-execute
+    action_type: execute
+    decision: escalate
+    reason: "Execution requires confirmation"
+
+  - id: escalate-write
+    action_type: write
+    decision: escalate
+    reason: "Write to non-standard path requires confirmation"
+
+  - id: escalate-unknown
+    action_type: unknown
+    decision: escalate
+    reason: "Unknown action types require confirmation"
+
+box_policy:
+  requireDefiniteTrue: true
+  requireNoObstructions: true
+
+diamond_policy:
+  allowIfDefiniteFalse: false
+  maxSeverity: warn

--- a/Packs/pai-governance-guard/policies/strict.yaml
+++ b/Packs/pai-governance-guard/policies/strict.yaml
@@ -1,0 +1,48 @@
+version: "1.0"
+name: strict
+description: "Read-only operations only. Everything else denied."
+default_decision: deny
+
+rules:
+  - id: allow-read
+    action_type: read
+    decision: approve
+    reason: "Read operations permitted"
+
+  - id: deny-write
+    action_type: write
+    decision: deny
+    reason: "Write operations denied in strict mode"
+
+  - id: deny-execute
+    action_type: execute
+    decision: deny
+    reason: "Execution denied in strict mode"
+
+  - id: deny-network
+    action_type: network
+    decision: deny
+    reason: "Network access denied in strict mode"
+
+  - id: deny-destructive
+    action_type: destructive
+    decision: deny
+    reason: "Destructive operations denied in strict mode"
+
+  - id: deny-credentials
+    action_type: credential
+    decision: deny
+    reason: "Credential access denied in strict mode"
+
+  - id: deny-unknown
+    action_type: unknown
+    decision: deny
+    reason: "Unknown operations denied in strict mode"
+
+box_policy:
+  requireDefiniteTrue: true
+  requireNoObstructions: true
+  maxSeverity: info
+
+diamond_policy:
+  maxSeverity: info

--- a/Packs/pai-governance-guard/references/policy-schema.md
+++ b/Packs/pai-governance-guard/references/policy-schema.md
@@ -1,0 +1,146 @@
+# Governance Policy Schema
+
+Policy files are YAML documents that define authorization rules for tool calls.
+
+## Top-Level Fields
+
+```yaml
+version: "1.0"                    # Policy format version (required)
+name: my-policy                   # Human-readable policy name (required)
+description: "Policy description" # What this policy does (optional)
+default_decision: deny            # approve | deny | escalate (required)
+
+rules: []                         # Array of policy rules (required)
+
+box_policy:                       # Modal gate: necessarily true (optional)
+  requireDefiniteTrue: true
+  requireNoObstructions: true
+  maxSeverity: warn               # info | warn | error | fatal
+
+diamond_policy:                   # Modal gate: possibly true (optional)
+  allowIfDefiniteFalse: false
+  maxSeverity: warn               # info | warn | error | fatal
+```
+
+## Rule Format
+
+```yaml
+rules:
+  - id: rule-name                 # Unique rule identifier (required)
+    tool_name: "^Bash$"           # Regex pattern for tool name (optional)
+    action_type: execute          # Action type filter (optional)
+    target: "**/src/**"           # Glob pattern for target (optional)
+    decision: approve             # approve | deny | escalate (required)
+    reason: "Why this rule exists" # Human-readable explanation (required)
+```
+
+### Rule Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | string | Yes | Unique identifier for this rule |
+| `tool_name` | string (regex) | No | Regex pattern matched against tool name |
+| `action_type` | string or array | No | One or more of: read, write, execute, network, destructive, credential, unknown |
+| `target` | string (glob) | No | Glob pattern matched against the tool's target (file path, command, URL) |
+| `decision` | string | Yes | What to do when this rule matches: approve, deny, or escalate |
+| `reason` | string | Yes | Human-readable explanation shown to the user |
+
+### Rule Matching
+
+1. Rules are evaluated **in order** (first match wins)
+2. All specified conditions must match (AND logic)
+3. Omitted conditions match everything
+4. If no rule matches, `default_decision` applies
+
+### Glob Patterns
+
+| Pattern | Matches |
+|---|---|
+| `*` | Any characters except `/` |
+| `**` | Any characters including `/` (directory traversal) |
+| `?` | Any single character except `/` |
+
+Examples:
+- `**/src/**` matches `/project/src/app.ts`
+- `npm test*` matches `npm test --verbose`
+- `*.env` matches `production.env`
+
+### Tool Name Regex
+
+Standard JavaScript regex syntax:
+- `^Bash$` matches only the Bash tool
+- `^(Read\|Glob\|Grep)$` matches read-only tools
+- `^mcp__` matches all MCP tools
+- Omit `tool_name` to match any tool
+
+## Action Types
+
+| Type | Tools that produce it | Description |
+|---|---|---|
+| `read` | Read, Glob, Grep, `cat`, `ls` | Reading files or searching |
+| `write` | Write, Edit, output redirection | Creating or modifying files |
+| `execute` | Bash (`npm`, `cargo`, etc.) | Running programs |
+| `network` | WebFetch, WebSearch, `curl`, `ssh` | Network access |
+| `destructive` | `rm -rf`, `git reset --hard`, `DROP TABLE` | Irreversible operations |
+| `credential` | `.env`, `.ssh/`, `credentials` access | Sensitive data access |
+| `unknown` | MCP tools, unrecognized tools | Unclassified operations |
+
+## Modal Gates (Advanced)
+
+Modal gates provide fine-grained control over the approve/deny/escalate decision:
+
+**Box policy** (necessarily true -- all conditions must be met for approval):
+- `requireDefiniteTrue`: Rule must produce a definitive "approve" (default: true)
+- `requireNoObstructions`: No warnings or errors allowed (default: false)
+- `maxSeverity`: Maximum obstruction severity to tolerate (info/warn/error/fatal)
+
+**Diamond policy** (possibly true -- at least one path allows):
+- `allowIfDefiniteFalse`: Allow escalation even for definitive "deny" rules (default: false)
+- `maxSeverity`: Maximum severity for escalation (default: warn)
+
+**Decision flow with modal gates:**
+1. Rule match produces an internal verdict
+2. If box gate passes: **approve**
+3. If diamond gate passes (but box fails): **escalate**
+4. If both fail: **deny**
+
+Without modal gates, the rule's `decision` field is used directly.
+
+## Examples
+
+### Allow reads, deny everything else
+```yaml
+version: "1.0"
+name: read-only
+default_decision: deny
+rules:
+  - id: allow-read
+    action_type: read
+    decision: approve
+    reason: "Read operations are safe"
+```
+
+### Allow project work, escalate external access
+```yaml
+version: "1.0"
+name: project-scoped
+default_decision: deny
+rules:
+  - id: allow-read
+    action_type: read
+    decision: approve
+    reason: "Reads are safe"
+  - id: allow-project-write
+    action_type: write
+    target: "**/my-project/**"
+    decision: approve
+    reason: "Writing within project scope"
+  - id: escalate-network
+    action_type: network
+    decision: escalate
+    reason: "Network access needs confirmation"
+  - id: deny-destructive
+    action_type: destructive
+    decision: deny
+    reason: "Destructive operations blocked"
+```

--- a/Packs/pai-governance-guard/src/config/settings-fragment.json
+++ b/Packs/pai-governance-guard/src/config/settings-fragment.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun run ${GOVERNANCE_HOOK_PATH:-~/.pai/hooks/GovernanceGuard.hook.ts}",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/Packs/pai-governance-guard/src/governance/canonical.ts
+++ b/Packs/pai-governance-guard/src/governance/canonical.ts
@@ -1,0 +1,47 @@
+// ============================================================================
+// pai-governance-guard — Canonical Hashing
+// Deterministic JSON serialization + SHA-256
+// Ported from verdict_logic/canonical.ts — zero dependencies
+// ============================================================================
+
+import { createHash } from "node:crypto";
+
+/**
+ * Stable JSON serialization with sorted keys (JCS-compatible).
+ * Produces identical output for semantically equivalent objects
+ * regardless of key insertion order.
+ */
+export function stableStringify(x: unknown): string {
+  if (x === null) return "null";
+  if (x === undefined) return "null";
+  const t = typeof x;
+  if (t === "string") return JSON.stringify(x);
+  if (t === "boolean") return x ? "true" : "false";
+  if (t === "number") return Number.isFinite(x as number) ? String(x) : JSON.stringify(x);
+  if (t !== "object") return JSON.stringify(x);
+
+  if (Array.isArray(x)) return "[" + x.map(stableStringify).join(",") + "]";
+
+  const o = x as Record<string, unknown>;
+  const keys = Object.keys(o)
+    .filter((k) => o[k] !== undefined)
+    .sort();
+  return (
+    "{" + keys.map((k) => JSON.stringify(k) + ":" + stableStringify(o[k])).join(",") + "}"
+  );
+}
+
+/**
+ * SHA-256 hex digest of a UTF-8 string.
+ * Uses Node built-in crypto — zero external dependencies.
+ */
+export function sha256Hex(s: string): string {
+  return createHash("sha256").update(s, "utf8").digest("hex");
+}
+
+/**
+ * Canonical hash of any value: stableStringify then SHA-256.
+ */
+export function canonicalHash(x: unknown): string {
+  return sha256Hex(stableStringify(x));
+}

--- a/Packs/pai-governance-guard/src/governance/intent.ts
+++ b/Packs/pai-governance-guard/src/governance/intent.ts
@@ -1,0 +1,211 @@
+// ============================================================================
+// pai-governance-guard — PROPOSE Phase
+// Parse Claude Code tool calls into structured ActionIntent
+// ============================================================================
+
+import { stableStringify, sha256Hex } from "./canonical";
+import type { ActionIntent, ActionType, HookInput } from "./types";
+
+// -- Destructive command patterns --
+const DESTRUCTIVE_PATTERNS = [
+  /\brm\s+(-[a-zA-Z]*[rf]|--recursive|--force)/,
+  /\brm\b.*\s+\//, // rm targeting root-relative paths
+  /\bdrop\s+(table|database|schema|index)\b/i,
+  /\btruncate\s+table\b/i,
+  /\bformat\b.*\b[a-zA-Z]:\\/i,
+  /\bgit\s+(reset\s+--hard|clean\s+-[a-zA-Z]*f|push\s+--force|branch\s+-D)/,
+  /\b(shutdown|reboot|halt|poweroff)\b/,
+  /\bdd\s+.*\bof=/,
+  /\bmkfs\b/,
+  />\s*\/dev\/sd[a-z]/,
+];
+
+// -- Network command patterns --
+const NETWORK_PATTERNS = [
+  /\b(curl|wget|http|fetch)\b/,
+  /\bssh\b/,
+  /\bscp\b/,
+  /\brsync\b.*:/,
+  /\bnc\b/,
+  /\btelnet\b/,
+  /\bftp\b/,
+  /\bnmap\b/,
+  /\bping\b/,
+  /https?:\/\//,
+];
+
+// -- Credential access patterns --
+const CREDENTIAL_PATTERNS = [
+  /\.env\b/,
+  /credentials?\b/i,
+  /\bsecrets?\b/i,
+  /\bpassw(or)?d/i,
+  /\btoken\b/i,
+  /\bapi[_-]?key\b/i,
+  /\bprivate[_-]?key\b/i,
+  /\.pem$/,
+  /\.key$/,
+  /id_rsa/,
+  /id_ed25519/,
+  /\.aws\//,
+  /\.ssh\//,
+  /\.gnupg\//,
+  /\.npmrc$/,
+  /\.pypirc$/,
+  /\.netrc$/,
+];
+
+// -- Read-only command patterns --
+const READ_PATTERNS = [
+  /^\s*(cat|head|tail|less|more|wc|file|stat)\b/,
+  /^\s*(ls|dir|find|tree|du|df)\b/,
+  /^\s*(grep|rg|ag|ack)\b/,
+  /^\s*(type|which|where|whereis)\b/,
+  /^\s*git\s+(log|show|diff|status|branch(?!\s+-D))\b/,
+];
+
+// -- Package manager / build patterns --
+const EXECUTE_PATTERNS = [
+  /^\s*(npm|yarn|pnpm|bun|npx)\s/,
+  /^\s*(pip|pip3|python|python3)\s/,
+  /^\s*(cargo|rustc|rustup)\s/,
+  /^\s*(go|go\s+run|go\s+build)\s/,
+  /^\s*(make|cmake)\b/,
+  /^\s*(node|deno|tsx|ts-node)\s/,
+];
+
+/**
+ * PROPOSE: Parse a Claude Code hook input into a structured ActionIntent.
+ *
+ * Classifies the tool call by action type (read/write/execute/network/
+ * destructive/credential/unknown) and extracts the target.
+ */
+export function propose(input: HookInput): ActionIntent {
+  const actionType = classifyAction(input.tool_name, input.tool_input);
+  const target = extractTarget(input.tool_name, input.tool_input);
+  const contentHash = sha256Hex(stableStringify(input.tool_input));
+
+  return {
+    tool_name: input.tool_name,
+    action_type: actionType,
+    target,
+    raw_input: input.tool_input,
+    content_hash: contentHash,
+    timestamp: new Date().toISOString(),
+    session_id: input.session_id,
+  };
+}
+
+/**
+ * Classify a tool call into an ActionType.
+ * Order matters: destructive > credential > network > read > execute > write > unknown
+ */
+export function classifyAction(
+  toolName: string,
+  toolInput: Record<string, unknown>
+): ActionType {
+  const name = toolName.toLowerCase();
+
+  // -- Tool-specific classification --
+
+  if (name === "bash") {
+    const command = String(toolInput.command ?? "");
+    return classifyBashCommand(command);
+  }
+
+  if (name === "read" || name === "glob" || name === "grep") {
+    // Check if reading credential files
+    const target = extractTarget(toolName, toolInput);
+    if (matchesAny(target, CREDENTIAL_PATTERNS)) return "credential";
+    return "read";
+  }
+
+  if (name === "write" || name === "edit" || name === "multiedit" || name === "notebookedit") {
+    const target = extractTarget(toolName, toolInput);
+    if (matchesAny(target, CREDENTIAL_PATTERNS)) return "credential";
+    return "write";
+  }
+
+  if (name === "webfetch" || name === "websearch") {
+    return "network";
+  }
+
+  // MCP tools — default to unknown for governance evaluation
+  if (name.startsWith("mcp__")) {
+    return "unknown";
+  }
+
+  // Task/TodoWrite/AskUserQuestion — safe operations
+  if (name === "task" || name === "todowrite" || name === "askuserquestion") {
+    return "read";
+  }
+
+  return "unknown";
+}
+
+function classifyBashCommand(command: string): ActionType {
+  // Check in priority order
+  if (matchesAny(command, DESTRUCTIVE_PATTERNS)) return "destructive";
+  if (matchesAny(command, CREDENTIAL_PATTERNS)) return "credential";
+  if (matchesAny(command, NETWORK_PATTERNS)) return "network";
+  if (matchesAny(command, READ_PATTERNS)) return "read";
+  if (matchesAny(command, EXECUTE_PATTERNS)) return "execute";
+
+  // Commands with output redirection are writes
+  if (/[>|]/.test(command)) return "write";
+
+  return "execute";
+}
+
+/**
+ * Extract the primary target from a tool call.
+ * For Bash: the command string. For file tools: the file path. For web: the URL.
+ */
+export function extractTarget(
+  toolName: string,
+  toolInput: Record<string, unknown>
+): string {
+  const name = toolName.toLowerCase();
+
+  if (name === "bash") {
+    return String(toolInput.command ?? "");
+  }
+
+  if (name === "read" || name === "write") {
+    return String(toolInput.file_path ?? toolInput.path ?? "");
+  }
+
+  if (name === "edit" || name === "multiedit") {
+    return String(toolInput.file_path ?? "");
+  }
+
+  if (name === "glob") {
+    return String(toolInput.pattern ?? "");
+  }
+
+  if (name === "grep") {
+    return String(toolInput.pattern ?? "");
+  }
+
+  if (name === "webfetch") {
+    return String(toolInput.url ?? "");
+  }
+
+  if (name === "websearch") {
+    return String(toolInput.query ?? "");
+  }
+
+  if (name === "notebookedit") {
+    return String(toolInput.notebook_path ?? "");
+  }
+
+  // Fallback: serialize all input keys
+  return Object.keys(toolInput).join(",");
+}
+
+function matchesAny(text: string, patterns: RegExp[]): boolean {
+  for (const p of patterns) {
+    if (p.test(text)) return true;
+  }
+  return false;
+}

--- a/Packs/pai-governance-guard/src/governance/policy-engine.ts
+++ b/Packs/pai-governance-guard/src/governance/policy-engine.ts
@@ -1,0 +1,364 @@
+// ============================================================================
+// pai-governance-guard — DECIDE Phase
+// Deterministic policy evaluation with modal gates
+// Adapted from verdict_logic/authorize.ts + modal.ts
+// ============================================================================
+
+import { readFileSync, statSync } from "node:fs";
+import { parseYaml } from "./yaml-parse";
+import { stableStringify, sha256Hex } from "./canonical";
+import type {
+  ActionIntent,
+  ActionType,
+  BoxPolicy,
+  DiamondPolicy,
+  Justification,
+  Obstruction,
+  ObstructionSeverity,
+  PolicyConfig,
+  PolicyDecision,
+  PolicyRule,
+  PolicyVerdict,
+  Verdict,
+} from "./types";
+
+// -- Verdict DSL (from verdict_logic/verdict.ts) --
+
+function definite(
+  value: boolean,
+  obstructions: Obstruction[] = [],
+  justifications: Justification[] = []
+): Verdict {
+  return { status: "Definite", value, obstructions, justifications };
+}
+
+function obstructed(
+  obstructions: Obstruction[],
+  justifications: Justification[] = []
+): Verdict {
+  return { status: "Obstructed", obstructions, justifications };
+}
+
+// -- Modal Gates (from verdict_logic/modal.ts) --
+
+const SEV_RANK: Record<string, number> = { info: 0, warn: 1, error: 2, fatal: 3 };
+
+function maxObstructionSeverity(v: Verdict): number {
+  let m = -1;
+  for (const o of v.obstructions) {
+    const r = SEV_RANK[o.severity ?? "error"] ?? 2;
+    if (r > m) m = r;
+  }
+  return m;
+}
+
+/**
+ * Box gate: necessarily true. All conditions must be met.
+ * Adapted from verdict_logic/modal.ts boxGate()
+ */
+function boxGate(policy: BoxPolicy, v: Verdict): boolean {
+  if (policy.requireDefiniteTrue !== false) {
+    if (v.status !== "Definite" || v.value !== true) return false;
+  }
+  if (policy.requireNoObstructions) {
+    if (v.obstructions.length > 0) return false;
+  }
+  if (policy.maxSeverity) {
+    const limit = SEV_RANK[policy.maxSeverity];
+    if (maxObstructionSeverity(v) > limit) return false;
+  }
+  return true;
+}
+
+/**
+ * Diamond gate: possibly true. At least one path allows.
+ * Adapted from verdict_logic/modal.ts diamondGate()
+ */
+function diamondGate(policy: DiamondPolicy, v: Verdict): boolean {
+  if (v.status === "Definite") {
+    if (v.value === true) return true;
+    return !!policy.allowIfDefiniteFalse;
+  }
+  const limit = SEV_RANK[policy.maxSeverity ?? "warn"];
+  return maxObstructionSeverity(v) <= limit;
+}
+
+// -- Policy Loading with Hot Reload --
+
+let cachedPolicy: PolicyConfig | null = null;
+let cachedPath: string | null = null;
+let cachedMtime: number = 0;
+
+/**
+ * Load and validate a YAML policy file.
+ * Caches by mtime for hot-reload without re-parsing unchanged files.
+ */
+export function loadPolicy(policyPath: string): PolicyConfig {
+  try {
+    const stat = statSync(policyPath);
+
+    if (cachedPolicy && cachedPath === policyPath && stat.mtimeMs === cachedMtime) {
+      return cachedPolicy;
+    }
+
+    const raw = readFileSync(policyPath, "utf8");
+    const parsed = parseYaml(raw);
+    const config = validatePolicyConfig(parsed);
+
+    cachedPolicy = config;
+    cachedPath = policyPath;
+    cachedMtime = stat.mtimeMs;
+
+    return config;
+  } catch (err) {
+    // Fail-closed: corrupt/missing policy → deny-all config
+    return DENY_ALL_POLICY;
+  }
+}
+
+/** Reset the policy cache (for testing). */
+export function resetPolicyCache(): void {
+  cachedPolicy = null;
+  cachedPath = null;
+  cachedMtime = 0;
+}
+
+const DENY_ALL_POLICY: PolicyConfig = {
+  version: "0.0.0",
+  name: "fail-closed",
+  description: "Default deny-all policy (policy file missing or corrupt)",
+  default_decision: "deny",
+  rules: [],
+};
+
+function validatePolicyConfig(parsed: unknown): PolicyConfig {
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("Policy must be a YAML mapping");
+  }
+
+  const p = parsed as Record<string, unknown>;
+
+  const config: PolicyConfig = {
+    version: String(p.version ?? "1.0"),
+    name: String(p.name ?? "unnamed"),
+    description: String(p.description ?? ""),
+    default_decision: validateDecision(p.default_decision) ?? "deny",
+    rules: [],
+  };
+
+  if (Array.isArray(p.rules)) {
+    config.rules = p.rules.map(validateRule).filter((r): r is PolicyRule => r !== null);
+  }
+
+  if (p.box_policy && typeof p.box_policy === "object") {
+    const bp = p.box_policy as Record<string, unknown>;
+    config.box_policy = {
+      requireDefiniteTrue: bp.requireDefiniteTrue as boolean | undefined,
+      requireNoObstructions: bp.requireNoObstructions as boolean | undefined,
+      maxSeverity: bp.maxSeverity as ObstructionSeverity | undefined,
+    };
+  }
+
+  if (p.diamond_policy && typeof p.diamond_policy === "object") {
+    const dp = p.diamond_policy as Record<string, unknown>;
+    config.diamond_policy = {
+      allowIfDefiniteFalse: dp.allowIfDefiniteFalse as boolean | undefined,
+      maxSeverity: dp.maxSeverity as ObstructionSeverity | undefined,
+    };
+  }
+
+  return config;
+}
+
+function validateDecision(v: unknown): PolicyDecision | null {
+  if (v === "approve" || v === "deny" || v === "escalate") return v;
+  return null;
+}
+
+function validateRule(raw: unknown): PolicyRule | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+
+  const decision = validateDecision(r.decision);
+  if (!decision) return null;
+
+  const rule: PolicyRule = {
+    id: String(r.id ?? "unnamed"),
+    decision,
+    reason: String(r.reason ?? ""),
+  };
+
+  if (r.tool_name !== undefined && r.tool_name !== null) {
+    rule.tool_name = String(r.tool_name);
+  }
+
+  if (r.action_type !== undefined && r.action_type !== null) {
+    if (Array.isArray(r.action_type)) {
+      rule.action_type = r.action_type.map(String) as ActionType[];
+    } else {
+      rule.action_type = String(r.action_type) as ActionType;
+    }
+  }
+
+  if (r.target !== undefined && r.target !== null) {
+    rule.target = String(r.target);
+  }
+
+  return rule;
+}
+
+// -- DECIDE: Intent x Policy → PolicyVerdict --
+
+/**
+ * DECIDE: Evaluate an ActionIntent against a PolicyConfig.
+ * Pure function. No LLM. No side effects.
+ *
+ * 1. Match intent against rules (first match wins)
+ * 2. Build internal Verdict from matched rule
+ * 3. Apply box/diamond modal gates for final decision
+ */
+export function decide(intent: ActionIntent, policy: PolicyConfig): PolicyVerdict {
+  // Find first matching rule
+  const matched = findMatchingRule(intent, policy.rules);
+
+  // Build verdict from matched rule (or default)
+  const ruleDecision = matched?.decision ?? policy.default_decision;
+  const ruleId = matched?.id ?? "default";
+  const ruleReason = matched?.reason ?? `Default policy: ${policy.default_decision}`;
+
+  const verdict = buildVerdict(ruleDecision, ruleId, ruleReason);
+  const reasons: string[] = [ruleReason];
+
+  // Apply modal gates if configured
+  let finalDecision: PolicyDecision;
+
+  if (policy.box_policy || policy.diamond_policy) {
+    const bPolicy = policy.box_policy ?? { requireDefiniteTrue: true };
+    const dPolicy = policy.diamond_policy ?? {};
+
+    const boxPasses = boxGate(bPolicy, verdict);
+    const diamondPasses = diamondGate(dPolicy, verdict);
+
+    if (boxPasses) {
+      finalDecision = "approve";
+    } else if (diamondPasses) {
+      finalDecision = "escalate";
+      if (!reasons.includes("Escalated by diamond gate")) {
+        reasons.push("Escalated by diamond gate");
+      }
+    } else {
+      finalDecision = "deny";
+      if (!reasons.includes("Denied by modal gates")) {
+        reasons.push("Denied by modal gates");
+      }
+    }
+  } else {
+    finalDecision = ruleDecision;
+  }
+
+  return {
+    decision: finalDecision,
+    intent,
+    verdict,
+    matched_rule: ruleId,
+    reasons,
+  };
+}
+
+function findMatchingRule(
+  intent: ActionIntent,
+  rules: PolicyRule[]
+): PolicyRule | null {
+  for (const rule of rules) {
+    if (ruleMatches(intent, rule)) return rule;
+  }
+  return null;
+}
+
+function ruleMatches(intent: ActionIntent, rule: PolicyRule): boolean {
+  // Check tool_name (regex)
+  if (rule.tool_name !== undefined) {
+    try {
+      const re = new RegExp(rule.tool_name);
+      if (!re.test(intent.tool_name)) return false;
+    } catch {
+      // Invalid regex → rule doesn't match
+      return false;
+    }
+  }
+
+  // Check action_type
+  if (rule.action_type !== undefined) {
+    if (Array.isArray(rule.action_type)) {
+      if (!rule.action_type.includes(intent.action_type)) return false;
+    } else {
+      if (rule.action_type !== intent.action_type) return false;
+    }
+  }
+
+  // Check target (glob)
+  if (rule.target !== undefined) {
+    if (!globMatch(rule.target, intent.target)) return false;
+  }
+
+  return true;
+}
+
+/**
+ * Minimal glob matcher for policy target patterns.
+ * Supports: * (non-separator), ** (any including separator)
+ */
+function globMatch(pattern: string, text: string): boolean {
+  // Convert glob to regex
+  let re = "^";
+  let i = 0;
+  while (i < pattern.length) {
+    const ch = pattern[i];
+    if (ch === "*" && pattern[i + 1] === "*") {
+      re += ".*";
+      i += 2;
+      if (pattern[i] === "/") i++; // skip trailing slash after **
+    } else if (ch === "*") {
+      re += "[^/]*";
+      i++;
+    } else if (ch === "?") {
+      re += "[^/]";
+      i++;
+    } else if (".+^${}()|[]\\".includes(ch)) {
+      re += "\\" + ch;
+      i++;
+    } else {
+      re += ch;
+      i++;
+    }
+  }
+  re += "$";
+
+  try {
+    return new RegExp(re).test(text);
+  } catch {
+    return false;
+  }
+}
+
+function buildVerdict(
+  decision: PolicyDecision,
+  ruleId: string,
+  reason: string
+): Verdict {
+  switch (decision) {
+    case "approve":
+      return definite(true, [], [
+        { kind: "policy_rule", source: ruleId, note: reason },
+      ]);
+    case "deny":
+      return definite(false, [
+        { kind: "policy_deny", source: ruleId, detail: reason, severity: "error" },
+      ]);
+    case "escalate":
+      return obstructed(
+        [{ kind: "escalation_required", source: ruleId, detail: reason, severity: "warn" }],
+        [{ kind: "policy_escalate", source: ruleId, note: reason }]
+      );
+  }
+}

--- a/Packs/pai-governance-guard/src/governance/types.ts
+++ b/Packs/pai-governance-guard/src/governance/types.ts
@@ -1,0 +1,137 @@
+// ============================================================================
+// pai-governance-guard — Type Definitions
+// PROPOSE / DECIDE / PROMOTE pipeline types
+// ============================================================================
+
+// -- Action Classification --
+
+export type ActionType =
+  | "read"
+  | "write"
+  | "execute"
+  | "network"
+  | "destructive"
+  | "credential"
+  | "unknown";
+
+// -- PROPOSE output --
+
+export interface ActionIntent {
+  tool_name: string;
+  action_type: ActionType;
+  target: string;
+  raw_input: unknown;
+  content_hash: string;
+  timestamp: string;
+  session_id: string;
+}
+
+// -- Internal Verdict (adapted from verdict_logic) --
+
+export type VerdictStatus = "Definite" | "Obstructed";
+export type ObstructionSeverity = "info" | "warn" | "error" | "fatal";
+
+export interface Obstruction {
+  kind: string;
+  source?: string;
+  detail?: string;
+  retryable?: boolean;
+  severity?: ObstructionSeverity;
+}
+
+export interface Justification {
+  kind: string;
+  source?: string;
+  note?: string;
+  ref?: string;
+  confidence?: number;
+}
+
+export interface Verdict {
+  status: VerdictStatus;
+  value?: boolean;
+  obstructions: Obstruction[];
+  justifications: Justification[];
+}
+
+// -- DECIDE output (user-facing) --
+
+export type PolicyDecision = "approve" | "deny" | "escalate";
+
+export interface PolicyVerdict {
+  decision: PolicyDecision;
+  intent: ActionIntent;
+  verdict: Verdict;
+  matched_rule?: string;
+  reasons: string[];
+}
+
+// -- PROMOTE output --
+
+export interface WitnessRecord {
+  sequence: number;
+  timestamp: string;
+  session_id: string;
+  intent_hash: string;
+  verdict_hash: string;
+  decision: PolicyDecision;
+  tool_name: string;
+  action_type: ActionType;
+  target: string;
+  reasons: string[];
+  prev_hash: string;
+  record_hash: string;
+}
+
+// -- Policy Configuration --
+
+export interface PolicyRule {
+  id: string;
+  tool_name?: string;
+  action_type?: ActionType | ActionType[];
+  target?: string;
+  decision: PolicyDecision;
+  reason: string;
+}
+
+export interface BoxPolicy {
+  requireDefiniteTrue?: boolean;
+  requireNoObstructions?: boolean;
+  maxSeverity?: ObstructionSeverity;
+}
+
+export interface DiamondPolicy {
+  allowIfDefiniteFalse?: boolean;
+  maxSeverity?: ObstructionSeverity;
+}
+
+export interface PolicyConfig {
+  version: string;
+  name: string;
+  description: string;
+  default_decision: PolicyDecision;
+  rules: PolicyRule[];
+  box_policy?: BoxPolicy;
+  diamond_policy?: DiamondPolicy;
+}
+
+// -- Claude Code Hook I/O --
+
+export interface HookInput {
+  session_id: string;
+  cwd: string;
+  hook_event_name: string;
+  tool_name: string;
+  tool_input: Record<string, unknown>;
+  transcript_path?: string;
+  permission_mode?: string;
+  tool_use_id?: string;
+}
+
+export interface HookOutput {
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse";
+    permissionDecision: "allow" | "deny" | "ask";
+    permissionDecisionReason?: string;
+  };
+}

--- a/Packs/pai-governance-guard/src/governance/witness.ts
+++ b/Packs/pai-governance-guard/src/governance/witness.ts
@@ -1,0 +1,219 @@
+// ============================================================================
+// pai-governance-guard — PROMOTE Phase
+// Hash-chained witness log for governance audit
+// Adapted from verdict_logic/telemetry.ts
+// ============================================================================
+
+import { mkdirSync, readFileSync, appendFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { stableStringify, sha256Hex, canonicalHash } from "./canonical";
+import type {
+  ActionIntent,
+  HookOutput,
+  PolicyDecision,
+  PolicyVerdict,
+  WitnessRecord,
+} from "./types";
+
+const GENESIS_HASH = sha256Hex("GENESIS");
+
+/**
+ * PROMOTE: Gate on verdict, record to hash-chained witness log,
+ * and produce the Claude Code hook output.
+ */
+export function promote(
+  intent: ActionIntent,
+  verdict: PolicyVerdict,
+  witnessDir: string
+): { output: HookOutput; record: WitnessRecord } {
+  // Map PolicyDecision to Claude Code permissionDecision
+  const permMap: Record<PolicyDecision, "allow" | "deny" | "ask"> = {
+    approve: "allow",
+    deny: "deny",
+    escalate: "ask",
+  };
+
+  // Build and append witness record
+  const record = buildWitnessRecord(intent, verdict, witnessDir);
+  appendWitness(witnessDir, record);
+
+  // Build reason string
+  const reasonStr = verdict.reasons.join("; ");
+
+  const output: HookOutput = {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: permMap[verdict.decision],
+      permissionDecisionReason:
+        verdict.decision === "approve"
+          ? undefined
+          : `[GOVERNANCE] ${verdict.decision === "deny" ? "Denied" : "Escalation required"}: ${reasonStr}`,
+    },
+  };
+
+  return { output, record };
+}
+
+/**
+ * Build a WitnessRecord with hash chain linking.
+ */
+function buildWitnessRecord(
+  intent: ActionIntent,
+  verdict: PolicyVerdict,
+  witnessDir: string
+): WitnessRecord {
+  const logPath = getLogPath(witnessDir);
+  const { prevHash, sequence } = getChainTip(logPath);
+
+  const intentHash = canonicalHash({
+    tool_name: intent.tool_name,
+    action_type: intent.action_type,
+    target: intent.target,
+    content_hash: intent.content_hash,
+  });
+
+  const verdictHash = canonicalHash({
+    decision: verdict.decision,
+    matched_rule: verdict.matched_rule,
+    reasons: verdict.reasons,
+  });
+
+  const partial: Omit<WitnessRecord, "record_hash"> = {
+    sequence,
+    timestamp: new Date().toISOString(),
+    session_id: intent.session_id,
+    intent_hash: intentHash,
+    verdict_hash: verdictHash,
+    decision: verdict.decision,
+    tool_name: intent.tool_name,
+    action_type: intent.action_type,
+    target: truncateTarget(intent.target, 200),
+    reasons: verdict.reasons,
+    prev_hash: prevHash,
+  };
+
+  const recordHash = sha256Hex(stableStringify(partial));
+
+  return { ...partial, record_hash: recordHash };
+}
+
+/**
+ * Read the last record from the witness log to get the chain tip.
+ */
+function getChainTip(logPath: string): { prevHash: string; sequence: number } {
+  if (!existsSync(logPath)) {
+    return { prevHash: GENESIS_HASH, sequence: 0 };
+  }
+
+  try {
+    const content = readFileSync(logPath, "utf8").trim();
+    if (content.length === 0) {
+      return { prevHash: GENESIS_HASH, sequence: 0 };
+    }
+
+    const lines = content.split("\n");
+    const lastLine = lines[lines.length - 1].trim();
+    if (lastLine.length === 0) {
+      return { prevHash: GENESIS_HASH, sequence: 0 };
+    }
+
+    const lastRecord = JSON.parse(lastLine) as WitnessRecord;
+    return {
+      prevHash: lastRecord.record_hash,
+      sequence: lastRecord.sequence + 1,
+    };
+  } catch {
+    // Corrupt log — start fresh chain but with detectable gap
+    return { prevHash: sha256Hex("RECOVERY"), sequence: 0 };
+  }
+}
+
+/**
+ * Append a witness record to the JSONL log.
+ */
+function appendWitness(witnessDir: string, record: WitnessRecord): void {
+  try {
+    mkdirSync(witnessDir, { recursive: true });
+    const logPath = getLogPath(witnessDir);
+    appendFileSync(logPath, JSON.stringify(record) + "\n", "utf8");
+  } catch {
+    // Witness write failure is non-fatal — the governance decision
+    // has already been made. Log failure is detectable by chain gap.
+  }
+}
+
+/**
+ * Get the witness log path for the current month.
+ * Format: witness-YYYY-MM.jsonl
+ */
+function getLogPath(witnessDir: string): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  return join(witnessDir, `witness-${year}-${month}.jsonl`);
+}
+
+/**
+ * Truncate target strings for witness records.
+ * Full content is preserved in the hash; display is truncated.
+ */
+function truncateTarget(target: string, maxLen: number): string {
+  if (target.length <= maxLen) return target;
+  return target.slice(0, maxLen - 3) + "...";
+}
+
+// -- Chain Verification (for testing and auditing) --
+
+/**
+ * Verify the integrity of a witness chain.
+ * Returns null if valid, or an error message describing the first break.
+ */
+export function verifyChain(records: WitnessRecord[]): string | null {
+  if (records.length === 0) return null;
+
+  // First record must link to GENESIS
+  if (records[0].prev_hash !== GENESIS_HASH) {
+    // Allow RECOVERY hash for corrupt recovery
+    if (records[0].prev_hash !== sha256Hex("RECOVERY")) {
+      return `Record 0: prev_hash does not match GENESIS or RECOVERY`;
+    }
+  }
+
+  for (let i = 0; i < records.length; i++) {
+    const record = records[i];
+
+    // Verify record_hash
+    const partial: Omit<WitnessRecord, "record_hash"> = {
+      sequence: record.sequence,
+      timestamp: record.timestamp,
+      session_id: record.session_id,
+      intent_hash: record.intent_hash,
+      verdict_hash: record.verdict_hash,
+      decision: record.decision,
+      tool_name: record.tool_name,
+      action_type: record.action_type,
+      target: record.target,
+      reasons: record.reasons,
+      prev_hash: record.prev_hash,
+    };
+
+    const expectedHash = sha256Hex(stableStringify(partial));
+    if (record.record_hash !== expectedHash) {
+      return `Record ${i}: record_hash mismatch (tampered)`;
+    }
+
+    // Verify chain linkage (record N+1's prev_hash = record N's record_hash)
+    if (i > 0) {
+      if (record.prev_hash !== records[i - 1].record_hash) {
+        return `Record ${i}: prev_hash does not match record ${i - 1}'s record_hash (chain break)`;
+      }
+    }
+
+    // Verify sequence monotonicity
+    if (record.sequence !== records[0].sequence + i) {
+      return `Record ${i}: sequence gap (expected ${records[0].sequence + i}, got ${record.sequence})`;
+    }
+  }
+
+  return null;
+}

--- a/Packs/pai-governance-guard/src/governance/yaml-parse.ts
+++ b/Packs/pai-governance-guard/src/governance/yaml-parse.ts
@@ -1,0 +1,299 @@
+// ============================================================================
+// pai-governance-guard — Zero-Dependency YAML Parser
+// Handles the subset of YAML needed for governance policy files:
+// mappings, sequences, scalars, comments, block scalars
+// ============================================================================
+
+type YamlValue = string | number | boolean | null | YamlValue[] | YamlMap;
+interface YamlMap {
+  [key: string]: YamlValue;
+}
+
+/**
+ * Parse a YAML string into a JavaScript value.
+ * Supports: mappings, sequences, scalars (string/number/boolean/null),
+ * quoted strings, comments, block scalars (| and >).
+ *
+ * Does NOT support: anchors, aliases, tags, complex keys, flow collections.
+ */
+export function parseYaml(text: string): YamlValue {
+  const lines = text.split(/\r?\n/);
+  const processed: { indent: number; content: string; lineNum: number }[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i];
+    const stripped = stripComment(raw);
+    if (stripped.trim().length === 0) continue;
+
+    const indent = countIndent(raw);
+    processed.push({ indent, content: stripped.trim(), lineNum: i + 1 });
+  }
+
+  if (processed.length === 0) {
+    throw new Error("YAML parse error: empty document");
+  }
+
+  const { value } = parseValue(processed, 0, -1);
+  return value;
+}
+
+function stripComment(line: string): string {
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === "'" && !inDouble) inSingle = !inSingle;
+    if (ch === '"' && !inSingle) inDouble = !inDouble;
+    if (ch === "#" && !inSingle && !inDouble) {
+      if (i === 0 || line[i - 1] === " ") {
+        return line.slice(0, i);
+      }
+    }
+  }
+  return line;
+}
+
+function countIndent(line: string): number {
+  let n = 0;
+  for (const ch of line) {
+    if (ch === " ") n++;
+    else break;
+  }
+  return n;
+}
+
+interface ParseResult {
+  value: YamlValue;
+  nextIndex: number;
+}
+
+function parseValue(
+  lines: { indent: number; content: string; lineNum: number }[],
+  startIndex: number,
+  parentIndent: number
+): ParseResult {
+  if (startIndex >= lines.length) {
+    return { value: null, nextIndex: startIndex };
+  }
+
+  const first = lines[startIndex];
+
+  // Check if this is a sequence
+  if (first.content.startsWith("- ") || first.content === "-") {
+    return parseSequence(lines, startIndex, first.indent);
+  }
+
+  // Check if this is a mapping
+  const colonIdx = findMappingColon(first.content);
+  if (colonIdx >= 0) {
+    return parseMapping(lines, startIndex, first.indent);
+  }
+
+  // Bare scalar
+  return { value: parseScalar(first.content), nextIndex: startIndex + 1 };
+}
+
+function parseMapping(
+  lines: { indent: number; content: string; lineNum: number }[],
+  startIndex: number,
+  baseIndent: number
+): ParseResult {
+  const result: YamlMap = {};
+  let i = startIndex;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Stop if indent decreased below our base
+    if (line.indent < baseIndent) break;
+    // Skip lines at deeper indent (handled by recursion)
+    if (line.indent > baseIndent) break;
+
+    const colonIdx = findMappingColon(line.content);
+    if (colonIdx < 0) break;
+
+    const key = line.content.slice(0, colonIdx).trim();
+    const afterColon = line.content.slice(colonIdx + 1).trim();
+
+    if (afterColon === "|" || afterColon === ">") {
+      // Block scalar
+      const fold = afterColon === ">";
+      const { value, nextIndex } = parseBlockScalar(lines, i + 1, baseIndent, fold);
+      result[key] = value;
+      i = nextIndex;
+    } else if (afterColon.length > 0) {
+      // Inline value
+      result[key] = parseScalar(afterColon);
+      i++;
+    } else {
+      // Nested value on next lines
+      if (i + 1 < lines.length && lines[i + 1].indent > baseIndent) {
+        const nested = parseValue(lines, i + 1, baseIndent);
+        result[key] = nested.value;
+        i = nested.nextIndex;
+      } else {
+        result[key] = null;
+        i++;
+      }
+    }
+  }
+
+  return { value: result, nextIndex: i };
+}
+
+function parseSequence(
+  lines: { indent: number; content: string; lineNum: number }[],
+  startIndex: number,
+  baseIndent: number
+): ParseResult {
+  const result: YamlValue[] = [];
+  let i = startIndex;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    if (line.indent < baseIndent) break;
+    if (line.indent > baseIndent) break;
+
+    if (!line.content.startsWith("- ") && line.content !== "-") break;
+
+    const afterDash = line.content === "-" ? "" : line.content.slice(2).trim();
+
+    if (afterDash.length === 0) {
+      // Nested value on next lines
+      if (i + 1 < lines.length && lines[i + 1].indent > baseIndent) {
+        const nested = parseValue(lines, i + 1, baseIndent);
+        result.push(nested.value);
+        i = nested.nextIndex;
+      } else {
+        result.push(null);
+        i++;
+      }
+    } else {
+      // Check if the item value is a mapping (e.g., "- key: value")
+      const itemColonIdx = findMappingColon(afterDash);
+      if (itemColonIdx >= 0) {
+        // Sequence of mappings: parse the first key-value inline,
+        // then collect remaining keys at deeper indent
+        const itemKey = afterDash.slice(0, itemColonIdx).trim();
+        const itemVal = afterDash.slice(itemColonIdx + 1).trim();
+        const obj: YamlMap = {};
+        obj[itemKey] = itemVal.length > 0 ? parseScalar(itemVal) : null;
+
+        // Collect continuation keys at deeper indent
+        const itemIndent = baseIndent + 2; // standard indent for sequence item continuation
+        let j = i + 1;
+        while (j < lines.length && lines[j].indent >= itemIndent) {
+          const subLine = lines[j];
+          if (subLine.indent > baseIndent) {
+            const subColonIdx = findMappingColon(subLine.content);
+            if (subColonIdx >= 0) {
+              const subKey = subLine.content.slice(0, subColonIdx).trim();
+              const subAfter = subLine.content.slice(subColonIdx + 1).trim();
+              if (subAfter.length > 0) {
+                obj[subKey] = parseScalar(subAfter);
+                j++;
+              } else {
+                // Nested value
+                if (j + 1 < lines.length && lines[j + 1].indent > subLine.indent) {
+                  const nested = parseValue(lines, j + 1, subLine.indent);
+                  obj[subKey] = nested.value;
+                  j = nested.nextIndex;
+                } else {
+                  obj[subKey] = null;
+                  j++;
+                }
+              }
+            } else {
+              break;
+            }
+          } else {
+            break;
+          }
+        }
+        result.push(obj);
+        i = j;
+      } else {
+        // Simple scalar item
+        result.push(parseScalar(afterDash));
+        i++;
+      }
+    }
+  }
+
+  return { value: result, nextIndex: i };
+}
+
+function parseBlockScalar(
+  lines: { indent: number; content: string; lineNum: number }[],
+  startIndex: number,
+  parentIndent: number,
+  fold: boolean
+): ParseResult {
+  const blockLines: string[] = [];
+  let i = startIndex;
+  let blockIndent = -1;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    if (line.indent <= parentIndent) break;
+
+    if (blockIndent < 0) blockIndent = line.indent;
+    if (line.indent < blockIndent) break;
+
+    blockLines.push(line.content);
+    i++;
+  }
+
+  const joined = fold
+    ? blockLines.join(" ").replace(/\s+/g, " ").trim()
+    : blockLines.join("\n");
+
+  return { value: joined, nextIndex: i };
+}
+
+function findMappingColon(content: string): number {
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < content.length; i++) {
+    const ch = content[i];
+    if (ch === "'" && !inDouble) inSingle = !inSingle;
+    if (ch === '"' && !inSingle) inDouble = !inDouble;
+    if (ch === ":" && !inSingle && !inDouble) {
+      // Must be followed by space, end of string, or be at end
+      if (i + 1 >= content.length || content[i + 1] === " ") {
+        return i;
+      }
+    }
+  }
+  return -1;
+}
+
+function parseScalar(value: string): string | number | boolean | null {
+  if (value === "null" || value === "~" || value === "") return null;
+  if (value === "true" || value === "True" || value === "TRUE") return true;
+  if (value === "false" || value === "False" || value === "FALSE") return false;
+
+  // Quoted strings
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    const inner = value.slice(1, -1);
+    // Handle basic escape sequences for double-quoted strings
+    if (value.startsWith('"')) {
+      return inner
+        .replace(/\\n/g, "\n")
+        .replace(/\\t/g, "\t")
+        .replace(/\\"/g, '"')
+        .replace(/\\\\/g, "\\");
+    }
+    return inner;
+  }
+
+  // Numbers
+  if (/^-?\d+$/.test(value)) return parseInt(value, 10);
+  if (/^-?\d+\.\d+$/.test(value)) return parseFloat(value);
+
+  return value;
+}

--- a/Packs/pai-governance-guard/src/hooks/GovernanceGuard.hook.ts
+++ b/Packs/pai-governance-guard/src/hooks/GovernanceGuard.hook.ts
@@ -1,0 +1,135 @@
+#!/usr/bin/env bun
+// ============================================================================
+// pai-governance-guard — PreToolUse Hook
+// Deterministic authorization: PROPOSE → DECIDE → PROMOTE
+//
+// Registered as PreToolUse hook with "*" matcher (evaluates all tool calls).
+// Complements SecurityValidator — does not replace it.
+//
+// Exit 0 + JSON stdout: structured decision (allow/deny/ask)
+// All errors → fail-closed (deny)
+// ============================================================================
+
+import { propose } from "../governance/intent";
+import { decide, loadPolicy } from "../governance/policy-engine";
+import { promote } from "../governance/witness";
+import type { HookInput, HookOutput } from "../governance/types";
+import { existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { homedir } from "node:os";
+
+// -- Path Resolution --
+
+function getPaiDir(): string {
+  if (process.env.PAI_DIR) return process.env.PAI_DIR;
+
+  // PAI default location
+  const home = homedir();
+  const paiDir = join(home, ".pai");
+  if (existsSync(paiDir)) return paiDir;
+
+  // Fallback: look in current directory
+  const localPai = join(process.cwd(), ".pai");
+  if (existsSync(localPai)) return localPai;
+
+  return join(home, ".pai");
+}
+
+function resolvePolicy(): string {
+  // 1. Explicit env var
+  if (process.env.GOVERNANCE_POLICY) return resolve(process.env.GOVERNANCE_POLICY);
+
+  const paiDir = getPaiDir();
+
+  // 2. Project-level policy
+  const projectPolicy = join(process.cwd(), ".claude", "governance-policy.yaml");
+  if (existsSync(projectPolicy)) return projectPolicy;
+
+  // 3. PAI MEMORY governance policy
+  const paiPolicy = join(paiDir, "MEMORY", "GOVERNANCE", "governance-policy.yaml");
+  if (existsSync(paiPolicy)) return paiPolicy;
+
+  // 4. User-level policy
+  const userPolicy = join(homedir(), ".claude", "governance-policy.yaml");
+  if (existsSync(userPolicy)) return userPolicy;
+
+  // 5. Bundled standard policy (fallback)
+  const bundledPolicy = join(__dirname, "..", "..", "policies", "standard.yaml");
+  if (existsSync(bundledPolicy)) return bundledPolicy;
+
+  // No policy found — fail-closed will trigger in loadPolicy
+  return join(paiDir, "MEMORY", "GOVERNANCE", "governance-policy.yaml");
+}
+
+function getWitnessDir(): string {
+  const paiDir = getPaiDir();
+  return join(paiDir, "MEMORY", "GOVERNANCE");
+}
+
+// -- Fail-Closed Output --
+
+function denyOutput(reason: string): HookOutput {
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: `[GOVERNANCE] ${reason}`,
+    },
+  };
+}
+
+// -- Main --
+
+async function main(): Promise<void> {
+  let input: HookInput;
+
+  try {
+    // Read JSON from stdin (same pattern as SecurityValidator.hook.ts)
+    const chunks: Buffer[] = [];
+    const reader = Bun.stdin.stream().getReader();
+
+    const timeout = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error("stdin timeout")), 500)
+    );
+
+    const readAll = (async () => {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(Buffer.from(value));
+      }
+      return Buffer.concat(chunks).toString("utf8");
+    })();
+
+    const raw = await Promise.race([readAll, timeout]);
+    input = JSON.parse(raw);
+  } catch {
+    console.log(JSON.stringify(denyOutput("Failed to parse hook input — fail-closed")));
+    return;
+  }
+
+  try {
+    // 1. PROPOSE — serialize intent
+    const intent = propose(input);
+
+    // 2. DECIDE — evaluate against policy
+    const policyPath = resolvePolicy();
+    const policy = loadPolicy(policyPath);
+    const verdict = decide(intent, policy);
+
+    // 3. PROMOTE — gate and record
+    const witnessDir = getWitnessDir();
+    const { output } = promote(intent, verdict, witnessDir);
+
+    console.log(JSON.stringify(output));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.log(JSON.stringify(denyOutput(`Pipeline error — fail-closed: ${msg}`)));
+  }
+}
+
+main().catch(() => {
+  console.log(
+    JSON.stringify(denyOutput("Unhandled error — fail-closed"))
+  );
+});

--- a/Packs/pai-governance-guard/tests/adversarial.test.ts
+++ b/Packs/pai-governance-guard/tests/adversarial.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import { strict as assert } from "node:assert";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { propose } from "../src/governance/intent";
+import { decide, loadPolicy, resetPolicyCache } from "../src/governance/policy-engine";
+import { promote, verifyChain } from "../src/governance/witness";
+import type { HookInput, WitnessRecord } from "../src/governance/types";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TEST_DIR = join(__dirname, "..", ".test-adversarial");
+const POLICIES_DIR = join(__dirname, "..", "policies");
+
+function makeHookInput(toolName: string, toolInput: Record<string, unknown>): HookInput {
+  return {
+    session_id: "adversarial-test",
+    cwd: "/test",
+    hook_event_name: "PreToolUse",
+    tool_name: toolName,
+    tool_input: toolInput,
+  };
+}
+
+beforeEach(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true });
+  mkdirSync(TEST_DIR, { recursive: true });
+  resetPolicyCache();
+});
+
+afterEach(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe("adversarial — spoofed content hash", () => {
+  it("computes its own hash regardless of input", () => {
+    const input = makeHookInput("Bash", { command: "npm test" });
+    const intent1 = propose(input);
+    const intent2 = propose(input);
+    assert.equal(intent1.content_hash, intent2.content_hash);
+    assert.equal(intent1.content_hash.length, 64);
+  });
+});
+
+describe("adversarial — witness tamper detection", () => {
+  it("detects modified decision in witness record", () => {
+    const policyPath = join(POLICIES_DIR, "minimal.yaml");
+    const intent = propose(makeHookInput("Bash", { command: "rm -rf /" }));
+    const policy = loadPolicy(policyPath);
+    const verdict = decide(intent, policy);
+    const { record } = promote(intent, verdict, TEST_DIR);
+    assert.equal(record.decision, "deny");
+
+    const tampered = { ...record, decision: "approve" as const };
+    const error = verifyChain([tampered]);
+    assert.ok(error);
+    assert.ok(error.includes("tampered"));
+  });
+
+  it("detects modified target in witness record", () => {
+    const policyPath = join(POLICIES_DIR, "minimal.yaml");
+    const intent = propose(makeHookInput("Read", { file_path: "/src/a.ts" }));
+    const policy = loadPolicy(policyPath);
+    const verdict = decide(intent, policy);
+    const { record } = promote(intent, verdict, TEST_DIR);
+
+    const tampered = { ...record, target: "/etc/shadow" };
+    const error = verifyChain([tampered]);
+    assert.ok(error);
+  });
+
+  it("detects deleted record in chain", () => {
+    const policyPath = join(POLICIES_DIR, "minimal.yaml");
+    const records: WitnessRecord[] = [];
+
+    for (let i = 0; i < 5; i++) {
+      const intent = propose(makeHookInput("Read", { file_path: `/src/f${i}.ts` }));
+      const policy = loadPolicy(policyPath);
+      const verdict = decide(intent, policy);
+      const { record } = promote(intent, verdict, TEST_DIR);
+      records.push(record);
+    }
+
+    const withGap = [records[0], records[1], records[3], records[4]];
+    const error = verifyChain(withGap);
+    assert.ok(error);
+  });
+});
+
+describe("adversarial — path traversal", () => {
+  it("classifies .env access via Write as credential", () => {
+    const intent = propose(makeHookInput("Write", { file_path: "../../../.env" }));
+    assert.equal(intent.action_type, "credential");
+  });
+
+  it("classifies Write to ~/.ssh/id_rsa as credential", () => {
+    const intent = propose(makeHookInput("Write", { file_path: "/home/user/.ssh/id_rsa" }));
+    assert.equal(intent.action_type, "credential");
+  });
+});
+
+describe("adversarial — malformed YAML policy", () => {
+  it("fail-closed on invalid YAML", () => {
+    const badPolicyPath = join(TEST_DIR, "bad-policy.yaml");
+    writeFileSync(badPolicyPath, "{{{{not yaml at all}}}}");
+    resetPolicyCache();
+    const policy = loadPolicy(badPolicyPath);
+    assert.equal(policy.default_decision, "deny");
+    assert.equal(policy.rules.length, 0);
+  });
+
+  it("fail-closed on empty YAML", () => {
+    const emptyPolicyPath = join(TEST_DIR, "empty-policy.yaml");
+    writeFileSync(emptyPolicyPath, "");
+    resetPolicyCache();
+    const policy = loadPolicy(emptyPolicyPath);
+    assert.equal(policy.default_decision, "deny");
+  });
+
+  it("fail-closed on YAML with wrong structure", () => {
+    const wrongPolicyPath = join(TEST_DIR, "wrong-policy.yaml");
+    writeFileSync(wrongPolicyPath, "- just\n- a\n- list");
+    resetPolicyCache();
+    const policy = loadPolicy(wrongPolicyPath);
+    assert.equal(policy.default_decision, "deny");
+  });
+});
+
+describe("adversarial — JSON injection", () => {
+  it("handles command with embedded JSON", () => {
+    const input = makeHookInput("Bash", { command: 'echo \'{"malicious": true}\' > /tmp/test' });
+    const intent = propose(input);
+    assert.ok(intent.content_hash.length === 64);
+    assert.equal(intent.action_type, "write");
+  });
+});
+
+describe("adversarial — extremely long inputs", () => {
+  it("handles very long command (>10KB)", () => {
+    const longCommand = "echo " + "A".repeat(20000);
+    const input = makeHookInput("Bash", { command: longCommand });
+    const intent = propose(input);
+    assert.ok(intent.content_hash.length === 64);
+  });
+
+  it("truncates long targets in witness record", () => {
+    const longCommand = "echo " + "A".repeat(1000);
+    const input = makeHookInput("Bash", { command: longCommand });
+    const intent = propose(input);
+    const policy = loadPolicy(join(POLICIES_DIR, "minimal.yaml"));
+    const verdict = decide(intent, policy);
+    const { record } = promote(intent, verdict, TEST_DIR);
+    assert.ok(record.target.length <= 203);
+  });
+});
+
+describe("adversarial — replay detection", () => {
+  it("sequential records have unique sequence numbers", () => {
+    const policyPath = join(POLICIES_DIR, "minimal.yaml");
+    const records: WitnessRecord[] = [];
+
+    for (let i = 0; i < 5; i++) {
+      const intent = propose(makeHookInput("Bash", { command: "npm test" }));
+      const policy = loadPolicy(policyPath);
+      const verdict = decide(intent, policy);
+      const { record } = promote(intent, verdict, TEST_DIR);
+      records.push(record);
+    }
+
+    const sequences = records.map((r) => r.sequence);
+    const unique = new Set(sequences);
+    assert.equal(unique.size, 5);
+  });
+
+  it("duplicate record insertion breaks chain verification", () => {
+    const policyPath = join(POLICIES_DIR, "minimal.yaml");
+    const intent = propose(makeHookInput("Bash", { command: "npm test" }));
+    const policy = loadPolicy(policyPath);
+    const verdict = decide(intent, policy);
+
+    const r1 = promote(intent, verdict, TEST_DIR).record;
+    const r2 = promote(intent, verdict, TEST_DIR).record;
+
+    const replayed = [r1, r1, r2];
+    const error = verifyChain(replayed);
+    assert.ok(error);
+  });
+});

--- a/Packs/pai-governance-guard/tests/canonical.test.ts
+++ b/Packs/pai-governance-guard/tests/canonical.test.ts
@@ -1,0 +1,76 @@
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+import { stableStringify, sha256Hex, canonicalHash } from "../src/governance/canonical";
+
+describe("stableStringify", () => {
+  it("serializes primitives", () => {
+    assert.equal(stableStringify(null), "null");
+    assert.equal(stableStringify(undefined), "null");
+    assert.equal(stableStringify(true), "true");
+    assert.equal(stableStringify(false), "false");
+    assert.equal(stableStringify(42), "42");
+    assert.equal(stableStringify(3.14), "3.14");
+    assert.equal(stableStringify("hello"), '"hello"');
+  });
+
+  it("serializes arrays", () => {
+    assert.equal(stableStringify([1, 2, 3]), "[1,2,3]");
+    assert.equal(stableStringify([]), "[]");
+    assert.equal(stableStringify(["a", null, true]), '["a",null,true]');
+  });
+
+  it("sorts object keys deterministically", () => {
+    const a = { z: 1, a: 2, m: 3 };
+    const b = { a: 2, m: 3, z: 1 };
+    assert.equal(stableStringify(a), stableStringify(b));
+    assert.equal(stableStringify(a), '{"a":2,"m":3,"z":1}');
+  });
+
+  it("handles nested objects", () => {
+    const obj = { b: { d: 1, c: 2 }, a: [3] };
+    assert.equal(stableStringify(obj), '{"a":[3],"b":{"c":2,"d":1}}');
+  });
+
+  it("omits undefined values in objects", () => {
+    const obj = { a: 1, b: undefined, c: 3 };
+    assert.equal(stableStringify(obj), '{"a":1,"c":3}');
+  });
+});
+
+describe("sha256Hex", () => {
+  it("produces 64-char hex string", () => {
+    const hash = sha256Hex("hello");
+    assert.equal(hash.length, 64);
+    assert.match(hash, /^[0-9a-f]{64}$/);
+  });
+
+  it("is deterministic", () => {
+    assert.equal(sha256Hex("test"), sha256Hex("test"));
+  });
+
+  it("produces different hashes for different inputs", () => {
+    assert.notEqual(sha256Hex("a"), sha256Hex("b"));
+  });
+
+  it("matches known SHA-256 for empty string", () => {
+    assert.equal(
+      sha256Hex(""),
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    );
+  });
+});
+
+describe("canonicalHash", () => {
+  it("hashes via stableStringify then SHA-256", () => {
+    const obj = { b: 2, a: 1 };
+    const expected = sha256Hex(stableStringify(obj));
+    assert.equal(canonicalHash(obj), expected);
+  });
+
+  it("produces same hash for key-reordered objects", () => {
+    assert.equal(
+      canonicalHash({ x: 1, y: 2 }),
+      canonicalHash({ y: 2, x: 1 })
+    );
+  });
+});

--- a/Packs/pai-governance-guard/tests/integration.test.ts
+++ b/Packs/pai-governance-guard/tests/integration.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import { strict as assert } from "node:assert";
+import { mkdirSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { propose } from "../src/governance/intent";
+import { decide, loadPolicy, resetPolicyCache } from "../src/governance/policy-engine";
+import { promote, verifyChain } from "../src/governance/witness";
+import type { HookInput, HookOutput, WitnessRecord } from "../src/governance/types";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TEST_DIR = join(__dirname, "..", ".test-integration");
+const POLICIES_DIR = join(__dirname, "..", "policies");
+
+function makeHookInput(toolName: string, toolInput: Record<string, unknown>): HookInput {
+  return {
+    session_id: "integration-test",
+    cwd: "/test/project",
+    hook_event_name: "PreToolUse",
+    tool_name: toolName,
+    tool_input: toolInput,
+  };
+}
+
+function runPipeline(
+  input: HookInput,
+  policyPath: string,
+  witnessDir: string
+): { output: HookOutput; record: WitnessRecord } {
+  const intent = propose(input);
+  const policy = loadPolicy(policyPath);
+  const verdict = decide(intent, policy);
+  return promote(intent, verdict, witnessDir);
+}
+
+beforeEach(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true });
+  mkdirSync(TEST_DIR, { recursive: true });
+  resetPolicyCache();
+});
+
+afterEach(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe("end-to-end — minimal policy", () => {
+  const policyPath = join(POLICIES_DIR, "minimal.yaml");
+
+  it("allows read operations", () => {
+    const { output } = runPipeline(makeHookInput("Read", { file_path: "/src/main.ts" }), policyPath, TEST_DIR);
+    assert.equal(output.hookSpecificOutput.permissionDecision, "allow");
+  });
+
+  it("denies destructive operations", () => {
+    const { output } = runPipeline(makeHookInput("Bash", { command: "rm -rf /tmp/important" }), policyPath, TEST_DIR);
+    assert.equal(output.hookSpecificOutput.permissionDecision, "deny");
+  });
+
+  it("escalates network operations", () => {
+    const { output } = runPipeline(makeHookInput("Bash", { command: "curl https://api.example.com" }), policyPath, TEST_DIR);
+    assert.equal(output.hookSpecificOutput.permissionDecision, "ask");
+  });
+
+  it("denies credential access", () => {
+    const { output } = runPipeline(makeHookInput("Read", { file_path: "/project/.env" }), policyPath, TEST_DIR);
+    assert.equal(output.hookSpecificOutput.permissionDecision, "deny");
+  });
+
+  it("allows write operations", () => {
+    const { output } = runPipeline(makeHookInput("Write", { file_path: "/src/app.ts", content: "code" }), policyPath, TEST_DIR);
+    assert.equal(output.hookSpecificOutput.permissionDecision, "allow");
+  });
+
+  it("allows execute operations", () => {
+    const { output } = runPipeline(makeHookInput("Bash", { command: "npm test" }), policyPath, TEST_DIR);
+    assert.equal(output.hookSpecificOutput.permissionDecision, "allow");
+  });
+});
+
+describe("end-to-end — strict policy", () => {
+  const policyPath = join(POLICIES_DIR, "strict.yaml");
+
+  it("allows reads", () => {
+    const { output } = runPipeline(makeHookInput("Read", { file_path: "/src/main.ts" }), policyPath, TEST_DIR);
+    assert.equal(output.hookSpecificOutput.permissionDecision, "allow");
+  });
+
+  it("denies writes", () => {
+    const { output } = runPipeline(makeHookInput("Write", { file_path: "/src/app.ts", content: "code" }), policyPath, TEST_DIR);
+    assert.equal(output.hookSpecificOutput.permissionDecision, "deny");
+  });
+
+  it("denies execution", () => {
+    const { output } = runPipeline(makeHookInput("Bash", { command: "npm test" }), policyPath, TEST_DIR);
+    assert.equal(output.hookSpecificOutput.permissionDecision, "deny");
+  });
+
+  it("denies network", () => {
+    const { output } = runPipeline(makeHookInput("WebFetch", { url: "https://example.com", prompt: "test" }), policyPath, TEST_DIR);
+    assert.equal(output.hookSpecificOutput.permissionDecision, "deny");
+  });
+});
+
+describe("end-to-end — witness chain integrity", () => {
+  const policyPath = join(POLICIES_DIR, "minimal.yaml");
+
+  it("builds valid chain across multiple calls", () => {
+    const inputs = [
+      makeHookInput("Read", { file_path: "/src/a.ts" }),
+      makeHookInput("Write", { file_path: "/src/b.ts", content: "x" }),
+      makeHookInput("Bash", { command: "rm -rf /tmp" }),
+      makeHookInput("Bash", { command: "curl https://example.com" }),
+      makeHookInput("Bash", { command: "npm test" }),
+    ];
+
+    const records: WitnessRecord[] = [];
+    for (const input of inputs) {
+      const { record } = runPipeline(input, policyPath, TEST_DIR);
+      records.push(record);
+    }
+
+    assert.equal(records.length, 5);
+    assert.equal(verifyChain(records), null);
+
+    assert.equal(records[0].decision, "approve"); // read
+    assert.equal(records[1].decision, "approve"); // write (minimal allows)
+    assert.equal(records[2].decision, "deny");    // destructive
+    assert.equal(records[3].decision, "escalate"); // network
+    assert.equal(records[4].decision, "approve"); // execute
+  });
+
+  it("witness log file contains all records", () => {
+    for (let i = 0; i < 3; i++) {
+      runPipeline(makeHookInput("Read", { file_path: `/src/file${i}.ts` }), policyPath, TEST_DIR);
+    }
+
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, "0");
+    const logPath = join(TEST_DIR, `witness-${year}-${month}.jsonl`);
+
+    assert.ok(existsSync(logPath));
+    const lines = readFileSync(logPath, "utf8").trim().split("\n");
+    assert.equal(lines.length, 3);
+
+    const records = lines.map((l) => JSON.parse(l) as WitnessRecord);
+    assert.equal(verifyChain(records), null);
+  });
+});
+
+describe("end-to-end — hook output format", () => {
+  const policyPath = join(POLICIES_DIR, "minimal.yaml");
+
+  it("produces valid hookSpecificOutput for allow", () => {
+    const { output } = runPipeline(makeHookInput("Read", { file_path: "/src/a.ts" }), policyPath, TEST_DIR);
+    assert.equal(output.hookSpecificOutput.hookEventName, "PreToolUse");
+    assert.equal(output.hookSpecificOutput.permissionDecision, "allow");
+  });
+
+  it("produces valid hookSpecificOutput for deny", () => {
+    const { output } = runPipeline(makeHookInput("Bash", { command: "rm -rf /" }), policyPath, TEST_DIR);
+    assert.equal(output.hookSpecificOutput.hookEventName, "PreToolUse");
+    assert.equal(output.hookSpecificOutput.permissionDecision, "deny");
+    assert.ok(output.hookSpecificOutput.permissionDecisionReason!.startsWith("[GOVERNANCE]"));
+  });
+
+  it("produces valid hookSpecificOutput for ask", () => {
+    const { output } = runPipeline(makeHookInput("Bash", { command: "curl https://example.com" }), policyPath, TEST_DIR);
+    assert.equal(output.hookSpecificOutput.hookEventName, "PreToolUse");
+    assert.equal(output.hookSpecificOutput.permissionDecision, "ask");
+  });
+});
+
+describe("end-to-end — fail-closed", () => {
+  it("denies when policy file missing", () => {
+    const { output } = runPipeline(makeHookInput("Bash", { command: "echo hello" }), "/nonexistent/policy.yaml", TEST_DIR);
+    assert.equal(output.hookSpecificOutput.permissionDecision, "deny");
+  });
+});

--- a/Packs/pai-governance-guard/tests/intent.test.ts
+++ b/Packs/pai-governance-guard/tests/intent.test.ts
@@ -1,0 +1,217 @@
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+import { propose, classifyAction, extractTarget } from "../src/governance/intent";
+import type { HookInput } from "../src/governance/types";
+
+function makeInput(toolName: string, toolInput: Record<string, unknown>): HookInput {
+  return {
+    session_id: "test-session",
+    cwd: "/test",
+    hook_event_name: "PreToolUse",
+    tool_name: toolName,
+    tool_input: toolInput,
+  };
+}
+
+describe("classifyAction — Bash commands", () => {
+  it("classifies rm -rf as destructive", () => {
+    assert.equal(classifyAction("Bash", { command: "rm -rf /tmp/foo" }), "destructive");
+  });
+
+  it("classifies rm -r as destructive", () => {
+    assert.equal(classifyAction("Bash", { command: "rm -r ./build" }), "destructive");
+  });
+
+  it("classifies git reset --hard as destructive", () => {
+    assert.equal(classifyAction("Bash", { command: "git reset --hard HEAD~1" }), "destructive");
+  });
+
+  it("classifies git push --force as destructive", () => {
+    assert.equal(classifyAction("Bash", { command: "git push --force origin main" }), "destructive");
+  });
+
+  it("classifies git clean -f as destructive", () => {
+    assert.equal(classifyAction("Bash", { command: "git clean -fd" }), "destructive");
+  });
+
+  it("classifies drop table as destructive", () => {
+    assert.equal(classifyAction("Bash", { command: 'psql -c "DROP TABLE users"' }), "destructive");
+  });
+
+  it("classifies curl as network", () => {
+    assert.equal(classifyAction("Bash", { command: "curl https://api.example.com" }), "network");
+  });
+
+  it("classifies wget as network", () => {
+    assert.equal(classifyAction("Bash", { command: "wget https://example.com/file.zip" }), "network");
+  });
+
+  it("classifies ssh as network", () => {
+    assert.equal(classifyAction("Bash", { command: "ssh user@host" }), "network");
+  });
+
+  it("classifies cat .env as credential", () => {
+    assert.equal(classifyAction("Bash", { command: "cat .env" }), "credential");
+  });
+
+  it("classifies reading ~/.ssh as credential", () => {
+    assert.equal(classifyAction("Bash", { command: "cat ~/.ssh/id_rsa" }), "credential");
+  });
+
+  it("classifies cat README as read", () => {
+    assert.equal(classifyAction("Bash", { command: "cat README.md" }), "read");
+  });
+
+  it("classifies ls as read", () => {
+    assert.equal(classifyAction("Bash", { command: "ls -la" }), "read");
+  });
+
+  it("classifies git status as read", () => {
+    assert.equal(classifyAction("Bash", { command: "git status" }), "read");
+  });
+
+  it("classifies git log as read", () => {
+    assert.equal(classifyAction("Bash", { command: "git log --oneline" }), "read");
+  });
+
+  it("classifies npm test as execute", () => {
+    assert.equal(classifyAction("Bash", { command: "npm test" }), "execute");
+  });
+
+  it("classifies npm install as execute", () => {
+    assert.equal(classifyAction("Bash", { command: "npm install express" }), "execute");
+  });
+
+  it("classifies cargo build as execute", () => {
+    assert.equal(classifyAction("Bash", { command: "cargo build --release" }), "execute");
+  });
+
+  it("classifies command with redirect as write", () => {
+    assert.equal(classifyAction("Bash", { command: "echo hello > output.txt" }), "write");
+  });
+});
+
+describe("classifyAction — File tools", () => {
+  it("classifies Read as read", () => {
+    assert.equal(classifyAction("Read", { file_path: "/src/main.ts" }), "read");
+  });
+
+  it("classifies Glob as read", () => {
+    assert.equal(classifyAction("Glob", { pattern: "**/*.ts" }), "read");
+  });
+
+  it("classifies Grep as read", () => {
+    assert.equal(classifyAction("Grep", { pattern: "TODO" }), "read");
+  });
+
+  it("classifies Write as write", () => {
+    assert.equal(classifyAction("Write", { file_path: "/src/app.ts" }), "write");
+  });
+
+  it("classifies Edit as write", () => {
+    assert.equal(classifyAction("Edit", { file_path: "/src/app.ts" }), "write");
+  });
+
+  it("classifies Write to .env as credential", () => {
+    assert.equal(classifyAction("Write", { file_path: "/project/.env" }), "credential");
+  });
+
+  it("classifies Read of .env as credential", () => {
+    assert.equal(classifyAction("Read", { file_path: "/project/.env" }), "credential");
+  });
+
+  it("classifies Write to credentials file as credential", () => {
+    assert.equal(classifyAction("Write", { file_path: "/config/credentials.json" }), "credential");
+  });
+});
+
+describe("classifyAction — Web tools", () => {
+  it("classifies WebFetch as network", () => {
+    assert.equal(classifyAction("WebFetch", { url: "https://example.com" }), "network");
+  });
+
+  it("classifies WebSearch as network", () => {
+    assert.equal(classifyAction("WebSearch", { query: "test" }), "network");
+  });
+});
+
+describe("classifyAction — Other tools", () => {
+  it("classifies MCP tools as unknown", () => {
+    assert.equal(classifyAction("mcp__server__action", {}), "unknown");
+  });
+
+  it("classifies Task as read", () => {
+    assert.equal(classifyAction("Task", {}), "read");
+  });
+
+  it("classifies unrecognized tools as unknown", () => {
+    assert.equal(classifyAction("SomeNewTool", {}), "unknown");
+  });
+});
+
+describe("extractTarget", () => {
+  it("extracts command from Bash", () => {
+    assert.equal(extractTarget("Bash", { command: "npm test" }), "npm test");
+  });
+
+  it("extracts file_path from Read", () => {
+    assert.equal(extractTarget("Read", { file_path: "/src/app.ts" }), "/src/app.ts");
+  });
+
+  it("extracts file_path from Write", () => {
+    assert.equal(extractTarget("Write", { file_path: "/src/app.ts" }), "/src/app.ts");
+  });
+
+  it("extracts url from WebFetch", () => {
+    assert.equal(extractTarget("WebFetch", { url: "https://example.com" }), "https://example.com");
+  });
+
+  it("extracts query from WebSearch", () => {
+    assert.equal(extractTarget("WebSearch", { query: "test query" }), "test query");
+  });
+
+  it("extracts pattern from Glob", () => {
+    assert.equal(extractTarget("Glob", { pattern: "**/*.ts" }), "**/*.ts");
+  });
+});
+
+describe("propose — full pipeline", () => {
+  it("produces a valid ActionIntent", () => {
+    const input = makeInput("Bash", { command: "npm test" });
+    const intent = propose(input);
+
+    assert.equal(intent.tool_name, "Bash");
+    assert.equal(intent.action_type, "execute");
+    assert.equal(intent.target, "npm test");
+    assert.equal(intent.session_id, "test-session");
+    assert.ok(intent.content_hash.length === 64);
+    assert.ok(intent.timestamp.includes("T"));
+  });
+
+  it("produces deterministic content hash", () => {
+    const input = makeInput("Bash", { command: "npm test" });
+    const intent1 = propose(input);
+    const intent2 = propose(input);
+    assert.equal(intent1.content_hash, intent2.content_hash);
+  });
+
+  it("produces different hash for different input", () => {
+    const intent1 = propose(makeInput("Bash", { command: "npm test" }));
+    const intent2 = propose(makeInput("Bash", { command: "npm build" }));
+    assert.notEqual(intent1.content_hash, intent2.content_hash);
+  });
+
+  it("handles empty command gracefully", () => {
+    const input = makeInput("Bash", { command: "" });
+    const intent = propose(input);
+    assert.equal(intent.action_type, "execute");
+    assert.equal(intent.target, "");
+  });
+
+  it("handles missing fields gracefully", () => {
+    const input = makeInput("Bash", {});
+    const intent = propose(input);
+    assert.ok(intent.action_type);
+    assert.ok(intent.content_hash.length === 64);
+  });
+});

--- a/Packs/pai-governance-guard/tests/policy-engine.test.ts
+++ b/Packs/pai-governance-guard/tests/policy-engine.test.ts
@@ -1,0 +1,274 @@
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { decide, loadPolicy, resetPolicyCache } from "../src/governance/policy-engine";
+import type { ActionIntent, PolicyConfig } from "../src/governance/types";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function makeIntent(overrides: Partial<ActionIntent> = {}): ActionIntent {
+  return {
+    tool_name: "Bash",
+    action_type: "execute",
+    target: "npm test",
+    raw_input: { command: "npm test" },
+    content_hash: "abc123",
+    timestamp: new Date().toISOString(),
+    session_id: "test-session",
+    ...overrides,
+  };
+}
+
+const DENY_DEFAULT: PolicyConfig = {
+  version: "1.0",
+  name: "test-deny",
+  description: "Test policy with deny default",
+  default_decision: "deny",
+  rules: [],
+};
+
+const APPROVE_DEFAULT: PolicyConfig = {
+  version: "1.0",
+  name: "test-approve",
+  description: "Test policy with approve default",
+  default_decision: "approve",
+  rules: [],
+};
+
+describe("decide — default decision", () => {
+  it("returns deny when no rules match and default is deny", () => {
+    const result = decide(makeIntent(), DENY_DEFAULT);
+    assert.equal(result.decision, "deny");
+  });
+
+  it("returns approve when no rules match and default is approve", () => {
+    const result = decide(makeIntent(), APPROVE_DEFAULT);
+    assert.equal(result.decision, "approve");
+  });
+});
+
+describe("decide — rule matching", () => {
+  it("matches by action_type", () => {
+    const policy: PolicyConfig = {
+      ...DENY_DEFAULT,
+      rules: [{ id: "allow-read", action_type: "read", decision: "approve", reason: "Read OK" }],
+    };
+    const result = decide(makeIntent({ action_type: "read" }), policy);
+    assert.equal(result.decision, "approve");
+    assert.equal(result.matched_rule, "allow-read");
+  });
+
+  it("matches by tool_name regex", () => {
+    const policy: PolicyConfig = {
+      ...DENY_DEFAULT,
+      rules: [{ id: "allow-bash", tool_name: "^Bash$", decision: "approve", reason: "Bash OK" }],
+    };
+    const result = decide(makeIntent({ tool_name: "Bash" }), policy);
+    assert.equal(result.decision, "approve");
+  });
+
+  it("does not match mismatched tool_name regex", () => {
+    const policy: PolicyConfig = {
+      ...DENY_DEFAULT,
+      rules: [{ id: "allow-read-tool", tool_name: "^Read$", decision: "approve", reason: "Read OK" }],
+    };
+    const result = decide(makeIntent({ tool_name: "Bash" }), policy);
+    assert.equal(result.decision, "deny");
+  });
+
+  it("matches by target glob", () => {
+    const policy: PolicyConfig = {
+      ...DENY_DEFAULT,
+      rules: [{ id: "allow-src", action_type: "write", target: "**/src/**", decision: "approve", reason: "Src OK" }],
+    };
+    const result = decide(makeIntent({ action_type: "write", target: "/project/src/app.ts" }), policy);
+    assert.equal(result.decision, "approve");
+  });
+
+  it("does not match non-matching glob", () => {
+    const policy: PolicyConfig = {
+      ...DENY_DEFAULT,
+      rules: [{ id: "allow-src", action_type: "write", target: "**/src/**", decision: "approve", reason: "Src OK" }],
+    };
+    const result = decide(makeIntent({ action_type: "write", target: "/project/config/db.yaml" }), policy);
+    assert.equal(result.decision, "deny");
+  });
+
+  it("matches by action_type array", () => {
+    const policy: PolicyConfig = {
+      ...DENY_DEFAULT,
+      rules: [{ id: "allow-io", action_type: ["read", "write"] as any, decision: "approve", reason: "IO OK" }],
+    };
+    const result = decide(makeIntent({ action_type: "write" }), policy);
+    assert.equal(result.decision, "approve");
+  });
+
+  it("requires all conditions to match", () => {
+    const policy: PolicyConfig = {
+      ...DENY_DEFAULT,
+      rules: [{
+        id: "bash-test",
+        tool_name: "^Bash$",
+        action_type: "execute",
+        target: "npm test*",
+        decision: "approve",
+        reason: "Test OK",
+      }],
+    };
+
+    assert.equal(decide(makeIntent({ tool_name: "Bash", action_type: "execute", target: "npm test --verbose" }), policy).decision, "approve");
+    assert.equal(decide(makeIntent({ tool_name: "Read", action_type: "execute", target: "npm test" }), policy).decision, "deny");
+    assert.equal(decide(makeIntent({ tool_name: "Bash", action_type: "read", target: "npm test" }), policy).decision, "deny");
+  });
+});
+
+describe("decide — first-match semantics", () => {
+  it("uses first matching rule", () => {
+    const policy: PolicyConfig = {
+      ...DENY_DEFAULT,
+      rules: [
+        { id: "deny-execute", action_type: "execute", decision: "deny", reason: "Deny first" },
+        { id: "approve-execute", action_type: "execute", decision: "approve", reason: "Approve second" },
+      ],
+    };
+    const result = decide(makeIntent({ action_type: "execute" }), policy);
+    assert.equal(result.decision, "deny");
+    assert.equal(result.matched_rule, "deny-execute");
+  });
+});
+
+describe("decide — modal gates", () => {
+  it("approve verdict passes box gate", () => {
+    const policy: PolicyConfig = {
+      ...APPROVE_DEFAULT,
+      rules: [{ id: "allow-all", decision: "approve", reason: "OK" }],
+      box_policy: { requireDefiniteTrue: true, requireNoObstructions: true },
+      diamond_policy: { maxSeverity: "warn" },
+    };
+    const result = decide(makeIntent(), policy);
+    assert.equal(result.decision, "approve");
+  });
+
+  it("deny verdict fails both gates", () => {
+    const policy: PolicyConfig = {
+      ...DENY_DEFAULT,
+      rules: [{ id: "deny-all", decision: "deny", reason: "Nope" }],
+      box_policy: { requireDefiniteTrue: true },
+      diamond_policy: { allowIfDefiniteFalse: false, maxSeverity: "info" },
+    };
+    const result = decide(makeIntent(), policy);
+    assert.equal(result.decision, "deny");
+  });
+
+  it("escalate verdict passes diamond gate but not box gate", () => {
+    const policy: PolicyConfig = {
+      ...DENY_DEFAULT,
+      rules: [{ id: "esc", decision: "escalate", reason: "Need confirm" }],
+      box_policy: { requireDefiniteTrue: true },
+      diamond_policy: { maxSeverity: "warn" },
+    };
+    const result = decide(makeIntent(), policy);
+    assert.equal(result.decision, "escalate");
+  });
+});
+
+describe("decide — PolicyVerdict structure", () => {
+  it("includes intent in verdict", () => {
+    const result = decide(makeIntent(), APPROVE_DEFAULT);
+    assert.equal(result.intent.tool_name, "Bash");
+  });
+
+  it("includes matched_rule", () => {
+    const policy: PolicyConfig = {
+      ...DENY_DEFAULT,
+      rules: [{ id: "my-rule", action_type: "execute", decision: "deny", reason: "blocked" }],
+    };
+    assert.equal(decide(makeIntent(), policy).matched_rule, "my-rule");
+  });
+
+  it("includes reasons", () => {
+    const policy: PolicyConfig = {
+      ...DENY_DEFAULT,
+      rules: [{ id: "r1", action_type: "execute", decision: "deny", reason: "blocked" }],
+    };
+    const result = decide(makeIntent(), policy);
+    assert.ok(result.reasons.includes("blocked"));
+  });
+
+  it("includes internal verdict with obstructions for deny", () => {
+    const policy: PolicyConfig = {
+      ...DENY_DEFAULT,
+      rules: [{ id: "r1", action_type: "execute", decision: "deny", reason: "nope" }],
+    };
+    const result = decide(makeIntent(), policy);
+    assert.equal(result.verdict.status, "Definite");
+    assert.equal(result.verdict.value, false);
+    assert.ok(result.verdict.obstructions.length > 0);
+    assert.equal(result.verdict.obstructions[0].kind, "policy_deny");
+  });
+});
+
+describe("loadPolicy", () => {
+  it("loads minimal.yaml", () => {
+    resetPolicyCache();
+    const policy = loadPolicy(join(__dirname, "..", "policies", "minimal.yaml"));
+    assert.equal(policy.name, "minimal");
+    assert.equal(policy.default_decision, "approve");
+    assert.ok(policy.rules.length >= 3);
+  });
+
+  it("loads standard.yaml", () => {
+    resetPolicyCache();
+    const policy = loadPolicy(join(__dirname, "..", "policies", "standard.yaml"));
+    assert.equal(policy.name, "standard");
+    assert.equal(policy.default_decision, "deny");
+    assert.ok(policy.box_policy);
+  });
+
+  it("loads strict.yaml", () => {
+    resetPolicyCache();
+    const policy = loadPolicy(join(__dirname, "..", "policies", "strict.yaml"));
+    assert.equal(policy.name, "strict");
+    assert.equal(policy.default_decision, "deny");
+  });
+
+  it("returns deny-all for missing file", () => {
+    resetPolicyCache();
+    const policy = loadPolicy("/nonexistent/path.yaml");
+    assert.equal(policy.default_decision, "deny");
+    assert.equal(policy.rules.length, 0);
+  });
+});
+
+describe("decide — end-to-end with loaded policy", () => {
+  it("minimal allows reads", () => {
+    resetPolicyCache();
+    const policy = loadPolicy(join(__dirname, "..", "policies", "minimal.yaml"));
+    assert.equal(decide(makeIntent({ action_type: "read" }), policy).decision, "approve");
+  });
+
+  it("minimal denies destructive", () => {
+    resetPolicyCache();
+    const policy = loadPolicy(join(__dirname, "..", "policies", "minimal.yaml"));
+    assert.equal(decide(makeIntent({ action_type: "destructive" }), policy).decision, "deny");
+  });
+
+  it("minimal escalates network", () => {
+    resetPolicyCache();
+    const policy = loadPolicy(join(__dirname, "..", "policies", "minimal.yaml"));
+    assert.equal(decide(makeIntent({ action_type: "network" }), policy).decision, "escalate");
+  });
+
+  it("strict denies writes", () => {
+    resetPolicyCache();
+    const policy = loadPolicy(join(__dirname, "..", "policies", "strict.yaml"));
+    assert.equal(decide(makeIntent({ action_type: "write" }), policy).decision, "deny");
+  });
+
+  it("strict allows reads", () => {
+    resetPolicyCache();
+    const policy = loadPolicy(join(__dirname, "..", "policies", "strict.yaml"));
+    assert.equal(decide(makeIntent({ action_type: "read" }), policy).decision, "approve");
+  });
+});

--- a/Packs/pai-governance-guard/tests/witness.test.ts
+++ b/Packs/pai-governance-guard/tests/witness.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import { strict as assert } from "node:assert";
+import { mkdirSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promote, verifyChain } from "../src/governance/witness";
+import { sha256Hex } from "../src/governance/canonical";
+import type { ActionIntent, PolicyVerdict, WitnessRecord } from "../src/governance/types";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TEST_DIR = join(__dirname, "..", ".test-witness");
+
+function makeIntent(overrides: Partial<ActionIntent> = {}): ActionIntent {
+  return {
+    tool_name: "Bash",
+    action_type: "execute",
+    target: "npm test",
+    raw_input: { command: "npm test" },
+    content_hash: "abc123",
+    timestamp: new Date().toISOString(),
+    session_id: "test-session",
+    ...overrides,
+  };
+}
+
+function makeVerdict(decision: "approve" | "deny" | "escalate" = "approve"): PolicyVerdict {
+  return {
+    decision,
+    intent: makeIntent(),
+    verdict: {
+      status: "Definite",
+      value: decision === "approve",
+      obstructions: decision === "deny" ? [{ kind: "policy_deny", detail: "test" }] : [],
+      justifications: decision === "approve" ? [{ kind: "policy_rule" }] : [],
+    },
+    matched_rule: "test-rule",
+    reasons: [`Test ${decision}`],
+  };
+}
+
+beforeEach(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true });
+  mkdirSync(TEST_DIR, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe("promote — hook output", () => {
+  it("returns allow for approved verdict", () => {
+    const { output } = promote(makeIntent(), makeVerdict("approve"), TEST_DIR);
+    assert.equal(output.hookSpecificOutput.permissionDecision, "allow");
+  });
+
+  it("returns deny for denied verdict", () => {
+    const { output } = promote(makeIntent(), makeVerdict("deny"), TEST_DIR);
+    assert.equal(output.hookSpecificOutput.permissionDecision, "deny");
+    assert.ok(output.hookSpecificOutput.permissionDecisionReason?.includes("Denied"));
+  });
+
+  it("returns ask for escalated verdict", () => {
+    const { output } = promote(makeIntent(), makeVerdict("escalate"), TEST_DIR);
+    assert.equal(output.hookSpecificOutput.permissionDecision, "ask");
+    assert.ok(output.hookSpecificOutput.permissionDecisionReason?.includes("Escalation"));
+  });
+});
+
+describe("promote — witness record", () => {
+  it("produces a valid WitnessRecord", () => {
+    const { record } = promote(makeIntent(), makeVerdict(), TEST_DIR);
+    assert.equal(record.sequence, 0);
+    assert.equal(record.session_id, "test-session");
+    assert.equal(record.tool_name, "Bash");
+    assert.equal(record.action_type, "execute");
+    assert.equal(record.decision, "approve");
+    assert.ok(record.intent_hash.length === 64);
+    assert.ok(record.verdict_hash.length === 64);
+    assert.ok(record.record_hash.length === 64);
+    assert.ok(record.prev_hash.length === 64);
+  });
+
+  it("links to GENESIS on first record", () => {
+    const { record } = promote(makeIntent(), makeVerdict(), TEST_DIR);
+    const genesisHash = sha256Hex("GENESIS");
+    assert.equal(record.prev_hash, genesisHash);
+  });
+
+  it("writes JSONL to witness directory", () => {
+    promote(makeIntent(), makeVerdict(), TEST_DIR);
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, "0");
+    const logPath = join(TEST_DIR, `witness-${year}-${month}.jsonl`);
+    assert.ok(existsSync(logPath));
+    const content = readFileSync(logPath, "utf8").trim();
+    const record = JSON.parse(content) as WitnessRecord;
+    assert.equal(record.sequence, 0);
+  });
+});
+
+describe("promote — hash chain", () => {
+  it("builds a valid chain across multiple records", () => {
+    const r1 = promote(makeIntent(), makeVerdict(), TEST_DIR).record;
+    const r2 = promote(makeIntent(), makeVerdict("deny"), TEST_DIR).record;
+    const r3 = promote(makeIntent(), makeVerdict("escalate"), TEST_DIR).record;
+
+    assert.equal(r1.sequence, 0);
+    assert.equal(r2.sequence, 1);
+    assert.equal(r3.sequence, 2);
+    assert.equal(r2.prev_hash, r1.record_hash);
+    assert.equal(r3.prev_hash, r2.record_hash);
+  });
+});
+
+describe("verifyChain", () => {
+  it("validates an empty chain", () => {
+    assert.equal(verifyChain([]), null);
+  });
+
+  it("validates a single-record chain", () => {
+    const { record } = promote(makeIntent(), makeVerdict(), TEST_DIR);
+    assert.equal(verifyChain([record]), null);
+  });
+
+  it("validates a multi-record chain", () => {
+    const r1 = promote(makeIntent(), makeVerdict(), TEST_DIR).record;
+    const r2 = promote(makeIntent(), makeVerdict("deny"), TEST_DIR).record;
+    const r3 = promote(makeIntent(), makeVerdict("escalate"), TEST_DIR).record;
+    assert.equal(verifyChain([r1, r2, r3]), null);
+  });
+
+  it("detects tampered record_hash", () => {
+    const r1 = promote(makeIntent(), makeVerdict(), TEST_DIR).record;
+    const tampered = { ...r1, record_hash: "0".repeat(64) };
+    const error = verifyChain([tampered]);
+    assert.ok(error);
+    assert.ok(error.includes("tampered"));
+  });
+
+  it("detects broken chain link", () => {
+    const r1 = promote(makeIntent(), makeVerdict(), TEST_DIR).record;
+    const r2 = promote(makeIntent(), makeVerdict("deny"), TEST_DIR).record;
+    const broken = { ...r2, prev_hash: "0".repeat(64) };
+    const error = verifyChain([r1, broken]);
+    assert.ok(error);
+  });
+
+  it("detects sequence gap", () => {
+    const r1 = promote(makeIntent(), makeVerdict(), TEST_DIR).record;
+    const r2 = promote(makeIntent(), makeVerdict("deny"), TEST_DIR).record;
+    const gapped = { ...r2, sequence: 5 };
+    const error = verifyChain([r1, gapped]);
+    assert.ok(error);
+  });
+});
+
+describe("promote — target truncation", () => {
+  it("truncates long targets", () => {
+    const intent = makeIntent({ target: "x".repeat(500) });
+    const { record } = promote(intent, makeVerdict(), TEST_DIR);
+    assert.ok(record.target.length <= 203);
+  });
+
+  it("preserves short targets", () => {
+    const { record } = promote(makeIntent({ target: "npm test" }), makeVerdict(), TEST_DIR);
+    assert.equal(record.target, "npm test");
+  });
+});

--- a/Packs/pai-governance-guard/tests/yaml-parse.test.ts
+++ b/Packs/pai-governance-guard/tests/yaml-parse.test.ts
@@ -1,0 +1,180 @@
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseYaml } from "../src/governance/yaml-parse";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe("YAML parser — scalars", () => {
+  it("parses booleans", () => {
+    const result = parseYaml("a: true\nb: false\nc: True\nd: FALSE") as any;
+    assert.equal(result.a, true);
+    assert.equal(result.b, false);
+    assert.equal(result.c, true);
+    assert.equal(result.d, false);
+  });
+
+  it("parses integers", () => {
+    const result = parseYaml("x: 42\ny: -7\nz: 0") as any;
+    assert.equal(result.x, 42);
+    assert.equal(result.y, -7);
+    assert.equal(result.z, 0);
+  });
+
+  it("parses floats", () => {
+    const result = parseYaml("pi: 3.14\nneg: -0.5") as any;
+    assert.equal(result.pi, 3.14);
+    assert.equal(result.neg, -0.5);
+  });
+
+  it("parses quoted strings", () => {
+    const result = parseYaml('a: "hello"\nb: \'world\'') as any;
+    assert.equal(result.a, "hello");
+    assert.equal(result.b, "world");
+  });
+
+  it("parses unquoted strings", () => {
+    const result = parseYaml("name: standard") as any;
+    assert.equal(result.name, "standard");
+  });
+
+  it("parses null values", () => {
+    const result = parseYaml("a: null\nb: ~") as any;
+    assert.equal(result.a, null);
+    assert.equal(result.b, null);
+  });
+});
+
+describe("YAML parser — mappings", () => {
+  it("parses flat mappings", () => {
+    const result = parseYaml("a: 1\nb: 2\nc: 3") as any;
+    assert.deepEqual(result, { a: 1, b: 2, c: 3 });
+  });
+
+  it("parses nested mappings", () => {
+    const yaml = `parent:
+  child1: value1
+  child2: value2`;
+    const result = parseYaml(yaml) as any;
+    assert.deepEqual(result, { parent: { child1: "value1", child2: "value2" } });
+  });
+
+  it("parses deeply nested mappings", () => {
+    const yaml = `a:
+  b:
+    c: deep`;
+    const result = parseYaml(yaml) as any;
+    assert.equal(result.a.b.c, "deep");
+  });
+});
+
+describe("YAML parser — sequences", () => {
+  it("parses simple sequences", () => {
+    const yaml = `items:
+  - one
+  - two
+  - three`;
+    const result = parseYaml(yaml) as any;
+    assert.deepEqual(result.items, ["one", "two", "three"]);
+  });
+
+  it("parses sequences of mappings", () => {
+    const yaml = `rules:
+  - id: rule1
+    decision: deny
+  - id: rule2
+    decision: approve`;
+    const result = parseYaml(yaml) as any;
+    assert.equal(result.rules.length, 2);
+    assert.equal(result.rules[0].id, "rule1");
+    assert.equal(result.rules[0].decision, "deny");
+    assert.equal(result.rules[1].id, "rule2");
+    assert.equal(result.rules[1].decision, "approve");
+  });
+
+  it("parses mixed scalar types in sequences", () => {
+    const yaml = `items:
+  - 42
+  - true
+  - hello`;
+    const result = parseYaml(yaml) as any;
+    assert.deepEqual(result.items, [42, true, "hello"]);
+  });
+});
+
+describe("YAML parser — comments", () => {
+  it("strips full-line comments", () => {
+    const yaml = `# This is a comment
+key: value
+# Another comment`;
+    const result = parseYaml(yaml) as any;
+    assert.equal(result.key, "value");
+  });
+
+  it("strips inline comments", () => {
+    const yaml = `key: value # inline comment`;
+    const result = parseYaml(yaml) as any;
+    assert.equal(result.key, "value");
+  });
+
+  it("preserves # in quoted strings", () => {
+    const yaml = `key: "value # not a comment"`;
+    const result = parseYaml(yaml) as any;
+    assert.equal(result.key, "value # not a comment");
+  });
+});
+
+describe("YAML parser — edge cases", () => {
+  it("throws on empty input", () => {
+    assert.throws(() => parseYaml(""), /empty document/);
+  });
+
+  it("throws on whitespace-only input", () => {
+    assert.throws(() => parseYaml("   \n  \n  "), /empty document/);
+  });
+
+  it("handles colons in quoted values", () => {
+    const yaml = 'url: "https://example.com"';
+    const result = parseYaml(yaml) as any;
+    assert.equal(result.url, "https://example.com");
+  });
+});
+
+describe("YAML parser — policy presets", () => {
+  const policiesDir = join(__dirname, "..", "policies");
+
+  it("parses minimal.yaml", () => {
+    const raw = readFileSync(join(policiesDir, "minimal.yaml"), "utf8");
+    const result = parseYaml(raw) as any;
+    assert.equal(result.name, "minimal");
+    assert.equal(result.default_decision, "approve");
+    assert.ok(Array.isArray(result.rules));
+    assert.ok(result.rules.length >= 3);
+    assert.equal(result.rules[0].id, "block-destructive");
+    assert.equal(result.rules[0].decision, "deny");
+  });
+
+  it("parses standard.yaml", () => {
+    const raw = readFileSync(join(policiesDir, "standard.yaml"), "utf8");
+    const result = parseYaml(raw) as any;
+    assert.equal(result.name, "standard");
+    assert.equal(result.default_decision, "deny");
+    assert.ok(result.rules.length >= 10);
+    assert.ok(result.box_policy);
+    assert.equal(result.box_policy.requireDefiniteTrue, true);
+    assert.ok(result.diamond_policy);
+  });
+
+  it("parses strict.yaml", () => {
+    const raw = readFileSync(join(policiesDir, "strict.yaml"), "utf8");
+    const result = parseYaml(raw) as any;
+    assert.equal(result.name, "strict");
+    assert.equal(result.default_decision, "deny");
+    assert.equal(result.rules[0].id, "allow-read");
+    assert.equal(result.rules[0].decision, "approve");
+    assert.ok(result.box_policy);
+    assert.equal(result.box_policy.maxSeverity, "info");
+  });
+});

--- a/Packs/pai-governance-guard/tsconfig.json
+++ b/Packs/pai-governance-guard/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "declaration": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

**pai-governance-guard** adds a deterministic governance layer that complements SecurityValidator by addressing a different class of risk: actions that aren't pattern-matchable as dangerous but exceed authorized scope.

SecurityValidator catches known-dangerous commands (`rm -rf`, credential access, destructive git ops). Governance-guard addresses the structural question: *should this action happen at all, given the user's policy?*

**Repo:** https://github.com/MetaCortex-Dynamics/governance-guard

---

## The Gap This Fills

PAI's current security model is defense-in-depth with two layers:

1. **Pre-commit validation** (`validate-protected.ts`) — scans for credential patterns before commits
2. **Runtime validation** (`SecurityValidator.hook.ts`) — pattern-matches commands against `patterns.yaml` tiers

Both layers are valuable and this pack doesn't replace either of them. But both operate on the same principle: **known-bad pattern detection.** They block things that look dangerous.

The gap is actions that don't look dangerous but aren't authorized:

- Creating accounts on external services
- Sending API requests to third-party services the user never approved
- Writing to directories outside the project scope
- Invoking tools with side effects the user didn't request

These actions don't match any regex tier. They pass SecurityValidator cleanly. But they exceed the user's intended authorization. The agent proposed the action, evaluated whether it was appropriate, and executed it — all in the same computational pathway.

PAI Principle #5 says: *"AI is probabilistic; your infrastructure shouldn't be."* Governance-guard makes the authorization decision deterministic.

---

## How It Works

Three-phase pipeline as a PreToolUse hook:

```
Tool Call → PROPOSE → DECIDE → PROMOTE → Execution
               │          │         │
           serialize   evaluate   gate
           + hash      against    on
           intent      policy     verdict
                       (no LLM)
```

**PROPOSE** — Serializes the tool call into a structured `ActionIntent` (tool name, action type, target, parameters). Binds with SHA-256 hash.

**DECIDE** — Evaluates the intent against a user-defined YAML policy. Pure function. No LLM. No interpretation. Policy + intent → verdict (approve / deny / escalate). Default: deny.

**PROMOTE** — Approved actions proceed. Denied actions are blocked (exit code 2). Escalated actions prompt the user. Every decision is recorded in a hash-chained witness log.

---

## How It Integrates With PAI

This pack is designed as a **companion to SecurityValidator**, not a replacement:

| Layer | What It Catches | Mechanism |
|---|---|---|
| `validate-protected.ts` | Credential leaks in commits | Pattern matching on file content |
| `SecurityValidator.hook.ts` | Known-dangerous commands | Regex tiers on bash commands |
| **`governance-guard`** | Unauthorized-but-not-dangerous actions | Deterministic policy evaluation on structured intent |

**Hook registration:** PreToolUse with `*` matcher (evaluates all tool calls, not just Bash). Runs alongside SecurityValidator — both hooks fire, both must pass.

**Policy presets:** Three YAML presets that match PAI's security philosophy:
- `minimal.yaml` — Blocks destructive + credential access (similar scope to SecurityValidator, structured format)
- `standard.yaml` — Deny-default with explicit allows (recommended)
- `strict.yaml` — Allow reads only, deny everything else

**Witness chain:** JSONL log at `$PAI_DIR/MEMORY/GOVERNANCE/` — integrates with PAI's existing MEMORY system. Every governance decision is captured as a learning signal, consistent with PAI's continuous learning architecture.

**Zero dependencies.** Custom YAML parser, Node built-in crypto. Matches PAI's principle of deterministic infrastructure.

---

## What's In the Pack

```
Packs/pai-governance-guard/
├── README.md                    # Pack documentation
├── INSTALL.md                   # AI-assisted installation wizard
├── VERIFY.md                    # Verification checklist
├── src/
│   ├── hooks/
│   │   └── GovernanceGuard.hook.ts   # PreToolUse hook
│   ├── governance/
│   │   ├── types.ts                  # Type definitions
│   │   ├── canonical.ts             # Deterministic hashing (JCS + SHA-256)
│   │   ├── intent.ts                # PROPOSE: ActionIntent serialization
│   │   ├── policy-engine.ts         # DECIDE: Deterministic evaluation
│   │   ├── witness.ts               # PROMOTE: Hash-chained audit log
│   │   └── yaml-parse.ts            # Zero-dep YAML parser
│   └── config/
│       └── settings-fragment.json   # Hook registration config
├── policies/
│   ├── minimal.yaml
│   ├── standard.yaml
│   └── strict.yaml
├── references/
│   └── policy-schema.md            # Policy file format docs
└── tests/
    ├── canonical.test.ts
    ├── yaml-parse.test.ts
    ├── intent.test.ts
    ├── policy-engine.test.ts
    ├── witness.test.ts
    ├── integration.test.ts
    └── adversarial.test.ts
```

### Tests

146 tests passing across 7 test suites:
- `canonical.test.ts` — Hash computation, deterministic serialization
- `yaml-parse.test.ts` — YAML parser, all policy presets
- `intent.test.ts` — Action classification for all tool types
- `policy-engine.test.ts` — Rule matching, modal gates, policy loading
- `witness.test.ts` — Hash chain integrity, tamper detection
- `integration.test.ts` — End-to-end pipeline with all policy presets
- `adversarial.test.ts` — Spoofed hashes, path traversal, replay attacks, malformed YAML

---

## Alignment With PAI Principles

| PAI Principle | How governance-guard implements it |
|---|---|
| **#5: Deterministic Infrastructure** | Decision layer is a pure function — same policy + same intent = same verdict, every time |
| **#7: Spec / Test / Evals First** | 146 tests including adversarial coverage, written before implementation |
| **#8: UNIX Philosophy** | Does one thing (authorization decisions), composes with existing security layers |
| **#9: ENG / SRE Principles** | Hash-chained witness log enables incident reconstruction and compliance auditing |
| **#4: Scaffolding > Model** | Authorization decisions removed from the LLM entirely — structural, not behavioral |

---

## What This Does NOT Do

- Does not replace SecurityValidator (complementary, not competitive)
- Does not verify LLM intent accuracy (fundamental limitation of wrapping an untrusted component)
- Does not perform semantic consequence analysis (evaluates structural properties against policy rules)
- Witness chain is tamper-evident, not tamper-proof (filesystem deletion is detectable but not preventable)

---

## About

Built by [MetaCortex Dynamics](https://github.com/MetaCortex-Dynamics) — governance infrastructure for autonomous systems.

The core implementation is also available as a [standalone package](https://github.com/MetaCortex-Dynamics/governance-guard).

**AI disclosure:** Architecture review and spec drafting assisted by Claude. All code reviewed, understood, and tested by the author. The PROPOSE/DECIDE/PROMOTE governance architecture is original work. 146/146 tests fully passing.

**License:** MIT