### PR TITLE
fix: SecurityValidator confirm handler silently passes through

### DIFF
--- a/Releases/v3.0/.claude/hooks/SecurityValidator.hook.ts
+++ b/Releases/v3.0/.claude/hooks/SecurityValidator.hook.ts
@@ -17,13 +17,22 @@
  * OUTPUT:
  * - stdout: JSON decision object
  *   - {"continue": true} → Allow operation
- *   - {"decision": "ask", "message": "..."} → Prompt user for confirmation
+ *   (Note: confirm-level operations now hard-block via exit(2), see below)
  * - exit(0): Normal completion (with decision)
  * - exit(2): Hard block (catastrophic operation prevented)
  *
  * SIDE EFFECTS:
  * - Writes to: MEMORY/SECURITY/YYYY/MM/security-{summary}-{timestamp}.jsonl
- * - User prompt: May trigger confirmation dialog for confirm-level operations
+ * - Confirm operations: Hard-blocked via exit(2) — see BUG FIX note below
+ *
+ * BUG FIX (2026-03-09):
+ * Claude Code PreToolUse hooks only recognize two stdout formats:
+ *   - {"continue": true} to allow the operation
+ *   - exit code 2 to hard block the operation
+ * The previously used {"decision": "ask"} format is NOT recognized by
+ * Claude Code and silently passes through, allowing operations that
+ * should require confirmation to execute without any user prompt.
+ * Confirm-level operations now use exit(2) to hard-block instead.
  *
  * INTER-HOOK RELATIONSHIPS:
  * - DEPENDS ON: patterns.yaml (security pattern definitions)
@@ -177,10 +186,10 @@ interface PatternsConfig {
 // ========================================
 
 // Pattern paths in priority order:
-// 1. skills/PAI/USER/PAISECURITYSYSTEM/patterns.yaml (user's custom rules)
-// 2. skills/PAI/PAISECURITYSYSTEM/patterns.example.yaml (default template)
-const USER_PATTERNS_PATH = paiPath('skills', 'PAI', 'USER', 'PAISECURITYSYSTEM', 'patterns.yaml');
-const SYSTEM_PATTERNS_PATH = paiPath('skills', 'PAI', 'PAISECURITYSYSTEM', 'patterns.example.yaml');
+// 1. PAI/USER/PAISECURITYSYSTEM/patterns.yaml (user's custom rules)
+// 2. PAI/PAISECURITYSYSTEM/patterns.example.yaml (default template)
+const USER_PATTERNS_PATH = paiPath('PAI', 'USER', 'PAISECURITYSYSTEM', 'patterns.yaml');
+const SYSTEM_PATTERNS_PATH = paiPath('PAI', 'PAISECURITYSYSTEM', 'patterns.example.yaml');
 
 let patternsCache: PatternsConfig | null = null;
 let patternsSource: 'user' | 'system' | 'none' = 'none';
@@ -427,12 +436,12 @@ function handleBash(input: HookInput): void {
         category: 'bash_command',
         target: command.slice(0, 500),
         reason: result.reason,
-        action_taken: 'Prompted user for confirmation'
+        action_taken: 'Hard block - exit 2 (confirm-level)'
       });
-      console.log(JSON.stringify({
-        decision: 'ask',
-        message: `[PAI SECURITY] ⚠️ ${result.reason}\n\nCommand: ${command.slice(0, 200)}\n\nProceed?`
-      }));
+      console.error(`[PAI SECURITY] BLOCKED (confirm): ${result.reason}`);
+      console.error(`Command: ${command.slice(0, 200)}`);
+      console.error(`This operation requires confirmation. Run it manually outside Claude Code.`);
+      process.exit(2);
       break;
 
     case 'alert':
@@ -494,12 +503,12 @@ function handleEdit(input: HookInput): void {
         category: 'path_access',
         target: filePath,
         reason: result.reason,
-        action_taken: 'Prompted user for confirmation'
+        action_taken: 'Hard block - exit 2 (confirm-level)'
       });
-      console.log(JSON.stringify({
-        decision: 'ask',
-        message: `[PAI SECURITY] ⚠️ ${result.reason}\n\nPath: ${filePath}\n\nProceed?`
-      }));
+      console.error(`[PAI SECURITY] BLOCKED (confirm): ${result.reason}`);
+      console.error(`Path: ${filePath}`);
+      console.error(`This operation requires confirmation. Run it manually outside Claude Code.`);
+      process.exit(2);
       break;
 
     default:
