### PR TITLE
fix: Add Identity section to CLAUDE.md template

### DIFF
--- a/Releases/v4.0.3/.claude/CLAUDE.md
+++ b/Releases/v4.0.3/.claude/CLAUDE.md
@@ -47,6 +47,15 @@ FOR: Multi-step, complex, or difficult work. Troubleshooting, debugging, buildin
 
 ---
 
+### Identity
+
+- **User:** User
+- **Assistant:** Assistant
+
+Always address the user as "User". The assistant's name "Assistant" may appear in system paths, project names, or other infrastructure — do not confuse infrastructure naming with the user's identity.
+
+---
+
 ### Critical Rules (Zero Exceptions)
 
 - **Mandatory output format** — Every response MUST use exactly one of the output formats above (ALGORITHM, NATIVE, or MINIMAL). No freeform output.

--- a/Releases/v4.0.3/.claude/CLAUDE.md.template
+++ b/Releases/v4.0.3/.claude/CLAUDE.md.template
@@ -47,6 +47,15 @@ FOR: Multi-step, complex, or difficult work. Troubleshooting, debugging, buildin
 
 ---
 
+### Identity
+
+- **User:** {PRINCIPAL.NAME}
+- **Assistant:** {DAIDENTITY.NAME}
+
+Always address the user as "{PRINCIPAL.NAME}". The assistant's name "{DAIDENTITY.NAME}" may appear in system paths, project names, or other infrastructure — do not confuse infrastructure naming with the user's identity.
+
+---
+
 ### Critical Rules (Zero Exceptions)
 
 - **Mandatory output format** — Every response MUST use exactly one of the output formats above (ALGORITHM, NATIVE, or MINIMAL). No freeform output.


### PR DESCRIPTION
## Problem

`CLAUDE.md.template` uses `{DAIDENTITY.NAME}` for the assistant's name in output format lines, but never includes `{PRINCIPAL.NAME}` (the user's name). The generated `CLAUDE.md` tells the LLM the assistant's name but not the user's name.

In setups where the assistant's name appears in system paths, project names, or OS usernames, the LLM mistakes the assistant's name for the user's identity — addressing the user by the wrong name.

**Data from affected setup** (2 weeks of Slack gateway logs):
- Before v4.0 (had explicit identity injection in LoadContext hook): 0 name misidentifications across 200+ messages
- After v4.0 (identity injection removed, relies on CLAUDE.md): 30+ misidentifications, getting worse on high-volume days

## Fix

Add an Identity section to `CLAUDE.md.template` between the format definitions and Critical Rules:

```
### Identity

- **User:** {PRINCIPAL.NAME}
- **Assistant:** {DAIDENTITY.NAME}

Always address the user as "{PRINCIPAL.NAME}". The assistant's name "{DAIDENTITY.NAME}" may appear in system paths, project names, or other infrastructure — do not confuse infrastructure naming with the user's identity.
```

`BuildCLAUDE.ts` already resolves `{PRINCIPAL.NAME}` from `settings.json`, so this just needs the template reference. Updated the pre-built `CLAUDE.md` with default values ("User"/"Assistant") to match.

## Files Changed

- `Releases/v4.0.3/.claude/CLAUDE.md.template` — Added Identity section with template variables
- `Releases/v4.0.3/.claude/CLAUDE.md` — Updated pre-built version with default values

🤖 Generated with [Claude Code](https://claude.com/claude-code)