### PR TITLE
feat(council): file-first output & session recovery (v4.0.3)

### DIFF
--- a/Releases/v4.0.3/.claude/skills/Thinking/Council/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Thinking/Council/SKILL.md
@@ -51,6 +51,7 @@ Running the **WorkflowName** workflow in the **Council** skill to ACTION...
 |---------|----------|
 | Full structured debate (3 rounds, visible transcript) | `Workflows/Debate.md` |
 | Quick consensus check (1 round, fast) | `Workflows/Quick.md` |
+| Resume interrupted session | `Workflows/Recovery.md` |
 | Pure adversarial analysis | RedTeam skill |
 
 ## Quick Reference
@@ -59,6 +60,7 @@ Running the **WorkflowName** workflow in the **Council** skill to ACTION...
 |----------|---------|--------|--------|
 | **DEBATE** | Full structured discussion | 3 | Complete transcript + synthesis |
 | **QUICK** | Fast perspective check | 1 | Initial positions only |
+| **RECOVERY** | Resume interrupted session | Remaining | Continue from last checkpoint |
 
 ## Context Files
 
@@ -74,6 +76,8 @@ Running the **WorkflowName** workflow in the **Council** skill to ACTION...
 
 **Speed:** Parallel execution within rounds, sequential between rounds. A 3-round debate of 4 agents = 12 agent calls but only 3 sequential waits. Complete in 30-90 seconds.
 
+**Resilience:** File-first output means session state survives context compaction and rate limits. See `Workflows/Recovery.md` for resuming interrupted sessions.
+
 ## Examples
 
 ```
@@ -85,6 +89,9 @@ Running the **WorkflowName** workflow in the **Council** skill to ACTION...
 
 "Council with security: Evaluate this auth approach"
 -> DEBATE with Security agent added
+
+"Council recovery: Resume session 20260202-143052-a1b2c3d4"
+-> RECOVERY workflow (partial rerun) -> Continue from checkpoint
 ```
 
 ## Integration

--- a/Releases/v4.0.3/.claude/skills/Thinking/Council/Workflows/Debate.md
+++ b/Releases/v4.0.3/.claude/skills/Thinking/Council/Workflows/Debate.md
@@ -20,6 +20,34 @@ Running the **Debate** workflow in the **Council** skill to run multi-agent deba
 
 ## Execution
 
+### Step 0: Initialize Session
+
+Generate a session ID and create the session directory for file-first output.
+
+**Session ID format:** `YYYYMMDD-HHMMSS-[8 hex chars]` (e.g., `20260302-143052-a1b2c3d4`)
+
+```bash
+SESSION_ID="$(date +%Y%m%d-%H%M%S)-$(openssl rand -hex 4)"
+SESSION_DIR="$HOME/.claude/MEMORY/STATE/council-sessions/$SESSION_ID"
+mkdir -p "$SESSION_DIR"
+```
+
+Write `metadata.json` to the session directory:
+
+```bash
+cat <<EOF > "$SESSION_DIR/metadata.json"
+{
+  "session_id": "$SESSION_ID",
+  "topic": "[The topic being debated]",
+  "members": ["architect", "designer", "engineer", "researcher"],
+  "rounds_total": 3,
+  "rounds_completed": 0,
+  "status": "in_progress",
+  "started": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+```
+
 ### Step 1: Announce the Council
 
 Output the debate header:
@@ -27,8 +55,10 @@ Output the debate header:
 ```markdown
 ## Council Debate: [Topic]
 
+**Session:** $SESSION_ID
+**Output:** ~/.claude/MEMORY/STATE/council-sessions/$SESSION_ID/
 **Council Members:** [List agents participating]
-**Rounds:** 3 (Positions → Responses → Synthesis)
+**Rounds:** 3 (Positions -> Responses -> Synthesis)
 ```
 
 ### Step 2: Round 1 - Initial Positions
