### PR TITLE
feat(voice): add global voice toggle via daidentity.voices.enabled

### DIFF
--- a/Releases/v4.0.3/.claude/PAI/Tools/BuildCLAUDE.ts
+++ b/Releases/v4.0.3/.claude/PAI/Tools/BuildCLAUDE.ts
@@ -97,6 +97,14 @@ export function build(): { rebuilt: boolean; reason?: string } {
     content = content.replaceAll(key, value);
   }
 
+  // Strip voice curl instructions when voice is globally disabled
+  const settings = existsSync(SETTINGS_PATH)
+    ? JSON.parse(readFileSync(SETTINGS_PATH, "utf-8"))
+    : {};
+  if (settings.daidentity?.voices?.enabled === false) {
+    content = content.replace(/\*\*Voice:\*\* `curl[^`]*`\n?/g, '');
+  }
+
   // Check if output already matches
   if (existsSync(OUTPUT_PATH)) {
     const existing = readFileSync(OUTPUT_PATH, "utf-8");

--- a/Releases/v4.0.3/.claude/PAI/Tools/RebuildPAI.ts
+++ b/Releases/v4.0.3/.claude/PAI/Tools/RebuildPAI.ts
@@ -124,6 +124,15 @@ for (const file of components) {
 const variables = loadVariables();
 output = resolveVariables(output, variables);
 
+// Strip voice instructions when voice is globally disabled
+try {
+  const settings = JSON.parse(readFileSync(SETTINGS_PATH, "utf-8"));
+  if (settings.daidentity?.voices?.enabled === false) {
+    output = output.replace(/\*\*Voice:\*\* `curl[^`]*`\n?/g, '');
+    output = output.replace(/## Voice Announcements[\s\S]*?(?=\n## )/g, '');
+  }
+} catch { /* settings unavailable — leave voice intact */ }
+
 // Write output
 writeFileSync(OUTPUT_FILE, output);
 

