### PR TITLE
fix: align SKILL.md ISC system-of-record with Algorithm's PRD design

### DIFF
--- a/Releases/v4.0.3/.claude/PAI/SKILL.md
+++ b/Releases/v4.0.3/.claude/PAI/SKILL.md
@@ -191,7 +191,7 @@ Extended+:
 
 ## ISC Rules
 
-**System of record: Claude Code task system.** All ISC via `TaskCreate`/`TaskList`/`TaskUpdate`. Task system is sole source of truth — no text-based tracking.
+**System of record: PRD.md.** All ISC written as `- [ ] ISC-N: criterion` checkboxes in the PRD's `## Criteria` section using Write/Edit tools. PRD.md in `MEMORY/WORK/{slug}/` is the single source of truth — aligned with Algorithm's PRD-first design.
 
 **Every criterion:** 8-16 words, state not action, binary testable, one concern.
 


### PR DESCRIPTION
## Problem

SKILL.md and the Algorithm define mutually exclusive systems of record for ISC (Ideal State Criteria) tracking:

**SKILL.md** (line 194):
> "System of record: Claude Code task system. All ISC via TaskCreate/TaskList/TaskUpdate. Task system is sole source of truth — no text-based tracking."

**Algorithm v3.7.0** (lines 38-51):
> "The AI writes ALL PRD content directly using Write/Edit tools. PRD.md in MEMORY/WORK/{slug}/ is the single source of truth."

These are mutually exclusive instructions. The model alternates between using TaskCreate and writing PRD checkboxes depending on which instruction is more salient in context, producing inconsistent artifacts across sessions.

## Fix

Aligned SKILL.md with the Algorithm's PRD-first design since:
1. The Algorithm explicitly defines the PRDSync hook architecture (hooks read from PRD, never write to it)
2. The Algorithm's PRD system of record appears to represent the newer architectural intent
3. The Algorithm contains the ISC Count Gate enforcement logic that references PRD criteria

## Files Changed

- `Releases/v4.0.3/.claude/PAI/SKILL.md` — ISC Rules section (line 194)