### PR TITLE
feat(config): make startup catchphrase configurable from settings.json

### DIFF
--- a/Releases/v4.0.3/.claude/PAI/Tools/pai.ts
+++ b/Releases/v4.0.3/.claude/PAI/Tools/pai.ts
@@ -19,7 +19,7 @@
  */
 
 import { spawn, spawnSync } from "bun";
-import { getDAName, getIdentity } from "../../hooks/lib/identity";
+import { getDAName, getIdentity, getSettings } from "../../hooks/lib/identity";
 import { existsSync, readFileSync, writeFileSync, readdirSync, symlinkSync, unlinkSync, lstatSync } from "fs";
 import { homedir } from "os";
 import { join, basename } from "path";
@@ -417,8 +417,12 @@ async function cmdLaunch(options: { mcp?: string; resume?: boolean; skipPerms?: 
     process.chdir(CLAUDE_DIR);
   }
 
-  // Voice notification (using focused marker for calmer tone)
-  notifyVoice(`[🎯 focused] ${getDAName()} here, ready to go.`);
+  // Voice notification — speak the startup catchphrase
+  const settings = getSettings();
+  const daName = getDAName();
+  const rawCatchphrase = settings.daidentity?.startupCatchphrase || `${daName} here, ready to go.`;
+  const catchphrase = rawCatchphrase.replace(/\{name\}/gi, daName);
+  notifyVoice(catchphrase);
 
   // Launch Claude
   const proc = spawn(args, {


### PR DESCRIPTION
## Summary

The startup voice notification in `pai.ts` uses a hardcoded message. This PR makes it read from `settings.daidentity.startupCatchphrase` so each user can personalize the greeting to match their DA identity.

- Reads `settings.daidentity?.startupCatchphrase` at launch
- Supports `{name}` template variable (replaced with DA name at runtime)
- Falls back gracefully to original behavior if the setting is absent

## Example

In `settings.json`:
\`\`\`json
{
  "daidentity": {
    "startupCatchphrase": "{name}, awakened and at your service."
  }
}
\`\`\`

Result at launch: *"SoushAI, awakened and at your service."*

## Checklist

- [ ] `startupCatchphrase` read from `settings.daidentity`
- [ ] `{name}` placeholder replaced with DA name at runtime
- [ ] Fallback: default message used when setting is absent
- [ ] No breaking changes to existing behavior