### PR TITLE
feat(skills): add FocusAlignment skill to Telos category

### DIFF
--- a/Releases/v4.0.3/.claude/skills/Telos/FocusAlignment/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Telos/FocusAlignment/SKILL.md
@@ -107,4 +107,4 @@ Running the **WorkflowName** workflow in the **FocusAlignment** skill to ACTION.
 
 ---
 
-**Last Updated:** 2025-12-20
+**Last Updated:** 2026-03-02

--- a/Releases/v4.0.3/.claude/skills/Telos/FocusAlignment/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Telos/FocusAlignment/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: FocusAlignment
+description: TELOS-powered goal alignment checking — verify proposals against life goals, surface neglected areas, assess balance, filter decisions through priorities. USE WHEN focus alignment, alignment check, neglected, life balance, should I do this, opportunity cost, what am I neglecting, focus balance, priority check.
+---
+
+## Customization
+
+**Before executing, check for user customizations at:**
+`~/.claude/PAI/USER/SKILLCUSTOMIZATIONS/FocusAlignment/`
+
+If this directory exists, load and apply any PREFERENCES.md, configurations, or resources found there. These override default behavior. If the directory does not exist, proceed with skill defaults.
+
+
+## 🚨 MANDATORY: Voice Notification (REQUIRED BEFORE ANY ACTION)
+
+**You MUST send this notification BEFORE doing anything else when this skill is invoked.**
+
+1. **Send voice notification**:
+   ```bash
+   curl -s -X POST http://localhost:8888/notify \
+     -H "Content-Type: application/json" \
+     -d '{"message": "Running the WORKFLOWNAME workflow in the FocusAlignment skill to ACTION"}' \
+     > /dev/null 2>&1 &
+   ```
+
+2. **Output text notification**:
+   ```
+   Running the **WorkflowName** workflow in the **FocusAlignment** skill to ACTION...
+   ```
+
+**This is not optional. Execute this curl command immediately upon skill invocation.**
+
+# FocusAlignment Skill
+
+TELOS-powered goal alignment checking for {PRINCIPAL.NAME}'s life focus areas. Unlike static focus trackers, this skill dynamically reads TELOS files (GOALS.md, MISSION.md, PROJECTS.md, CHALLENGES.md) to discover and assess focus areas at runtime — every user's priorities are different.
+
+
+## Context Detection
+
+**How the skill discovers focus areas:**
+
+This skill does NOT use hardcoded focus areas. On every invocation:
+
+1. Read `~/.claude/PAI/USER/TELOS/GOALS.md` — extract goal categories as focus areas
+2. Read `~/.claude/PAI/USER/TELOS/MISSION.md` — understand overarching purpose
+3. Read `~/.claude/PAI/USER/TELOS/PROJECTS.md` — map active projects to goal areas
+4. Read `~/.claude/PAI/USER/TELOS/CHALLENGES.md` — identify current obstacles
+
+The intersection of goals, projects, and challenges defines the current focus landscape.
+
+
+## Workflow Routing
+
+Route to the appropriate workflow based on the request.
+
+**When executing a workflow, output this notification directly:**
+
+```
+Running the **WorkflowName** workflow in the **FocusAlignment** skill to ACTION...
+```
+
+| Trigger | Workflow |
+|---------|----------|
+| New proposal, "should I do this?", check alignment | `Workflows/AlignmentCheck.md` |
+| "What am I neglecting?", find gaps, neglect scan | `Workflows/NeglectScan.md` |
+| Balance assessment, rate investment, review period | `Workflows/BalanceAssessment.md` |
+| Decision filter, evaluate choice, opportunity cost | `Workflows/DecisionFilter.md` |
+
+## Quick Reference
+
+| Workflow | Purpose | Input | Output |
+|----------|---------|-------|--------|
+| **AlignmentCheck** | Verify proposal against TELOS goals | New project/commitment | Alignment score + honest assessment |
+| **NeglectScan** | Find neglected goal areas | None (reads TELOS) | Neglected areas + recommendations |
+| **BalanceAssessment** | Rate investment across goals | None (reads TELOS + activity) | Balance matrix + insights |
+| **DecisionFilter** | Filter decision through priorities | A choice to evaluate | Clear recommendation with reasoning |
+
+## Examples
+
+```
+"I'm thinking of starting a podcast — should I?"
+-> Invokes AlignmentCheck -> Evaluates against TELOS goals
+
+"What areas of my life am I neglecting?"
+-> Invokes NeglectScan -> Scans TELOS for gaps
+
+"How balanced is my focus right now?"
+-> Invokes BalanceAssessment -> Rates investment across goal areas
+
+"Should I take this job offer or stay?"
+-> Invokes DecisionFilter -> Filters through TELOS priorities
+```
+
+## Integration
+
+**Works well with:**
+- **Telos** — Reads all TELOS context files for goal discovery
+- **BrainDump** — When dumps touch goals/direction, BrainDump suggests running alignment check
+- **Research** — Gather context before making alignment decisions
+
+## Principles
+
+1. **Brutal honesty** — Call out when something doesn't serve any goal area
+2. **Opportunity cost** — Everything you say yes to means no to something else
+3. **Seasons matter** — Some periods emphasize certain areas — that's okay
+4. **Progress not perfection** — All areas don't need equal attention always
+
+---
+
+**Last Updated:** 2025-12-20

