### PR TITLE
Fix MEMORY statusline icon spacing

### DIFF
--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -563,24 +563,24 @@ printf "${SLATE_600}────────────────────
 
 case "$MODE" in
     nano)
-        printf "${LEARN_PRIMARY}◎${RESET} ${LEARN_WORK}📁${RESET}${SLATE_300}${work_count}${RESET} ${LEARN_SIGNALS}✦${RESET}${SLATE_300}${ratings_count}${RESET} ${LEARN_SESSIONS}⊕${RESET}${SLATE_300}${sessions_count}${RESET} ${LEARN_RESEARCH}◇${RESET}${SLATE_300}${research_count}${RESET}\n"
+        printf "${LEARN_PRIMARY}◎${RESET} ${LEARN_WORK}📁 ${RESET}${SLATE_300}${work_count}${RESET} ${LEARN_SIGNALS}✦ ${RESET}${SLATE_300}${ratings_count}${RESET} ${LEARN_SESSIONS}⊕ ${RESET}${SLATE_300}${sessions_count}${RESET} ${LEARN_RESEARCH}◇ ${RESET}${SLATE_300}${research_count}${RESET}\n"
         ;;
     micro)
-        printf "${LEARN_PRIMARY}◎${RESET} ${LEARN_WORK}📁${RESET}${SLATE_300}${work_count}${RESET} ${LEARN_SIGNALS}✦${RESET}${SLATE_300}${ratings_count}${RESET} ${LEARN_SESSIONS}⊕${RESET}${SLATE_300}${sessions_count}${RESET} ${LEARN_RESEARCH}◇${RESET}${SLATE_300}${research_count}${RESET}\n"
+        printf "${LEARN_PRIMARY}◎${RESET} ${LEARN_WORK}📁 ${RESET}${SLATE_300}${work_count}${RESET} ${LEARN_SIGNALS}✦ ${RESET}${SLATE_300}${ratings_count}${RESET} ${LEARN_SESSIONS}⊕ ${RESET}${SLATE_300}${sessions_count}${RESET} ${LEARN_RESEARCH}◇ ${RESET}${SLATE_300}${research_count}${RESET}\n"
         ;;
     mini)
         printf "${LEARN_PRIMARY}◎${RESET} ${LEARN_SECONDARY}MEMORY:${RESET} "
-        printf "${LEARN_WORK}📁${RESET}${SLATE_300}${work_count}${RESET} "
-        printf "${SLATE_600}│${RESET} ${LEARN_SIGNALS}✦${RESET}${SLATE_300}${ratings_count}${RESET} "
-        printf "${SLATE_600}│${RESET} ${LEARN_SESSIONS}⊕${RESET}${SLATE_300}${sessions_count}${RESET} "
-        printf "${SLATE_600}│${RESET} ${LEARN_RESEARCH}◇${RESET}${SLATE_300}${research_count}${RESET}\n"
+        printf "${LEARN_WORK}📁 ${RESET}${SLATE_300}${work_count}${RESET} "
+        printf "${SLATE_600}│${RESET} ${LEARN_SIGNALS}✦ ${RESET}${SLATE_300}${ratings_count}${RESET} "
+        printf "${SLATE_600}│${RESET} ${LEARN_SESSIONS}⊕ ${RESET}${SLATE_300}${sessions_count}${RESET} "
+        printf "${SLATE_600}│${RESET} ${LEARN_RESEARCH}◇ ${RESET}${SLATE_300}${research_count}${RESET}\n"
         ;;
     normal)
         printf "${LEARN_PRIMARY}◎${RESET} ${LEARN_SECONDARY}MEMORY:${RESET} "
-        printf "${LEARN_WORK}📁${RESET}${SLATE_300}${work_count}${RESET} ${LEARN_WORK}Work${RESET} "
-        printf "${SLATE_600}│${RESET} ${LEARN_SIGNALS}✦${RESET}${SLATE_300}${ratings_count}${RESET} ${LEARN_SIGNALS}Ratings${RESET} "
-        printf "${SLATE_600}│${RESET} ${LEARN_SESSIONS}⊕${RESET}${SLATE_300}${sessions_count}${RESET} ${LEARN_SESSIONS}Sessions${RESET} "
-        printf "${SLATE_600}│${RESET} ${LEARN_RESEARCH}◇${RESET}${SLATE_300}${research_count}${RESET} ${LEARN_RESEARCH}Research${RESET}\n"
+        printf "${LEARN_WORK}📁 ${RESET}${SLATE_300}${work_count}${RESET} ${LEARN_WORK}Work${RESET} "
+        printf "${SLATE_600}│${RESET} ${LEARN_SIGNALS}✦ ${RESET}${SLATE_300}${ratings_count}${RESET} ${LEARN_SIGNALS}Ratings${RESET} "
+        printf "${SLATE_600}│${RESET} ${LEARN_SESSIONS}⊕ ${RESET}${SLATE_300}${sessions_count}${RESET} ${LEARN_SESSIONS}Sessions${RESET} "
+        printf "${SLATE_600}│${RESET} ${LEARN_RESEARCH}◇ ${RESET}${SLATE_300}${research_count}${RESET} ${LEARN_RESEARCH}Research${RESET}\n"
         ;;
 esac
 


### PR DESCRIPTION
## Summary

- Add space between MEMORY line icons (`📁`, `✦`, `⊕`, `◇`) and their numeric values across all 4 display modes (nano, micro, mini, normal)
- Pure spacing fix — no logic, color, or behavioral changes

Fixes #899

## Before / After

| Before | After |
|--------|-------|
| `📁478 Work` | `📁 478 Work` |
| `✦379 Ratings` | `✦ 379 Ratings` |
| `⊕8 Sessions` | `⊕ 8 Sessions` |
| `◇0 Research` | `◇ 0 Research` |

## Changes

**File:** `.claude/statusline-command.sh`

Added a single space after each icon character before the `${RESET}` escape in all 4 display mode blocks (16 lines changed, identical pattern per icon).

## Test plan

- [ ] Run `bash ~/.claude/statusline-command.sh` and verify spacing between icons and values on the MEMORY line
- [ ] Confirm all 4 display modes render correctly (resize terminal to test nano/micro/mini/normal)
- [ ] Verify no extra whitespace or alignment regressions on other statusline sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)