### PR TITLE
fix: add audio device probe and afplay timeout to VoiceServer

### DIFF
--- a/Releases/v4.0.3/.claude/VoiceServer/server.ts
+++ b/Releases/v4.0.3/.claude/VoiceServer/server.ts
@@ -41,6 +41,47 @@ if (!ELEVENLABS_API_KEY) {
 }
 
 // ==========================================================================
+// Audio Device Probe — detect at startup whether afplay can actually play audio.
+// If the default output device is unavailable (virtual device, no speakers,
+// or running under launchd without an audio session), afplay hangs indefinitely.
+// We detect this once and skip all voice playback when audio is unavailable.
+// ==========================================================================
+
+const AUDIO_PROBE_TIMEOUT_MS = 3_000;
+let audioAvailable = false;
+
+async function probeAudioDevice(): Promise<boolean> {
+  const testFile = '/System/Library/Sounds/Tink.aiff';
+  if (!existsSync(testFile)) return false;
+
+  return new Promise((resolve) => {
+    const proc = spawn('/usr/bin/afplay', ['-v', '0.01', testFile]);
+    const timer = setTimeout(() => {
+      proc.kill();
+      resolve(false);
+    }, AUDIO_PROBE_TIMEOUT_MS);
+
+    proc.on('exit', (code) => {
+      clearTimeout(timer);
+      resolve(code === 0);
+    });
+
+    proc.on('error', () => {
+      clearTimeout(timer);
+      resolve(false);
+    });
+  });
+}
+
+// Run probe at startup
+audioAvailable = await probeAudioDevice();
+if (audioAvailable) {
+  console.log('🔊 Audio probe: output device available');
+} else {
+  console.log('🔇 Audio probe: no usable output device — voice playback disabled');
+}
+
+// ==========================================================================
 // Pronunciation System
 // ==========================================================================
 
@@ -370,25 +411,52 @@ async function generateSpeech(
 }
 
 // Play audio using afplay (macOS)
+// Includes a timeout to prevent hanging when afplay can't access the audio device
+// (e.g., when running under launchd without an audio session).
+const AFPLAY_TIMEOUT_MS = 10_000; // 10s — most clips are 1-3s; timeout catches hung audio device
+
 async function playAudio(audioBuffer: ArrayBuffer, volume: number = FALLBACK_VOLUME): Promise<void> {
+  if (!audioAvailable) {
+    console.log('🔇 Skipping playback (no audio device)');
+    return;
+  }
+
   const tempFile = `/tmp/voice-${Date.now()}.mp3`;
 
   await Bun.write(tempFile, audioBuffer);
 
   return new Promise((resolve, reject) => {
     const proc = spawn('/usr/bin/afplay', ['-v', volume.toString(), tempFile]);
+    let settled = false;
+
+    const timeout = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        proc.kill();
+        spawn('/bin/rm', [tempFile]);
+        reject(new Error(`afplay timed out after ${AFPLAY_TIMEOUT_MS / 1000}s (likely no audio session)`));
+      }
+    }, AFPLAY_TIMEOUT_MS);
 
     proc.on('error', (error) => {
-      console.error('Error playing audio:', error);
-      reject(error);
+      if (!settled) {
+        settled = true;
+        clearTimeout(timeout);
+        console.error('Error playing audio:', error);
+        reject(error);
+      }
     });
 
     proc.on('exit', (code) => {
-      spawn('/bin/rm', [tempFile]);
-      if (code === 0) {
-        resolve();
-      } else {
-        reject(new Error(`afplay exited with code ${code}`));
+      if (!settled) {
+        settled = true;
+        clearTimeout(timeout);
+        spawn('/bin/rm', [tempFile]);
+        if (code === 0) {
+          resolve();
+        } else {
+          reject(new Error(`afplay exited with code ${code}`));
+        }
       }
     });
   });


### PR DESCRIPTION
## Summary

Two related reliability fixes for VoiceServer on macOS:

- **Audio device probe at startup**: Plays a near-silent system sound (`Tink.aiff` at 1% volume) with a 3-second timeout. If `afplay` hangs (no output device, virtual audio, or running under `launchd` without an audio session), all voice playback is disabled for the session rather than hanging the server
- **afplay timeout per-clip**: 10-second timeout on each playback call with a settled-flag pattern to prevent resolve/reject races. Most TTS clips are 1-3s, so 10s catches hung audio devices without cutting off legitimate long utterances

## Problem

Without these fixes, `afplay` hangs indefinitely when no audio output device is available, blocking the notification server's `/notify` endpoint. This commonly happens when:
- Running VoiceServer as a system service (launchd) without an audio session
- Virtual audio devices that accept connections but don't produce output
- Headless environments or SSH sessions

## File Changed

`Releases/v4.0.3/.claude/VoiceServer/server.ts`

## Test plan

- [ ] Start VoiceServer with working audio → probe reports "output device available", playback works
- [ ] Start VoiceServer without audio output → probe reports "no usable output device", `/notify` returns success but skips playback
- [ ] Send a notification during audio device disconnect → timeout fires after 10s instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)