--- a/Releases/v4.0.3/.claude/skills/Telos/FocusAlignment/Workflows/AlignmentCheck.md
+++ b/Releases/v4.0.3/.claude/skills/Telos/FocusAlignment/Workflows/AlignmentCheck.md
@@ -1,0 +1,39 @@
+# AlignmentCheck Workflow
+
+Check new proposals or commitments against {PRINCIPAL.NAME}'s TELOS goals.
+
+## Trigger
+
+When {PRINCIPAL.NAME} proposes something new — a project, commitment, opportunity, or initiative.
+
+## Process
+
+1. **Load TELOS context:**
+   - Read `~/.claude/PAI/USER/TELOS/GOALS.md` — extract goal categories
+   - Read `~/.claude/PAI/USER/TELOS/MISSION.md` — understand purpose
+   - Read `~/.claude/PAI/USER/TELOS/PROJECTS.md` — current commitments
+
+2. **Map the proposal to goals:**
+   - Which goal area(s) does this serve?
+   - How directly does it serve them? (primary vs. tangential)
+
+3. **Check for conflicts:**
+   - Does it compete with higher-priority goals?
+   - Does it duplicate existing projects?
+   - What's the time/energy cost?
+
+4. **Honest assessment:**
+   - Clear statement of which goals it serves
+   - Clear statement of what it costs
+   - If it doesn't serve any goals, say so directly
+   - If {PRINCIPAL.NAME} already has too many commitments, flag it
+
+## Output
+
+```
+PROPOSAL: [what was proposed]
+SERVES: [goal areas it advances]
+COSTS: [what it takes away from]
+CONFLICTS: [competing priorities]
+ASSESSMENT: [honest recommendation]
+```

--- a/Releases/v4.0.3/.claude/skills/Telos/FocusAlignment/Workflows/BalanceAssessment.md
+++ b/Releases/v4.0.3/.claude/skills/Telos/FocusAlignment/Workflows/BalanceAssessment.md
@@ -1,0 +1,32 @@
+# BalanceAssessment Workflow
+
+Rate {PRINCIPAL.NAME}'s investment across all TELOS goal areas. Best used during review periods or when feeling off-balance.
+
+## Process
+
+1. **Load TELOS context:**
+   - Read `~/.claude/PAI/USER/TELOS/GOALS.md` — all goal categories
+   - Read `~/.claude/PAI/USER/TELOS/PROJECTS.md` — current project allocation
+   - Read `~/.claude/PAI/USER/TELOS/CHALLENGES.md` — where energy is going
+   - Read `~/.claude/PAI/USER/TELOS/MISSION.md` — overarching purpose
+
+2. **Rate each goal area (1-5) on recent investment:**
+
+   | Goal Area | Investment (1-5) | Notes |
+   |-----------|------------------|-------|
+   | [from GOALS.md] | [rating] | [evidence] |
+
+3. **Analyze the pattern:**
+   - Which areas are over-invested? (4-5)
+   - Which are under-invested? (1-2)
+   - Does the distribution align with stated priorities?
+   - Are there areas that SHOULD be low-priority right now (seasonal)?
+
+4. **Provide honest assessment:**
+   - Name the imbalances directly
+   - Distinguish intentional focus from accidental neglect
+   - Suggest rebalancing if needed — specific, actionable
+
+## Output
+
+Balance matrix table + narrative assessment + top 3 rebalancing recommendations.

--- a/Releases/v4.0.3/.claude/skills/Telos/FocusAlignment/Workflows/DecisionFilter.md
+++ b/Releases/v4.0.3/.claude/skills/Telos/FocusAlignment/Workflows/DecisionFilter.md
@@ -1,0 +1,42 @@
+# DecisionFilter Workflow
+
+Filter a decision through {PRINCIPAL.NAME}'s TELOS priorities. Use when facing a choice.
+
+## Process
+
+1. **Understand the decision:**
+   - What are the options?
+   - What's the timeline?
+   - What constraints exist?
+
+2. **Load TELOS context:**
+   - Read `~/.claude/PAI/USER/TELOS/GOALS.md` — priorities
+   - Read `~/.claude/PAI/USER/TELOS/MISSION.md` — purpose
+   - Read `~/.claude/PAI/USER/TELOS/PROJECTS.md` — current load
+   - Read `~/.claude/PAI/USER/TELOS/STRATEGIES.md` — strategic approaches
+
+3. **Evaluate each option against TELOS:**
+   - Which goals does each option serve?
+   - Which goals does each option hinder?
+   - What's the opportunity cost of each?
+   - Does either align with current season/priorities?
+
+4. **Assess fit:**
+   - Does this align with MISSION.md?
+   - Does this use or develop STRATEGIES.md approaches?
+   - What would {PRINCIPAL.NAME} in 5 years think of this choice?
+
+## Output
+
+```
+DECISION: [the choice]
+OPTIONS: [list]
+
+For each option:
+  SERVES: [goal areas]
+  COSTS: [opportunity costs]
+  ALIGNMENT: [mission fit score 1-5]
+
+RECOMMENDATION: [clear recommendation with reasoning]
+CAVEAT: [what you might be wrong about]
+```

