### PR TITLE
feat(skills): add BrainDump skill to Thinking category

### DIFF
--- a/Releases/v4.0.3/.claude/skills/Thinking/BrainDump/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Thinking/BrainDump/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: BrainDump
+description: Structured thought and emotion processing — receive raw thoughts, match against TELOS patterns, structure into MEMORY. USE WHEN brain dump, unload thoughts, process emotions, decompress, vent, think out loud, end of day, debrief, what happened today, need to talk.
+---
+
+## Customization
+
+**Before executing, check for user customizations at:**
+`~/.claude/PAI/USER/SKILLCUSTOMIZATIONS/BrainDump/`
+
+If this directory exists, load and apply any PREFERENCES.md, configurations, or resources found there. These override default behavior. If the directory does not exist, proceed with skill defaults.
+
+
+## 🚨 MANDATORY: Voice Notification (REQUIRED BEFORE ANY ACTION)
+
+**You MUST send this notification BEFORE doing anything else when this skill is invoked.**
+
+1. **Send voice notification**:
+   ```bash
+   curl -s -X POST http://localhost:8888/notify \
+     -H "Content-Type: application/json" \
+     -d '{"message": "Running the WORKFLOWNAME workflow in the BrainDump skill to ACTION"}' \
+     > /dev/null 2>&1 &
+   ```
+
+2. **Output text notification**:
+   ```
+   Running the **WorkflowName** workflow in the **BrainDump** skill to ACTION...
+   ```
+
+**This is not optional. Execute this curl command immediately upon skill invocation.**
+
+# BrainDump Skill
+
+Structured processing of thoughts, emotions, and experiences. Turns raw, unstructured input into pattern-matched, structured content connected to {PRINCIPAL.NAME}'s TELOS system. The skill listens first, reflects patterns back, then structures and stores.
+
+
+## Workflow Routing
+
+Route to the appropriate workflow based on the request.
+
+**When executing a workflow, output this notification directly:**
+
+```
+Running the **WorkflowName** workflow in the **BrainDump** skill to ACTION...
+```
+
+| Trigger | Workflow |
+|---------|----------|
+| Full structured dump (all 5 phases: receive → pattern match → structure → validate → cross-reference) | `Workflows/FullDump.md` |
+| Quick capture (just receive and structure, skip pattern matching) | `Workflows/QuickDump.md` |
+| Analyze existing content against TELOS patterns | `Workflows/PatternMatch.md` |
+
+## Quick Reference
+
+| Workflow | Purpose | Phases | Output |
+|----------|---------|--------|--------|
+| **FullDump** | Complete thought processing | 5 | Structured content + pattern analysis + MEMORY update |
+| **QuickDump** | Rapid capture | 2 | Structured content in MEMORY |
+| **PatternMatch** | Pattern analysis only | 1 | Pattern connections to TELOS |
+
+## Examples
+
+```
+"I need to unload what's on my mind"
+-> Invokes FullDump workflow -> 5-phase processing
+
+"Quick dump: had a weird interaction at work today"
+-> Invokes QuickDump workflow -> Rapid capture
+
+"Look at what I wrote yesterday and find patterns"
+-> Invokes PatternMatch workflow -> TELOS pattern analysis
+```
+
+## Integration
+
+**Works well with:**
+- **Telos** — Pattern matching reads from `~/.claude/PAI/USER/TELOS/` (BELIEFS, CHALLENGES, GOALS, LEARNED, NARRATIVES, TRAUMAS, WRONG)
+- **FocusAlignment** — If dump touches goals/direction, suggest running alignment check
+- **Research** — If dump reveals knowledge gaps, suggest research
+
+## Principles
+
+1. **Dump first, structure later** — don't impose structure on the dump itself
+2. **Patterns are tools, not labels** — use them to help see connections, not to categorize
+3. **Corrections are expected** — memory is imperfect, especially emotional memory
+4. **Their voice, not yours** — structured output should sound like {PRINCIPAL.NAME} wrote it
+5. **Direct over diplomatic** — if you see something concerning, say it
+6. **Not everything is a pattern** — sometimes a bad day is just a bad day
+7. **Ask before writing elsewhere** — MEMORY is fair game, other files need permission
+
+---
+
+**Last Updated:** 2026-03-02

