### PR TITLE
fix: harmonize SKILL.md effort budgets and ISC minimums with Algorithm

### DIFF
--- a/Releases/v4.0.3/.claude/PAI/SKILL.md
+++ b/Releases/v4.0.3/.claude/PAI/SKILL.md
@@ -59,13 +59,11 @@ Emit `♻️` header and `🗒️ TASK` as first tokens — IMMEDIATELY. Don't p
 
 | Tier | Budget | When |
 |------|--------|------|
-| **Instant** | <10s | Trivial lookup, greeting → minimal format |
-| **Fast** | <1min | Simple fix, skill invocation |
 | **Standard** | <2min | Normal request (DEFAULT) |
-| **Extended** | <4min | Higher quality, more capabilities/skills |
-| **Advanced** | <8min | Substantial complexity, many more|
-| **Deep** | <32min | Complex solution, extensive skills |
-| **Comprehensive** | <120m | Little time pressure, maximum skills |
+| **Extended** | <8min | Quality must be extraordinary |
+| **Advanced** | <16min | Substantial multi-file work |
+| **Deep** | <32min | Complex design |
+| **Comprehensive** | <120min | No time pressure |
 
 Default: Standard. Escalate to match Euphoric Surprise within time SLA. TIME CHECK each phase — >150% budget → auto-compress to next-lower tier.
 
@@ -195,17 +193,15 @@ Extended+:
 
 **Every criterion:** 8-16 words, state not action, binary testable, one concern.
 
-**ISC minimums per effort tier:**
+**ISC minimums per effort tier** (aligned with Algorithm ISC Count Gate):
 
-| Effort Tier | ISC Minimum | Target Range | Structure |
-|-------------|-------------|-------------|-----------|
-| Instant | None | — | — |
-| Fast | 2-4 | 2-4 | Flat list |
-| Standard | 8 | 8-32 | Flat |
-| Extended | 33 | 33+ | Grouped by domain |
-| Advanced | 64 | 64+ | Grouped by domain |
-| Deep | 128 | 128+ | Grouped by domain |
-| Comprehensive | 256 | 256+ | Multi-level hierarchy |
+| Effort Tier | ISC Minimum | ISC Range | Structure |
+|-------------|-------------|-----------|-----------|
+| Standard | 8 | 8-16 | Flat |
+| Extended | 16 | 16-32 | Grouped by domain |
+| Advanced | 24 | 24-48 | Grouped by domain |
+| Deep | 40 | 40-80 | Grouped by domain |
+| Comprehensive | 64 | 64-150 | Multi-level hierarchy |
 
 More ISC = finer verification = better hill-climbing. When in doubt, more criteria. One testable aspect per criterion.
 


### PR DESCRIPTION
## Problem

SKILL.md and the Algorithm (v3.7.0) define conflicting effort budgets and ISC minimums for the same tiers. Both files are loaded into every session simultaneously, so the model sees contradictory requirements and picks whichever it encounters first in context.

**Effort Budgets:**

| Tier | Algorithm (§7-13) | SKILL.md (§60-68) |
|------|--------------------|--------------------|
| Extended | <8min | <4min |
| Advanced | <16min | <8min |

SKILL.md also defines Instant and Fast tiers not present in the Algorithm.

**ISC Minimums:**

| Tier | Algorithm ISC Count Gate (§182-188) | SKILL.md ISC Rules (§198-208) |
|------|-------------------------------------|-------------------------------|
| Standard | 8 | 8 |
| Extended | 16 | 33 |
| Advanced | 24 | 64 |
| Deep | 40 | 128 |
| Comprehensive | 64 | 256 |

## Fix

Aligned SKILL.md tables with the Algorithm since the Algorithm contains the ISC Count Gate enforcement logic. Removed the Instant/Fast tiers that only existed in SKILL.md and had no counterpart in the Algorithm.

## Files Changed

- `Releases/v4.0.3/.claude/PAI/SKILL.md` — Effort Levels table (lines 60-68) and ISC minimums table (lines 198-208)