--- a/Releases/v4.0.3/.claude/skills/Telos/FocusAlignment/Workflows/NeglectScan.md
+++ b/Releases/v4.0.3/.claude/skills/Telos/FocusAlignment/Workflows/NeglectScan.md
@@ -1,0 +1,36 @@
+# NeglectScan Workflow
+
+Scan {PRINCIPAL.NAME}'s TELOS goals to find neglected areas.
+
+## Process
+
+1. **Load TELOS context:**
+   - Read `~/.claude/PAI/USER/TELOS/GOALS.md` — all goal areas
+   - Read `~/.claude/PAI/USER/TELOS/PROJECTS.md` — what's actively being worked on
+   - Read `~/.claude/PAI/USER/TELOS/CHALLENGES.md` — what's blocking progress
+
+2. **Map activity to goals:**
+   - For each goal area, check: Are there active projects serving it?
+   - Are there recent updates or progress?
+   - Is this area mentioned in challenges?
+
+3. **Identify neglected areas:**
+   - Goal areas with no active projects
+   - Goal areas with no recent attention
+   - Goal areas where challenges are piling up without action
+
+4. **Recommend next steps:**
+   - Rank neglected areas by importance (from MISSION.md context)
+   - Suggest one small action per neglected area
+   - Don't overwhelm — focus on the top 2-3 most neglected
+
+## Output
+
+For each goal area:
+```
+| Goal Area | Active Projects | Recent Attention | Status |
+|-----------|----------------|------------------|--------|
+| [area] | [count/names] | [yes/no] | ✅ Active / ⚠️ Neglected / 🔴 Abandoned |
+```
+
+Plus specific recommendations for neglected areas.

--- a/Releases/v4.0.3/.claude/skills/Telos/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Telos/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Telos
-description: Life OS and project analysis — goals, dependencies, beliefs, wisdom, books, movies, narrative points, interview extraction, McKinsey reports, and project dashboards. USE WHEN Telos, life goals, projects, dependencies, books, movies, beliefs, wisdom, update TELOS, narrative points, interview extraction, write report, McKinsey report, TELOS report, project analysis, dashboard, n=24.
+description: Life OS and project analysis — goals, dependencies, beliefs, wisdom, books, movies, narrative points, interview extraction, McKinsey reports, and project dashboards. USE WHEN Telos, life goals, projects, dependencies, books, movies, beliefs, wisdom, update TELOS, narrative points, interview extraction, write report, McKinsey report, TELOS report, project analysis, dashboard, n=24, focus alignment, alignment check, neglected, life balance, should I do this, opportunity cost.
 ---
 
 ## 🚨 MANDATORY: Voice Notification (REQUIRED BEFORE ANY ACTION)
@@ -44,6 +44,7 @@ Running the **WorkflowName** workflow in the **Telos** skill to ACTION...
 | **InterviewExtraction** | "extract content", "extract interviews", "analyze interviews" | `Workflows/InterviewExtraction.md` |
 | **CreateNarrativePoints** | "create narrative", "narrative points", "TELOS report", "n=24" | `Workflows/CreateNarrativePoints.md` |
 | **WriteReport** | "write report", "McKinsey report", "create TELOS report", "professional report" | `Workflows/WriteReport.md` |
+| **FocusAlignment** | "alignment check", "focus balance", "what am I neglecting", "should I do this" | `FocusAlignment/SKILL.md` |
 
 **Note:** For general project analysis, dashboards, dependency mapping, and executive summaries, the skill handles these directly without a separate workflow file.
 


### PR DESCRIPTION
## Summary

Adds a **FocusAlignment** skill to the Telos category — checks proposals, decisions, and life balance against TELOS goals.

Key design decision: the original version hardcoded 5 focus areas. This PAI version reads GOALS.md, MISSION.md, PROJECTS.md, and CHALLENGES.md dynamically at runtime — every user's priorities are different, so the skill discovers them instead of assuming them.

Four workflows:

- **AlignmentCheck** — "should I do this?" → maps proposal to TELOS goals, flags conflicts and opportunity costs
- **NeglectScan** — "what am I neglecting?" → scans goal areas for gaps in active projects
- **BalanceAssessment** — rates investment (1-5) across all goal areas, good for review periods
- **DecisionFilter** — filters a choice through TELOS priorities with a clear recommendation

## Changes

**Added:**
- `skills/Telos/FocusAlignment/SKILL.md` + 4 workflows in `Workflows/`

**Modified:**
- `skills/Telos/SKILL.md` — routing entry + trigger words

Structure mirrors Council (frontmatter, customization check, voice notification, routing table).

---

Ported from a personal Claude Code skill system. The dynamic TELOS reading is new for the PAI version.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)