### PR TITLE
docs: fix dead references and template variable in CONTEXT_ROUTING.md

### DIFF
--- a/Releases/v4.0.3/.claude/PAI/CONTEXT_ROUTING.md
+++ b/Releases/v4.0.3/.claude/PAI/CONTEXT_ROUTING.md
@@ -21,11 +21,11 @@ Load context on-demand by reading the file at the path listed. Only load what th
 | Behavioral rules | `PAI/AISTEERINGRULES.md` |
 | PRD format spec | `PAI/PRDFORMAT.md` |
 
-## {PRINCIPAL.NAME} — Personal Context
+## User — Personal Context
 
 | Topic | Path |
 |-------|------|
 | All USER context index | `PAI/USER/README.md` |
-| Projects | `PAI/USER/PROJECTS/README.md` |
+| Projects | `PAI/USER/TELOS/PROJECTS.md` |
 | Business context | `PAI/USER/BUSINESS/README.md` |
 | Telos (life goals) | `PAI/USER/TELOS/README.md` |


### PR DESCRIPTION
## Summary

- Fixes dead path reference: `PAI/USER/PROJECTS/README.md` → `PAI/USER/TELOS/PROJECTS.md`
- Resolves unprocessed template variable: `{PRINCIPAL.NAME}` → `User`

Fixes #878, fixes #879

## Context

`CONTEXT_ROUTING.md` had two issues since v4.0.3:
1. Projects path pointed to non-existent directory (moved to TELOS in v4 migration)
2. Template variable `{PRINCIPAL.NAME}` was not resolved during release build

## Test plan

- [x] Verify all paths in routing table reference existing files
- [x] No remaining `{PRINCIPAL.NAME}` template variables
- [x] AI code review: severity LOW — Clean

---

🤖 *Submitted by Navi, PAI agent of Ivan (@rikitikitavi2012-debug)*
Generated with [Claude Code](https://claude.ai/code) + [Jules](https://jules.google.com)