--- a/Releases/v4.0.3/.claude/skills/Thinking/BrainDump/Workflows/FullDump.md
+++ b/Releases/v4.0.3/.claude/skills/Thinking/BrainDump/Workflows/FullDump.md
@@ -1,0 +1,91 @@
+# FullDump Workflow
+
+Full 5-phase structured processing of thoughts, emotions, and experiences.
+
+## Phase 1: Receive (Listen Mode)
+
+Let {PRINCIPAL.NAME} talk. Don't interrupt with analysis yet. Capture everything.
+
+**Your job:**
+- Listen to the full dump without structuring prematurely
+- Note key themes, people mentioned, emotions expressed
+- Identify factual details that need clarifying (dates, names, what actually happened vs. interpretation)
+
+**Ask only clarifying questions about facts**, not feelings. Don't psychoanalyze mid-dump. One question at a time. Let them finish before switching to Phase 2.
+
+**Language:** {PRINCIPAL.NAME} may dump in any language or a mix. Process in whatever language the input comes in.
+
+## Phase 2: Pattern Match (Reflect Back)
+
+After the dump is complete:
+
+1. **Read TELOS files** from `~/.claude/PAI/USER/TELOS/` — focus on:
+   - `CHALLENGES.md` — current struggles
+   - `LEARNED.md` — lessons learned
+   - `WRONG.md` — past mistakes
+   - `TRAUMAS.md` — past experiences
+   - `NARRATIVES.md` — self-stories
+   - `BELIEFS.md` — core beliefs
+   - `GOALS.md` — what they're working toward
+
+2. **Name the patterns you see** — explicitly, with references:
+   - "This connects to your challenge around [X from CHALLENGES.md]"
+   - "I see a link between this and what you learned about [Y from LEARNED.md]"
+   - Connect dots across different TELOS areas
+
+3. **Share your honest read** of the situation — what you think is actually going on beneath the surface
+
+4. **Ask {PRINCIPAL.NAME} to validate:** "Does this land? What am I missing?"
+
+**Rules for pattern matching:**
+- Be direct. Don't coddle.
+- Connect dots they might not see
+- If you think they're rationalizing, say so
+- If something doesn't match a documented pattern, say that too
+- If you see a NEW pattern worth documenting, flag it
+
+## Phase 3: Structure & Write
+
+Write structured output to `~/.claude/MEMORY/`.
+
+**Map the dump to structured sections:**
+
+| Content Type | Section |
+|-------------|---------|
+| What happened | Events / Overview |
+| Good things | Wins |
+| Hard things | Challenges |
+| People interactions | Relationships |
+| Emotional insights, pattern recognition | Patterns & Insights |
+| Plans / next steps | Action Items |
+
+**Writing rules:**
+- Write in {PRINCIPAL.NAME}'s voice (first person)
+- Be specific with details (names, places, times, what actually happened)
+- Explicitly name patterns and reference TELOS files
+- Don't sanitize emotions — if they were sad, write sad. If frustrated, write frustrated.
+- Don't over-polish — this should sound authentic, not clinical
+
+## Phase 4: Validate
+
+After writing:
+
+1. Show {PRINCIPAL.NAME} what you wrote (key sections, not everything)
+2. Ask for corrections — details, timeline, what actually happened vs. your interpretation
+3. Fix and iterate
+
+**Expect 2-3 rounds of corrections.** This is normal. Emotional memory is imperfect. Common corrections:
+- Wrong sequence of events
+- Missing context about WHY something happened
+- Details about places, people, or conversations
+- Tone adjustments (too clinical, too dramatic, wrong emphasis)
+
+## Phase 5: Cross-Reference (Optional)
+
+If the dump reveals something worth updating elsewhere:
+
+- **TELOS update** → "Should I update CHALLENGES.md with [specific insight]?"
+- **New pattern** → "This seems like a new lesson for LEARNED.md. Want me to add it?"
+- **Goal relevance** → "This connects to your goal around [X]. Worth noting in GOALS.md?"
+
+**Don't do this automatically.** Always ask first. {PRINCIPAL.NAME} controls what goes into TELOS.

--- a/Releases/v4.0.3/.claude/skills/Thinking/BrainDump/Workflows/PatternMatch.md
+++ b/Releases/v4.0.3/.claude/skills/Thinking/BrainDump/Workflows/PatternMatch.md
@@ -1,0 +1,37 @@
+# PatternMatch Workflow
+
+Isolated Phase 2 — analyze existing content against TELOS patterns. Use when {PRINCIPAL.NAME} wants to find connections in things already written, not process new thoughts.
+
+## Input
+
+Ask what content to analyze:
+- Recent MEMORY entries
+- A specific piece of writing
+- A conversation or interaction they want examined
+
+## Process
+
+1. **Read the content** to be analyzed
+
+2. **Load TELOS context** from `~/.claude/PAI/USER/TELOS/`:
+   - CHALLENGES.md, LEARNED.md, WRONG.md, TRAUMAS.md
+   - NARRATIVES.md, BELIEFS.md, GOALS.md
+
+3. **Find connections:**
+   - What TELOS patterns appear in this content?
+   - Are there contradictions between stated beliefs and actions?
+   - Do any challenges or goals get reinforced or challenged?
+   - Are there new patterns not yet in TELOS?
+
+4. **Present findings:**
+   - Named patterns with TELOS file references
+   - Connections across different TELOS areas
+   - Honest assessment of what's beneath the surface
+   - Any new patterns worth adding to TELOS
+
+## Output
+
+Structured analysis with:
+- Pattern connections (referenced to specific TELOS files)
+- Cross-cutting themes
+- Recommended TELOS updates (if any — always ask before making changes)