@@ -75,6 +105,17 @@ Your perspective focuses on: [agent's domain]
 [Response]
 ```
 
+**Write round to session directory:**
+```bash
+cat <<'EOF' > "$SESSION_DIR/round-1.md"
+### Round 1: Initial Positions
+
+[Full Round 1 content as output above]
+EOF
+```
+
+Update `metadata.json` field `rounds_completed` to `1`.
+
 ### Step 3: Round 2 - Responses & Challenges
 
 Launch 4 parallel Task calls with Round 1 transcript included.
@@ -117,6 +158,17 @@ The value is in genuine intellectual friction—engage with their actual argumen
 [Response referencing others' points]
 ```
 
+**Write round to session directory:**
+```bash
+cat <<'EOF' > "$SESSION_DIR/round-2.md"
+### Round 2: Responses & Challenges
+
+[Full Round 2 content as output above]
+EOF
+```
+
+Update `metadata.json` field `rounds_completed` to `2`.
+
 ### Step 4: Round 3 - Synthesis
 
 Launch 4 parallel Task calls with Round 1 + Round 2 transcripts.
@@ -158,6 +210,17 @@ Be honest about remaining disagreements—forced consensus is worse than acknowl
 [Final synthesis]
 ```
 
+**Write round to session directory:**
+```bash
+cat <<'EOF' > "$SESSION_DIR/round-3.md"
+### Round 3: Synthesis
+
+[Full Round 3 content as output above]
+EOF
+```
+
+Update `metadata.json` field `rounds_completed` to `3`.
+
 ### Step 5: Council Synthesis
 
 After all rounds complete, synthesize the debate:
@@ -177,14 +240,52 @@ After all rounds complete, synthesize the debate:
 [Based on convergence and weight of arguments, the recommended approach is...]
 ```
 
+### Step 6: Archive Session
+
+Archive the complete session to `~/.claude/MEMORY/RESEARCH/`:
+
+```bash
+MONTH=$(date +%Y-%m)
+ARCHIVE_DIR="$HOME/.claude/MEMORY/RESEARCH/$MONTH"
+mkdir -p "$ARCHIVE_DIR"
+
+# Combine all rounds + synthesis into a single archived file
+TOPIC_SLUG=$(echo "[topic]" | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | tr -cd 'a-z0-9-')
+ARCHIVE_FILE="$ARCHIVE_DIR/$(date +%Y-%m-%d-%H%M%S)_COUNCIL_${TOPIC_SLUG}.md"
+
+cat "$SESSION_DIR/round-1.md" "$SESSION_DIR/round-2.md" "$SESSION_DIR/round-3.md" > "$ARCHIVE_FILE"
+# Append synthesis to archive
+cat <<'EOF' >> "$ARCHIVE_FILE"
+
+[Council Synthesis content from Step 5]
+EOF
+```
+
+Update `metadata.json`: set `status` to `"complete"`, add `"archived_to"` field with archive path.
+
+## Interruption Handling
+
+If the session is interrupted (rate limit, timeout, context compaction):
+
+1. Session state is preserved in `~/.claude/MEMORY/STATE/council-sessions/$SESSION_ID/`
+2. `metadata.json` records which rounds completed
+3. Any completed round files (`round-N.md`) contain full outputs
+
+**To resume:** Use the Recovery workflow with the session ID:
+```
+Council recovery: Resume session $SESSION_ID
+```
+
+See `Workflows/Recovery.md` for full/partial rerun modes.
+
 ## Custom Council Members
 
 If user specifies custom members, adjust accordingly:
 
-- "Council with security" → Add pentester agent
-- "Council with intern" → Add intern agent (fresh perspective)
-- "Council with writer" → Add writer agent (communication focus)
-- Omit agents: "Just architect and engineer" → Only those two
+- "Council with security" -> Add pentester agent
+- "Council with intern" -> Add intern agent (fresh perspective)
+- "Council with writer" -> Add writer agent (communication focus)
+- Omit agents: "Just architect and engineer" -> Only those two
 
 ## Agent Type Mapping
 
@@ -209,4 +310,4 @@ If user specifies custom members, adjust accordingly:
 
 ## Done
 
-Debate complete. The transcript shows the full intellectual journey from initial positions through challenges to synthesis.
+Debate complete. The transcript shows the full intellectual journey from initial positions through challenges to synthesis. Full session archived to `~/.claude/MEMORY/RESEARCH/` and session state preserved in `~/.claude/MEMORY/STATE/council-sessions/$SESSION_ID/`.

--- a/Releases/v4.0.3/.claude/skills/Thinking/Council/Workflows/Recovery.md
+++ b/Releases/v4.0.3/.claude/skills/Thinking/Council/Workflows/Recovery.md
@@ -1,0 +1,181 @@
+# Recovery Workflow
+
+Resume an interrupted Council session or rerun with partial prior results.
+
+## Voice Notification
+
+```bash
+curl -s -X POST http://localhost:8888/notify \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Running the Recovery workflow in the Council skill to resume interrupted session"}' \
+  > /dev/null 2>&1 &
+```
+
+Running the **Recovery** workflow in the **Council** skill to resume interrupted session...
+
+## When to Use
+
+- Session was interrupted by rate limit, timeout, or context compaction
+- Partial round outputs were saved before interruption
+- You want to continue without re-running completed work
+
+## Prerequisites
+
+- Session ID (the workflow resolves this to a session directory under `~/.claude/MEMORY/STATE/council-sessions/`)
+- Prior round outputs (partial or complete)
+- Knowledge of which agents completed / which didn't
+
+## Recovery Modes
+
+### Full Rerun
+
+Re-run all agents for all remaining rounds. Ignores prior partial outputs.
+
+**Use when:**
+- Only 1-2 agents completed before interruption
+- Significant time has passed (context may have drifted)
+- User explicitly prefers fresh run
+
+**Invoke:** `"Council recovery (full rerun): {topic}"`
+
+### Partial Rerun
+
+Keep completed agent outputs, only rerun missing agents.
+
+**Use when:**
+- 3+ agents completed Round 1
+- Interruption happened mid-round
+- Time-sensitive and want to preserve progress
+
+**Invoke:** `"Council recovery (partial): Resume session {session-id}"`
+
+### Short Form (Alias)
+
+`"Council recovery: Resume session {session-id}"` — defaults to partial rerun.
+
+## Execution
+
+### Step 1: Load Session State
+
+**Session ID and path handling:** The session root is a fixed base directory: `~/.claude/MEMORY/STATE/council-sessions/`.
+- Only accept **session IDs**, not arbitrary directory paths.
+- Validate the ID matches the expected format `YYYYMMDD-HHMMSS-[hex]` (e.g., `20260202-235539-a1b2c3d4`).
+- Reject IDs containing path traversal characters (`/`, `\`, `..`).
+- Always resolve the session directory as `{session-root}/{session-id}/` — never allow user-provided absolute paths.
+
+Read the session directory:
+```
+~/.claude/MEMORY/STATE/council-sessions/{session-id}/
+├── metadata.json     # Topic, members, timing
+├── round-1.md        # Partial or complete
+├── round-2.md        # Partial or complete (if exists)
+└── round-3.md        # (if exists)
+```
+
+Parse `metadata.json` to determine:
+- Which round was interrupted
+- Which agents completed that round
+- Which agents need to be re-run
+
+### Step 2: Announce Recovery
+
+```markdown
+## Council Recovery: [Topic]
+
+**Session ID:** {session-id}
+**Mode:** [Full Rerun | Partial Rerun]
+**Prior Progress:**
+- Round 1: [Complete | Partial - {N}/4 agents]
+- Round 2: [Complete | Partial | Not started]
+- Round 3: [Complete | Partial | Not started]
+
+**Recovery Plan:**
+- [List of agents to rerun]
+- [Rounds to complete]
+```
+
+### Step 3a: Full Rerun
+
+If full rerun mode:
+
+1. Archive prior session state to `~/.claude/MEMORY/RESEARCH/` with `_INTERRUPTED` suffix
+2. Start fresh session with new session ID
+3. Follow standard Debate workflow from Round 1
+
+### Step 3b: Partial Rerun
+
+If partial rerun mode:
+
+1. Load completed agent outputs from prior round
+2. Launch only the missing agents with this context:
+
+```
+You are [Agent Name], [brief role description].
+
+COUNCIL RECOVERY - ROUND {N}: [PHASE NAME]
+
+Topic: [The topic being debated]
+
+Context: This is a recovery from an interrupted session. The following agents already completed Round {N}:
+
+[Prior agent outputs from this round]
+
+Your task:
+- Provide your Round {N} response
+- You may reference the prior agents' points
+- Stay consistent with the established discussion
+- [Standard round instructions]
+```
+
+3. Merge recovered outputs with new outputs
+4. Continue to next round
+
+### Step 4: Resume Normal Flow
+
+After recovery round completes:
+- Update session state files
+- Continue with next round (or synthesis if Round 3 complete)
+- Follow standard Debate workflow steps
+
+### Step 5: Mark Recovery Complete
+
+After synthesis:
+```markdown
+**Recovery Complete:** Session resumed from Round {N}. Full transcript archived.
+```
+
+Archive final output to:
+```
+~/.claude/MEMORY/RESEARCH/YYYY-MM/YYYY-MM-DD-HHMMSS_COUNCIL_{topic-slug}_RECOVERED.md
+```
+
+## Diff-Only Mode (Partial Rerun Optimization)
+
+For partial reruns where 3+ agents completed, instruct recovered agents:
+
+```
+You are joining a council session in progress. The following perspectives have already been shared:
+
+[Prior agent outputs]
+
+Your task is to add NET-NEW insights only:
+- Do not repeat points already made
+- Focus on what the prior agents missed
+- State your unique perspective
+- If you agree with prior points, briefly acknowledge and move on
+```
+
+This reduces token usage while preserving the intellectual friction value.
+
+## Error Handling
+
+| Scenario | Action |
+|----------|--------|
+| Session directory not found | Ask user for session ID or start fresh |
+| metadata.json corrupted | Start fresh, note what was lost |
+| Round files missing | Treat as partial, rerun missing rounds |
+| All agents completed but synthesis missing | Skip to synthesis step |
+
+---
+
+**Last Updated:** 2026-03-02


### PR DESCRIPTION
## Summary

- Ports file-first output and session recovery from closed PR #738 (v3.0) to v4.0.3 Council skill at `skills/Thinking/Council/`
- Debate rounds now persist to `~/.claude/MEMORY/STATE/council-sessions/` after each round, surviving rate limits, timeouts, and context compaction
- New Recovery workflow enables full or partial rerun of interrupted sessions

## Changes

| File | What |
|------|------|
| `SKILL.md` | Recovery routing, quick reference row, Resilience philosophy, recovery example |
| `Workflows/Debate.md` | Step 0 session init, per-round file writes, Step 6 archival, interruption handling |
| `Workflows/Recovery.md` | New — full/partial rerun modes, diff-only optimization, error handling |

## Context

PR #738 was closed when v4.0 restructured the directory layout. Maintainer noted the features are good ideas and the skill still exists. This resubmission adapts to v4.0.3 structure (nested under `Thinking/`, no YAML frontmatter changes, keeps existing agent mapping).

**Scope:** File-first output + recovery only. Patchlist mode (PR #739) stays separate.

## Test plan

- [ ] Run a Council debate → verify files written to `~/.claude/MEMORY/STATE/council-sessions/`
- [ ] Interrupt a session mid-round → verify session state preserved
- [ ] Use Recovery workflow to resume → verify it picks up from checkpoint
- [ ] Verify archived output in `~/.claude/MEMORY/RESEARCH/`
- [ ] Verify standard debate still works with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)