@@ -545,12 +554,12 @@ function handleWrite(input: HookInput): void {
         category: 'path_access',
         target: filePath,
         reason: result.reason,
-        action_taken: 'Prompted user for confirmation'
+        action_taken: 'Hard block - exit 2 (confirm-level)'
       });
-      console.log(JSON.stringify({
-        decision: 'ask',
-        message: `[PAI SECURITY] ⚠️ ${result.reason}\n\nPath: ${filePath}\n\nProceed?`
-      }));
+      console.error(`[PAI SECURITY] BLOCKED (confirm): ${result.reason}`);
+      console.error(`Path: ${filePath}`);
+      console.error(`This operation requires confirmation. Run it manually outside Claude Code.`);
+      process.exit(2);
       break;
 
     default:


### PR DESCRIPTION
## Summary

Two security bugs in SecurityValidator.hook.ts (v3.0) that cause the hook to be effectively non-functional:

- **Confirm handler uses wrong JSON structure**: The confirm category outputs `{"decision": "ask", "message": "..."}` to stdout, but Claude Code PreToolUse hooks require a specific JSON structure with `hookSpecificOutput.permissionDecision`. The `{"decision": "ask"}` format is not recognized and silently ignored, meaning operations matching confirm patterns execute without any user interaction.
- **Pattern file paths have incorrect prefix**: `paiPath('skills', 'PAI', 'USER', ...)` resolves to `~/.claude/skills/PAI/USER/...`, but `patterns.yaml` lives at `~/.claude/PAI/USER/...` (no `skills/` prefix). This means the patterns file is never found, SecurityValidator falls through to `EMPTY_PATTERNS` (fail-open, everything allowed).

## Proof: Claude Code only recognizes specific PreToolUse output formats

From the [official Claude Code hooks documentation](https://code.claude.com/docs/en/hooks-guide):

**Exit codes:**
> - **Exit 0**: the action proceeds.
> - **Exit 2**: the action is blocked. Write a reason to stderr, and Claude receives it as feedback.

**Structured JSON output (exit 0 + stdout):**
> For example, a PreToolUse hook can deny a tool call and tell Claude why, or escalate it to the user for approval:
> ```json
> {
>   "hookSpecificOutput": {
>     "hookEventName": "PreToolUse",
>     "permissionDecision": "deny",
>     "permissionDecisionReason": "Use rg instead of grep for better performance"
>   }
> }
> ```
> These three options are specific to PreToolUse:
> - `"allow"`: proceed without showing a permission prompt
> - `"deny"`: cancel the tool call and send the reason to Claude
> - `"ask"`: show the permission prompt to the user as normal

The upstream SecurityValidator outputs `{"decision": "ask", "message": "..."}` which does NOT match either recognized format. It's not exit code 2, and it's not the `hookSpecificOutput` structure. Claude Code silently ignores it and proceeds with the operation.

## Changes

1. Changed all 3 confirm handlers (Bash, Edit, Write) from outputting `{"decision": "ask"}` to using `process.exit(2)` with descriptive stderr messages — matching the hard-block pattern used for `blocked` category
2. Removed `'skills'` from both `paiPath()` calls so `patterns.yaml` is actually found at `~/.claude/PAI/USER/PAISECURITYSYSTEM/patterns.yaml`
3. Updated JSDoc header to document the bug fix

## Impact

Without this fix, SecurityValidator's confirm-level protections provide zero actual protection — they silently pass through. The path bug compounds this by preventing ALL pattern matching from working, meaning even blocked-level patterns don't fire.

## Alternative fix

Instead of `process.exit(2)`, the confirm handlers could use the correct JSON structure to actually prompt the user:
```json
{
  "hookSpecificOutput": {
    "hookEventName": "PreToolUse",
    "permissionDecision": "ask",
    "permissionDecisionReason": "This operation requires confirmation"
  }
}
```
This PR uses `exit(2)` (hard block) as the safer default, since confirm-level operations are inherently risky. But switching to `"permissionDecision": "ask"` would restore the original intent of prompting the user.

— 🍁 Maple