--- a/Releases/v4.0.3/.claude/skills/Thinking/BrainDump/Workflows/QuickDump.md
+++ b/Releases/v4.0.3/.claude/skills/Thinking/BrainDump/Workflows/QuickDump.md
@@ -1,0 +1,20 @@
+# QuickDump Workflow
+
+Rapid capture — Phase 1 (Receive) + Phase 3 (Structure) only. Skip pattern matching for when {PRINCIPAL.NAME} just needs to get thoughts out quickly.
+
+## Phase 1: Receive
+
+Let {PRINCIPAL.NAME} talk. Capture everything without analysis.
+
+- Note key themes and emotions
+- Ask minimal clarifying questions (facts only)
+- Don't pattern match or reflect back
+
+## Phase 3: Structure & Write
+
+Write directly to `~/.claude/MEMORY/`.
+
+- Map content to structured sections (events, wins, challenges, insights, action items)
+- Write in {PRINCIPAL.NAME}'s voice
+- Keep it concise — quick capture, not deep processing
+- Flag anything that seems worth deeper processing later: "This might be worth a full dump when you have time."

--- a/Releases/v4.0.3/.claude/skills/Thinking/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Thinking/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Thinking
-description: Multi-mode analytical and creative thinking — first principles decomposition, iterative depth analysis, creative brainstorming, multi-agent council debates, adversarial red teaming, world threat modeling, and scientific hypothesis testing. USE WHEN first principles, decompose, deconstruct, reconstruct, challenge assumptions, iterative depth, multi-angle, deep exploration, be creative, brainstorm, divergent ideas, tree of thoughts, maximum creativity, technical creativity, idea generation, domain specific, council, debate, perspectives, quick consensus, red team, critique, stress test, adversarial validation, parallel analysis, devil's advocate, threat model, world model, future analysis, test idea, test investment, update models, view models, time horizon, think about, figure out, experiment, iterate, science, hypothesis, define goal, design experiment, quick diagnosis, structured investigation, full cycle.
+description: Multi-mode analytical and creative thinking — first principles decomposition, iterative depth analysis, creative brainstorming, multi-agent council debates, adversarial red teaming, world threat modeling, and scientific hypothesis testing. USE WHEN first principles, decompose, deconstruct, reconstruct, challenge assumptions, iterative depth, multi-angle, deep exploration, be creative, brainstorm, divergent ideas, tree of thoughts, maximum creativity, technical creativity, idea generation, domain specific, council, debate, perspectives, quick consensus, red team, critique, stress test, adversarial validation, parallel analysis, devil's advocate, threat model, world model, future analysis, test idea, test investment, update models, view models, time horizon, think about, figure out, experiment, iterate, science, hypothesis, define goal, design experiment, quick diagnosis, structured investigation, full cycle, brain dump, unload thoughts, process emotions, decompress, vent, think out loud.
 ---
 
 # Thinking
@@ -18,3 +18,4 @@ Unified skill for all analytical and creative thinking modes.
 | Red team, attack idea, counterarguments, critique, stress test, devil's advocate | `RedTeam/SKILL.md` |
 | Threat model, world model, test idea, future analysis, test investment, time horizons | `WorldThreatModelHarness/SKILL.md` |
 | Think about, figure out, experiment, iterate, improve, optimize, hypothesis | `Science/SKILL.md` |
+| Brain dump, unload thoughts, process emotions, decompress, vent, think out loud | `BrainDump/SKILL.md` |


### PR DESCRIPTION
## Summary

Adds a **BrainDump** skill to the Thinking category — structured thought and emotion processing that connects to the TELOS system.

The idea: when someone needs to unload what's on their mind, the skill listens first (no premature structuring), reflects TELOS patterns back, then writes structured output to MEMORY. Three workflows cover different needs:

- **FullDump** — all 5 phases: receive → pattern match against TELOS → structure → validate → cross-reference
- **QuickDump** — just capture and structure, skip the analysis
- **PatternMatch** — analyze existing content against TELOS (CHALLENGES, LEARNED, WRONG, NARRATIVES, BELIEFS, GOALS)

Pattern matching reads `~/.claude/PAI/USER/TELOS/` files to reflect connections back — "this connects to your challenge around X" rather than generic advice.

## Changes

**Added:**
- `skills/Thinking/BrainDump/SKILL.md` + 3 workflows in `Workflows/`

**Modified:**
- `skills/Thinking/SKILL.md` — routing entry + trigger words

Structure mirrors Council (frontmatter, customization check, voice notification, routing table).

---

Ported from a personal Claude Code skill system where this has been running daily.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)