### PR TITLE
fix(install): guard headless detection against unbound variables

### DIFF
--- a/Releases/v4.0.3/.claude/PAI-Install/install.sh
+++ b/Releases/v4.0.3/.claude/PAI-Install/install.sh
@@ -155,11 +155,12 @@ info "Launching installer..."
 echo ""
 
 # Auto-detect headless/SSH environments and fall back to CLI mode
-if [ -z "$DISPLAY" ] && [ -z "$WAYLAND_DISPLAY" ] && [ "$(uname)" != "Darwin" ]; then
-    INSTALL_MODE="cli"
-    info "Headless environment detected — using CLI installer."
-else
+# Use ${VAR:-} to avoid unbound variable errors under set -u
+INSTALL_MODE="cli"
+if [[ -n "${DISPLAY:-}" ]] || [[ -n "${WAYLAND_DISPLAY:-}" ]] || [[ "$(uname)" == "Darwin" ]]; then
     INSTALL_MODE="gui"
+else
+    info "No display detected — using CLI installer"
 fi
 
 exec bun run "$INSTALLER_DIR/main.ts" --mode "$INSTALL_MODE"


### PR DESCRIPTION
## Summary

- v4.0.3 `install.sh` uses `set -euo pipefail`, but the headless display detection references `$DISPLAY` and `$WAYLAND_DISPLAY` without default-value guards
- On headless servers where these variables are unset, `set -u` causes an unbound variable error before detection can run — the installer crashes instead of falling back to CLI mode

## Fix

- Uses `${VAR:-}` syntax so unset variables evaluate as empty strings instead of crashing
- Defaults to CLI mode (works everywhere), only activates GUI when a display server is confirmed available or on macOS

## Test plan

- [ ] Run `install.sh` on headless Linux (no $DISPLAY) — should launch CLI wizard
- [ ] Run `install.sh` on desktop Linux/macOS — should launch GUI as before
- [ ] Run `DISPLAY=:0 install.sh` on headless — should attempt GUI (confirms detection works)