### PR TITLE
fix(install): Add missing output directory to Parser skill for v4.0.x (Issue 848)

### DIFF
--- a/Releases/v4.0.1/.claude/skills/Utilities/Parser/output/.gitignore
+++ b/Releases/v4.0.1/.claude/skills/Utilities/Parser/output/.gitignore
@@ -1,0 +1,1 @@
+# Output folder for Parser Workflows

--- a/Releases/v4.0.2/.claude/skills/Utilities/Parser/output/.gitignore
+++ b/Releases/v4.0.2/.claude/skills/Utilities/Parser/output/.gitignore
@@ -1,0 +1,1 @@
+# Output folder for Parser Workflows

--- a/Releases/v4.0.3/.claude/skills/Utilities/Parser/output/.gitignore
+++ b/Releases/v4.0.3/.claude/skills/Utilities/Parser/output/.gitignore
@@ -1,0 +1,1 @@
+# Output folder for Parser Workflows


### PR DESCRIPTION
Creates missing `output` folders in `v4.0.x`.  

Simple fix for https://github.com/danielmiessler/Personal_AI_Infrastructure/issues/848 after deducing (https://github.com/danielmiessler/Personal_AI_Infrastructure/blob/main/Releases/v4.0.3/.claude/skills/Utilities/Parser/Workflows/BatchEntityExtractionGemini3.md?plain=1#L559) this was the intended folder structure. Assuming the original `git add` didn't work because you can't add empty folders in git, so added a brief `.gitignore` to each folder in the v4.0.x series. 