### PR TITLE
fix: add embedded safe defaults to SecurityValidator

### DIFF
--- a/Releases/v4.0.3/.claude/hooks/SecurityValidator.hook.ts
+++ b/Releases/v4.0.3/.claude/hooks/SecurityValidator.hook.ts
@@ -32,8 +32,8 @@
  * - MUST RUN AFTER: None
  *
  * ERROR HANDLING:
- * - Missing patterns.yaml: Uses default safe patterns
- * - Parse errors: Logs warning, allows operation (fail-open for usability)
+ * - Missing patterns.yaml: Uses embedded safe defaults (catastrophic ops blocked)
+ * - Parse errors: Logs warning, falls back to embedded safe defaults
  * - Logging failures: Silent (should not block operations)
  *
  * PERFORMANCE:
@@ -204,20 +204,75 @@ function getPatternsPath(): string | null {
   return null;
 }
 
+// ========================================
+// Embedded Safe Defaults
+// ========================================
+
+/**
+ * Hardcoded catastrophic-operation patterns used when no patterns.yaml or
+ * patterns.example.yaml is found. Without this, a missing config silently
+ * disables all protection — the hook runs on every tool call but blocks nothing.
+ *
+ * v4.0.3 ships neither PAISECURITYSYSTEM/ directories nor patterns files,
+ * and the installer does not create them, so every fresh install hits this path.
+ */
+function getEmbeddedDefaults(): PatternsConfig {
+  return {
+    version: '0.0-embedded',
+    philosophy: { mode: 'safe_functional', principle: 'Embedded defaults - external config unavailable' },
+    bash: {
+      trusted: [],
+      blocked: [
+        { pattern: 'rm\\s+-rf\\s+/', reason: 'Filesystem destruction' },
+        { pattern: 'rm\\s+-rf\\s+~', reason: 'Home directory destruction' },
+        { pattern: 'sudo\\s+rm\\s+-rf\\s+/', reason: 'Filesystem destruction with sudo' },
+        { pattern: 'sudo\\s+rm\\s+-rf\\s+~', reason: 'Home directory destruction with sudo' },
+        { pattern: 'diskutil\\s+eraseDisk', reason: 'Disk destruction' },
+        { pattern: 'diskutil\\s+zeroDisk', reason: 'Disk destruction' },
+        { pattern: 'diskutil\\s+partitionDisk', reason: 'Disk partitioning' },
+        { pattern: 'diskutil\\s+apfs\\s+deleteContainer', reason: 'APFS container deletion' },
+        { pattern: 'diskutil\\s+apfs\\s+eraseVolume', reason: 'Volume destruction' },
+        { pattern: 'dd\\s+if=/dev/zero', reason: 'Disk overwrite' },
+        { pattern: 'mkfs\\.', reason: 'Filesystem format' },
+        { pattern: 'gh\\s+repo\\s+delete', reason: 'Repository deletion' },
+      ],
+      confirm: [
+        { pattern: 'git\\s+push\\s+--force', reason: 'Force push can overwrite remote history' },
+        { pattern: 'git\\s+push\\s+-f\\b', reason: 'Force push can overwrite remote history' },
+        { pattern: 'git\\s+reset\\s+--hard', reason: 'Hard reset discards uncommitted changes' },
+      ],
+      alert: [
+        { pattern: 'curl.*\\|.*sh', reason: 'Piping remote content to shell' },
+        { pattern: 'curl.*\\|.*bash', reason: 'Piping remote content to shell' },
+      ],
+    },
+    paths: {
+      zeroAccess: [
+        '~/.ssh/id_*',
+        '~/.ssh/config',
+        '~/.gnupg/**',
+        '~/.aws/credentials',
+        '~/.config/gh/hosts.yml',
+      ],
+      readOnly: [],
+      confirmWrite: [],
+      noDelete: [],
+    },
+    projects: {}
+  };
+}
+
 function loadPatterns(): PatternsConfig {
   if (patternsCache) return patternsCache;
 
   const patternsPath = getPatternsPath();
 
   if (!patternsPath) {
-    // No patterns file - fail open (allow all)
-    return {
-      version: '0.0',
-      philosophy: { mode: 'permissive', principle: 'No patterns loaded - fail open' },
-      bash: { trusted: [], blocked: [], confirm: [], alert: [] },
-      paths: { zeroAccess: [], readOnly: [], confirmWrite: [], noDelete: [] },
-      projects: {}
-    };
+    // No patterns file found - use embedded safe defaults
+    console.error('[PAI SECURITY] No patterns.yaml found. Using embedded safe defaults.');
+    const defaults = getEmbeddedDefaults();
+    patternsCache = defaults;
+    return defaults;
   }
 
   try {
@@ -225,15 +280,12 @@ function loadPatterns(): PatternsConfig {
     patternsCache = parseYaml(content) as PatternsConfig;
     return patternsCache;
   } catch (error) {
-    // Parse error - fail open
-    console.error(`Failed to parse ${patternsSource} patterns.yaml:`, error);
-    return {
-      version: '0.0',
-      philosophy: { mode: 'permissive', principle: 'Parse error - fail open' },
-      bash: { trusted: [], blocked: [], confirm: [], alert: [] },
-      paths: { zeroAccess: [], readOnly: [], confirmWrite: [], noDelete: [] },
-      projects: {}
-    };
+    // Parse error - fall back to embedded defaults rather than empty config
+    console.error(`[PAI SECURITY] Failed to parse ${patternsSource} patterns.yaml:`, error);
+    console.error('[PAI SECURITY] Falling back to embedded safe defaults.');
+    const defaults = getEmbeddedDefaults();
+    patternsCache = defaults;
+    return defaults;
   }
 }
 


### PR DESCRIPTION
## Problem

`SecurityValidator.hook.ts` looks for security patterns in two locations:
1. `PAI/USER/PAISECURITYSYSTEM/patterns.yaml` (user rules)
2. `PAI/PAISECURITYSYSTEM/patterns.example.yaml` (system defaults)

v4.0.3 ships **neither** the `PAISECURITYSYSTEM/` directories nor the pattern files. The installer does not create them. The hook's `getPatternsPath()` returns `null`, and `loadPatterns()` returns empty arrays for all pattern categories:

```typescript
bash: { trusted: [], blocked: [], confirm: [], alert: [] },
paths: { zeroAccess: [], readOnly: [], confirmWrite: [], noDelete: [] },
```

The result: every fresh v4.0.3 install has a SecurityValidator that runs on every tool call but **blocks nothing**. Destructive filesystem commands, disk operations, and repo deletions pass through unchecked.

The hook's own docstring (line 35) says "Missing patterns.yaml: Uses default safe patterns" but no such defaults exist in the code.

## Fix

Adds a `getEmbeddedDefaults()` function with hardcoded patterns for catastrophic operations:

- **Blocked:** filesystem destruction, disk operations (`diskutil eraseDisk/zeroDisk/partitionDisk`, `dd if=/dev/zero`, `mkfs`), repo deletion (`gh repo delete`)
- **Confirm:** force push (`git push --force/-f`), hard reset (`git reset --hard`)
- **Alert:** piping remote content to shell (`curl | sh/bash`)
- **Path protection:** SSH keys, GnuPG, AWS credentials, gh token

When no external config is found or parsing fails, `loadPatterns()` now falls back to these embedded defaults instead of empty arrays.

This is intentionally a minimal safety net. Users who create their own `patterns.yaml` override these defaults entirely, preserving the existing cascading config design.

## What this does NOT change

- No path changes (the v4.0 `PAI/USER/...` convention is correct and untouched)
- No output format changes
- No schema validation additions
- No changes outside `SecurityValidator.hook.ts`

## Test plan

- [ ] Fresh install without `patterns.yaml`: verify destructive commands trigger exit(2)
- [ ] Fresh install without `patterns.yaml`: verify `git push --force` triggers confirm prompt
- [ ] With user `patterns.yaml` present: verify user patterns are used (not embedded defaults)
- [ ] With malformed `patterns.yaml`: verify fallback to embedded defaults with error logged to stderr
