### PR TITLE
feat(pai): add CLAUDE_MODEL env variable support

### DIFF
--- a/Releases/v4.0.0/.claude/PAI/Tools/pai.ts
+++ b/Releases/v4.0.0/.claude/PAI/Tools/pai.ts
@@ -412,6 +412,12 @@ async function cmdLaunch(options: { mcp?: string; resume?: boolean; skipPerms?: 
     args.push("--resume");
   }
 
+  // Read model from environment variable (e.g. CLAUDE_MODEL=gpt-oss:20b for Ollama)
+  const model = process.env.CLAUDE_MODEL;
+  if (model) {
+    args.push("--model", model);
+  }
+
   // Change to PAI directory unless --local flag is set
   if (!options.local) {
     process.chdir(CLAUDE_DIR);

--- a/Releases/v4.0.1/.claude/PAI/Tools/pai.ts
+++ b/Releases/v4.0.1/.claude/PAI/Tools/pai.ts
@@ -412,6 +412,12 @@ async function cmdLaunch(options: { mcp?: string; resume?: boolean; skipPerms?: 
     args.push("--resume");
   }
 
+  // Read model from environment variable (e.g. CLAUDE_MODEL=gpt-oss:20b for Ollama)
+  const model = process.env.CLAUDE_MODEL;
+  if (model) {
+    args.push("--model", model);
+  }
+
   // Change to PAI directory unless --local flag is set
   if (!options.local) {
     process.chdir(CLAUDE_DIR);

--- a/Releases/v4.0.2/.claude/PAI/Tools/pai.ts
+++ b/Releases/v4.0.2/.claude/PAI/Tools/pai.ts
@@ -412,6 +412,12 @@ async function cmdLaunch(options: { mcp?: string; resume?: boolean; skipPerms?: 
     args.push("--resume");
   }
 
+  // Read model from environment variable (e.g. CLAUDE_MODEL=gpt-oss:20b for Ollama)
+  const model = process.env.CLAUDE_MODEL;
+  if (model) {
+    args.push("--model", model);
+  }
+
   // Change to PAI directory unless --local flag is set
   if (!options.local) {
     process.chdir(CLAUDE_DIR);

--- a/Releases/v4.0.3/.claude/PAI/Tools/pai.ts
+++ b/Releases/v4.0.3/.claude/PAI/Tools/pai.ts
@@ -412,6 +412,12 @@ async function cmdLaunch(options: { mcp?: string; resume?: boolean; skipPerms?: 
     args.push("--resume");
   }
 
+  // Read model from environment variable (e.g. CLAUDE_MODEL=gpt-oss:20b for Ollama)
+  const model = process.env.CLAUDE_MODEL;
+  if (model) {
+    args.push("--model", model);
+  }
+
   // Change to PAI directory unless --local flag is set
   if (!options.local) {
     process.chdir(CLAUDE_DIR);


### PR DESCRIPTION
Allow users to set model via environment variable, e.g.:
  CLAUDE_MODEL=gpt-oss:20b bun ~/.claude/skills/CORE/Tools/pai.ts

Useful for local models (Ollama) and aliases.

Fixes #494

Made-with: Cursor
