### PR TITLE
Add --bare flag to algorithm.ts subprocess spawns

### DIFF
--- a/Releases/v4.0.3/.claude/PAI/Tools/algorithm.ts
+++ b/Releases/v4.0.3/.claude/PAI/Tools/algorithm.ts
@@ -666,7 +666,7 @@ async function runParallelIteration(
   const processes = assignments.map(assignment => {
     const criterion = assignment.criteriaDetails[0]; // One criterion per agent
     const prompt = buildWorkerPrompt(prdPath, assignment.agentId, criterion, iteration);
-    const proc = Bun.spawn(["claude", "-p", prompt,
+    const proc = Bun.spawn(["claude", "-p", "--bare", prompt,
       "--allowedTools", "Edit,Write,Bash,Read,Glob,Grep,WebFetch,WebSearch,NotebookEdit",
     ], {
       cwd: dirname(prdPath),
@@ -1112,7 +1112,7 @@ async function runLoop(prdPath: string, maxOverride?: number, agentCount: number
     const prompt = buildIterationPrompt(absPath, newIteration, max);
 
     const result = spawnSync("claude", [
-      "-p", prompt,
+      "-p", "--bare", prompt,
       "--allowedTools", "Edit,Write,Bash,Read,Glob,Grep,WebFetch,WebSearch,Task,TaskCreate,TaskUpdate,TaskList,NotebookEdit",
     ], {
       stdio: ["pipe", "pipe", "pipe"],


### PR DESCRIPTION
## Summary

- Add `--bare` flag to both `claude -p` subprocess calls in `algorithm.ts` (parallel workers at line 669, sequential iteration at line 1114)
- Interactive mode spawn (line 1227) intentionally left unchanged

## Problem

Algorithm loop mode spawns `claude -p` subprocesses that load the full Claude Code environment — all hooks, LSP, plugin sync, and skill directory walks. This causes:

1. **Unnecessary overhead** that compounds with parallel agents (N agents × full boot cost)
2. **Unintended side-effects** in headless context: voice notifications, session state writes, rating capture hooks all fire in automation subprocesses where they're meaningless
3. **Potential state corruption** from hooks writing session data in concurrent subprocess contexts

## Fix

`--bare` was added in Claude Code v2.1.81 specifically for scripted `-p` calls. It skips hooks, LSP initialization, plugin synchronization, and skill directory walks — giving clean headless execution.

```diff
-    const proc = Bun.spawn(["claude", "-p", prompt,
+    const proc = Bun.spawn(["claude", "-p", "--bare", prompt,
```

## Impact

Every PAI user running Algorithm loop mode benefits. The fix is 2 lines with zero behavioral change to the actual agent work — only the subprocess boot path is streamlined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)