--- a/Releases/v4.0.3/.claude/hooks/UpdateTabTitle.hook.ts
+++ b/Releases/v4.0.3/.claude/hooks/UpdateTabTitle.hook.ts
@@ -220,7 +220,9 @@ async function main() {
     const voiceContent = voiceSummary || (quickTitle && isValidWorkingTitle(quickTitle) ? quickTitle : null);
     if (voiceContent) {
       const identity = getIdentity();
-      try {
+      if (!identity.voiceEnabled) {
+        console.error('[UpdateTabTitle] Voice OFF (disabled in settings)');
+      } else try {
         await fetch('http://localhost:8888/notify', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/Releases/v4.0.3/.claude/hooks/VoiceCompletion.hook.ts
+++ b/Releases/v4.0.3/.claude/hooks/VoiceCompletion.hook.ts
@@ -18,6 +18,7 @@
 
 import { readHookInput, parseTranscriptFromInput } from './lib/hook-io';
 import { handleVoice } from './handlers/VoiceNotification';
+import { getIdentity } from './lib/identity';
 
 /**
  * Voice gate: only main terminal sessions get voice.
@@ -37,6 +38,12 @@ async function main() {
   // Voice gate: skip subagent sessions
   if (!isMainSession()) {
     console.error('[VoiceCompletion] Voice OFF (not main session)');
+    process.exit(0);
+  }
+
+  // Voice gate: skip when globally disabled via daidentity.voices.enabled
+  if (!getIdentity().voiceEnabled) {
+    console.error('[VoiceCompletion] Voice OFF (disabled in settings)');
     process.exit(0);
   }
 

--- a/Releases/v4.0.3/.claude/hooks/handlers/DocCrossRefIntegrity.ts
+++ b/Releases/v4.0.3/.claude/hooks/handlers/DocCrossRefIntegrity.ts
@@ -359,6 +359,9 @@ function checkHookCounts(docsToCheck: string[], actualCount: number): DriftItem[
 // ============================================================================
 
 async function notifyVoice(message: string): Promise<void> {
+  // Global voice toggle — skip when disabled
+  if (!getIdentity().voiceEnabled) return;
+
   try {
     await fetch('http://localhost:8888/notify', {
       method: 'POST',

--- a/Releases/v4.0.3/.claude/hooks/handlers/VoiceNotification.ts
+++ b/Releases/v4.0.3/.claude/hooks/handlers/VoiceNotification.ts
@@ -141,6 +141,9 @@ async function sendNotification(payload: ElevenLabsNotificationPayload, sessionI
  * Uses ElevenLabs TTS via the voice server.
  */
 export async function handleVoice(parsed: ParsedTranscript, sessionId: string): Promise<void> {
+  // Global voice toggle — skip all voice when disabled
+  if (!DA_IDENTITY.voiceEnabled) return;
+
   let voiceCompletion = parsed.voiceCompletion;
 
   // Validate voice completion

--- a/Releases/v4.0.3/.claude/hooks/lib/identity.ts
+++ b/Releases/v4.0.3/.claude/hooks/lib/identity.ts
@@ -57,6 +57,7 @@ export interface Identity {
   displayName: string;
   mainDAVoiceID: string;
   color: string;
+  voiceEnabled: boolean;
   voice?: VoiceProsody;
   personality?: VoicePersonality;
 }
@@ -117,6 +118,7 @@ export function getIdentity(): Identity {
     displayName: daidentity.displayName || daidentity.name || envDA || DEFAULT_IDENTITY.displayName,
     mainDAVoiceID: voiceConfig?.voiceId || (daidentity as any).voiceId || daidentity.mainDAVoiceID || DEFAULT_IDENTITY.mainDAVoiceID,
     color: daidentity.color || DEFAULT_IDENTITY.color,
+    voiceEnabled: voices.enabled !== false,
     voice: voiceConfig as VoiceProsody | undefined,
     personality: (daidentity as any).personality as VoicePersonality | undefined,
   };

--- a/Releases/v4.0.3/.claude/settings.json
+++ b/Releases/v4.0.3/.claude/settings.json
@@ -913,6 +913,7 @@
     "displayName": "{DAIDENTITY.NAME}",
     "color": "#3B82F6",
     "voices": {
+      "enabled": true,
       "main": {
         "_docs": "Primary DA voice - stability 0.85 for consistent output, style 0.3 for minimal variation",
         "voiceId": "{YOUR_ELEVENLABS_VOICE_ID}",


### PR DESCRIPTION
## Summary

- Adds `daidentity.voices.enabled` master toggle to suppress all TTS voice calls system-wide
- Guards all 6 voice dispatch points across hooks, handlers, and build-time prompt assembly
- Backward compatible: missing key defaults to `true` via `!== false` pattern — no behavior change for existing installs

Supersedes #740 (closed — targeted v3.0 architecture). Reimplemented against v4.0.3 hook/voice structure.

## Problem

Users who don't run the VoiceServer get silent `fetch` failures (connection refused) on every response completion and prompt receipt. There is no way to disable voice system-wide — you can only stop the VoiceServer process, but hooks still attempt connections and the model still generates curl commands that waste output tokens.

## Solution

One setting, three defense layers:

### Setting

```json
"daidentity": {
  "voices": {
    "enabled": true,
    "main": { ... },
    "algorithm": { ... }
  }
}
```

### Layer 1: Build-time stripping (primary)

When `enabled: false`, the build tools strip voice curl instructions so the model never sees them:

| File | What it strips |
|------|---------------|
| `PAI/Tools/BuildCLAUDE.ts` | `**Voice:** \`curl...\`` lines from generated CLAUDE.md |
| `PAI/Tools/RebuildPAI.ts` | `**Voice:** \`curl...\`` blocks + Voice Announcements section from SKILL.md |

**Result:** Zero voice curl instructions reach the prompt. No wasted output tokens.

### Layer 2: Hook-level gates (secondary)

| File | Guard |
|------|-------|
| `hooks/VoiceCompletion.hook.ts` | Early `process.exit(0)` if `!identity.voiceEnabled` |
| `hooks/UpdateTabTitle.hook.ts` | Skip voice fetch if `!identity.voiceEnabled` |

### Layer 3: Handler-level gates (belt-and-suspenders)

| File | Guard |
|------|-------|
| `hooks/handlers/VoiceNotification.ts` | Early return at top of `handleVoice()` |
| `hooks/handlers/DocCrossRefIntegrity.ts` | Early return at top of `notifyVoice()` |

### Central resolver

`hooks/lib/identity.ts`: Added `voiceEnabled: boolean` to `Identity` interface, resolved from `settings.daidentity.voices.enabled !== false`.

## What does NOT change

- `PAI/Algorithm/v3.5.0.md` — curls stripped at SKILL.md build time, source untouched
- `VoiceServer/` — server unchanged, just never called when disabled
- `CLAUDE.md.template` — source untouched, curls stripped during CLAUDE.md generation

## Community context

Incorporates feedback from #740:
- @virtualian's discovery that PreToolUse hooks can't silently deny — not an issue here since we gate at Stop/PostToolUse hooks
- @nikolainobadi's #776 centralized `pai-notify` approach — complementary, doesn't conflict
- Per-channel toggle architecture (`notifications.voice.enabled` / `notifications.desktop.enabled`) noted as future direction

## Test plan

- [x] Set `voices.enabled: false` → no voice calls fire (all 4 programmatic paths skip)
- [x] Set `voices.enabled: false` → `bun BuildCLAUDE.ts` produces CLAUDE.md with zero voice curls
- [x] Set `voices.enabled: false` → `bun RebuildPAI.ts` produces SKILL.md with zero voice curls
- [x] Set `voices.enabled: true` → voice works normally
- [x] Remove `enabled` key entirely → voice works normally (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)