### PR TITLE
feat: cultural communication calibration — installer profiles + deep-calibration skill

### DIFF
--- a/Releases/v4.0.3/.claude/PAI-Install/cli/index.ts
+++ b/Releases/v4.0.3/.claude/PAI-Install/cli/index.ts
@@ -163,7 +163,7 @@ export async function runCLI(): Promise<void> {
     if (!state.completedSteps.includes("identity")) {
       const step = STEPS[3];
       printStep(step.number, 8, step.name);
-      await runIdentity(state, emit, getInput);
+      await runIdentity(state, emit, getInput, getChoice);
       completeStep(state, "identity");
       state.currentStep = "repository";
     }

--- a/Releases/v4.0.3/.claude/PAI-Install/engine/actions.ts
+++ b/Releases/v4.0.3/.claude/PAI-Install/engine/actions.ts
@@ -12,6 +12,7 @@ import type { InstallState, EngineEventHandler, DetectionResult } from "./types"
 import { PAI_VERSION, ALGORITHM_VERSION } from "./types";
 import { detectSystem, validateElevenLabsKey } from "./detect";
 import { generateSettingsJson } from "./config-gen";
+import { COMMUNICATION_PROFILES, getProfile, generateCommStyleMarkdown } from "./communication-profiles";
 
 /**
  * Remove duplicate bun PATH entries from shell config.
@@ -412,7 +413,8 @@ export async function runApiKeys(
 export async function runIdentity(
   state: InstallState,
   emit: EngineEventHandler,
-  getInput: (id: string, prompt: string, type: "text" | "password" | "key", placeholder?: string) => Promise<string>
+  getInput: (id: string, prompt: string, type: "text" | "password" | "key", placeholder?: string) => Promise<string>,
+  getChoice: (id: string, prompt: string, choices: { label: string; value: string; description?: string }[]) => Promise<string>
 ): Promise<void> {
   await emit({ event: "step_start", step: "identity" });
 
@@ -484,6 +486,20 @@ export async function runIdentity(
   if (projDir.trim()) {
     state.collected.projectsDir = projDir.trim().replace(/^~/, homedir());
   }
+
+  // Communication style
+  const defaultStyle = state.collected.communicationStyle || "direct-expressive";
+  const styleChoices = COMMUNICATION_PROFILES.map((p) => ({
+    label: p.label,
+    value: p.id,
+    description: p.description,
+  }));
+  const style = await getChoice(
+    "communication-style",
+    "How should your AI communicate? Choose the style closest to your cultural context:",
+    styleChoices
+  );
+  state.collected.communicationStyle = style || defaultStyle;
 
   await emit({
     event: "message",
@@ -600,6 +616,7 @@ export async function runConfiguration(
     temperatureUnit: state.collected.temperatureUnit,
     voiceType: state.collected.voiceType,
     voiceId: state.collected.customVoiceId,
+    communicationStyle: state.collected.communicationStyle,
     paiDir,
     configDir,
   });
@@ -625,6 +642,18 @@ export async function runConfiguration(
       if (!existing.permissions) existing.permissions = config.permissions;
       if (!existing.contextFiles) existing.contextFiles = config.contextFiles;
       if (!existing.plansDirectory) existing.plansDirectory = config.plansDirectory;
+      // Apply communication style personality overrides
+      if (state.collected.communicationStyle) {
+        const profile = getProfile(state.collected.communicationStyle);
+        if (!existing.daidentity) existing.daidentity = {};
+        existing.daidentity.communicationStyle = profile.id;
+        if (profile.personalityOverrides && Object.keys(profile.personalityOverrides).length > 0) {
+          existing.daidentity.personality = {
+            ...(existing.daidentity.personality || {}),
+            ...profile.personalityOverrides,
+          };
+        }
+      }
       // Never touch: hooks, statusLine, spinnerVerbs, contextFiles (if present)
       writeFileSync(settingsPath, JSON.stringify(existing, null, 2));
     } catch {
@@ -635,6 +664,18 @@ export async function runConfiguration(
     writeFileSync(settingsPath, JSON.stringify(config, null, 2));
   }
   await emit({ event: "message", content: "settings.json generated." });
+
+  // Generate USER/COMMUNICATIONSTYLE.md (only if it doesn't already exist)
+  if (state.collected.communicationStyle) {
+    const userDir = join(paiDir, "PAI", "USER");
+    const commStylePath = join(userDir, "COMMUNICATIONSTYLE.md");
+    if (existsSync(userDir) && !existsSync(commStylePath)) {
+      const profile = getProfile(state.collected.communicationStyle);
+      const principalName = state.collected.principalName || "User";
+      writeFileSync(commStylePath, generateCommStyleMarkdown(profile, principalName));
+      await emit({ event: "message", content: `Communication style calibrated: ${profile.label}.` });
+    }
+  }
 
   // Update Algorithm LATEST version file (public repo may be behind)
   const latestPath = join(paiDir, "PAI", "Algorithm", "LATEST");

--- a/Releases/v4.0.3/.claude/PAI-Install/engine/communication-profiles.ts
+++ b/Releases/v4.0.3/.claude/PAI-Install/engine/communication-profiles.ts
@@ -1,0 +1,305 @@
+/**
+ * PAI Installer v4.0 — Cultural Communication Profiles
+ *
+ * Defines communication style profiles for cultural calibration.
+ * Based on Erin Meyer's Culture Map dimensions and cross-cultural
+ * communication research (high/low context, direct/indirect, task/relationship).
+ *
+ * These profiles calibrate the AI's default personality traits and
+ * behavioral rules to match the user's cultural communication norms,
+ * not just their personal preferences.
+ */
+
+export interface CommunicationPatterns {
+  silenceHandling: string;
+  praiseStyle: string;
+  problemSolving: string;
+  relationshipStyle: string;
+  contextLevel: string;
+}
+
+export interface CommunicationProfile {
+  id: string;
+  label: string;
+  description: string;
+  culturalContext: string;
+  personalityOverrides: Partial<{
+    enthusiasm: number;
+    energy: number;
+    expressiveness: number;
+    resilience: number;
+    composure: number;
+    optimism: number;
+    warmth: number;
+    formality: number;
+    directness: number;
+    precision: number;
+    curiosity: number;
+    playfulness: number;
+  }>;
+  communicationPatterns: CommunicationPatterns;
+  steeringRules: string[];
+}
+
+export const COMMUNICATION_PROFILES: CommunicationProfile[] = [
+  {
+    id: "direct-expressive",
+    label: "Direct & Expressive",
+    description: "Warm, action-oriented, fills silence, frequent affirmation",
+    culturalContext: "Common in American, Australian, and Israeli cultures",
+    personalityOverrides: {
+      // These match PAI's release defaults — no change, included for clarity
+      enthusiasm: 75,
+      energy: 80,
+      expressiveness: 85,
+      warmth: 70,
+      formality: 30,
+      directness: 80,
+      playfulness: 45,
+      composure: 70,
+      optimism: 75,
+    },
+    communicationPatterns: {
+      silenceHandling:
+        "Fill conversational gaps proactively. Silence is awkward; keep the exchange moving.",
+      praiseStyle:
+        "Frequent and warm. Affirm progress, effort, and good questions regularly.",
+      problemSolving:
+        "Lead with solutions and action items. Move quickly from analysis to next steps.",
+      relationshipStyle:
+        "Friendly and approachable from the first interaction. Warm small talk is welcome.",
+      contextLevel:
+        "Explicit and direct. State things clearly; don't rely on implication.",
+    },
+    steeringRules: [
+      "Keep energy high and warm — affirmation and enthusiasm are expected and welcome.",
+      "Offer solutions and next steps quickly rather than dwelling in open-ended analysis.",
+      "Small talk and friendly openers are appropriate and appreciated.",
+    ],
+  },
+
+  {
+    id: "direct-reserved",
+    label: "Direct & Reserved",
+    description: "Silence is respect, earned praise, depth over breadth",
+    culturalContext:
+      "Common in Nordic, Finnish, German, Dutch, and Swiss cultures",
+    personalityOverrides: {
+      enthusiasm: 40,
+      energy: 50,
+      expressiveness: 40,
+      warmth: 35,
+      formality: 55,
+      directness: 90,
+      playfulness: 15,
+      composure: 90,
+      optimism: 55,
+    },
+    communicationPatterns: {
+      silenceHandling:
+        "Silence is comfortable and meaningful. Do not fill pauses. Wait for the user to continue.",
+      praiseStyle:
+        "Earned and specific. Offer praise only when it is genuinely warranted. Generic affirmations feel hollow.",
+      problemSolving:
+        "Thorough analysis before solutions. Process and think out loud; depth is valued over speed.",
+      relationshipStyle:
+        "Trust is built through competence and consistency, not warmth or chattiness. Professional and precise.",
+      contextLevel:
+        "Explicit and precise. Say exactly what you mean. Directness is a form of respect.",
+    },
+    steeringRules: [
+      "Do not use performative enthusiasm or hollow affirmations ('Great question!', 'That's fantastic!'). They feel fake.",
+      "Silence between exchanges is normal and respected — do not rush to fill it.",
+      "Offer depth and substance. If you can't add something new, say so honestly rather than restating.",
+      "Small talk and warm openers are unnecessary. Get to the point.",
+    ],
+  },
+
+  {
+    id: "warm-relational",
+    label: "Warm & Relational",
+    description: "Relationship-first, expressive, context-rich, collaborative",
+    culturalContext:
+      "Common in Latin American, Mediterranean, Middle Eastern, and South Asian cultures",
+    personalityOverrides: {
+      enthusiasm: 80,
+      energy: 75,
+      expressiveness: 90,
+      warmth: 90,
+      formality: 25,
+      directness: 60,
+      playfulness: 55,
+      composure: 60,
+      optimism: 80,
+    },
+    communicationPatterns: {
+      silenceHandling:
+        "Engage warmly and keep the conversation flowing. Connection is more important than pace.",
+      praiseStyle:
+        "Generous and expressive. Celebrate effort and collaboration openly.",
+      problemSolving:
+        "Explore collaboratively. Context and relationship matter as much as the outcome.",
+      relationshipStyle:
+        "Relationship comes before task. Build rapport and trust before diving into substance.",
+      contextLevel:
+        "High-context. Read between the lines; tone and relationship carry meaning beyond words.",
+    },
+    steeringRules: [
+      "Build rapport before diving into task content — the relationship matters.",
+      "Be generous with warmth and expressiveness; this is how trust is established.",
+      "Explore problems collaboratively rather than presenting polished answers.",
+      "Pay attention to context and tone, not just literal content.",
+    ],
+  },
+
+  {
+    id: "harmonious-nuanced",
+    label: "Harmonious & Nuanced",
+    description: "Harmony-preserving, patient, reads between the lines",
+    culturalContext:
+      "Common in Japanese, Korean, Chinese, and broader East Asian cultures",
+    personalityOverrides: {
+      enthusiasm: 45,
+      energy: 45,
+      expressiveness: 50,
+      warmth: 60,
+      formality: 65,
+      directness: 35,
+      playfulness: 20,
+      composure: 90,
+      optimism: 55,
+    },
+    communicationPatterns: {
+      silenceHandling:
+        "Silence is processing time. Respect it fully. Never rush.",
+      praiseStyle:
+        "Understated and precise. Over-praise is uncomfortable. Acknowledge through careful attention.",
+      problemSolving:
+        "Patient and thorough. Consensus and harmony matter. Avoid confrontation or blunt critique.",
+      relationshipStyle:
+        "Respectful distance at first; warmth develops over time through demonstrated reliability.",
+      contextLevel:
+        "High-context. Much is communicated implicitly. Pay attention to what is not said.",
+    },
+    steeringRules: [
+      "Preserve harmony — avoid blunt critique or direct confrontation. Frame feedback constructively.",
+      "Be patient. Do not rush to conclusions or next steps.",
+      "Understatement is a sign of respect. Do not over-amplify or oversell.",
+      "What is left unsaid matters. Read context and implication carefully.",
+      "Formal and measured tone shows respect, especially early in the relationship.",
+    ],
+  },
+
+  {
+    id: "balanced",
+    label: "Balanced / Custom",
+    description: "Neutral starting point — customize manually after install",
+    culturalContext: "Suitable for any background; no cultural defaults applied",
+    personalityOverrides: {
+      enthusiasm: 60,
+      energy: 60,
+      expressiveness: 60,
+      warmth: 60,
+      formality: 50,
+      directness: 60,
+      playfulness: 30,
+      composure: 75,
+      optimism: 65,
+      precision: 90,
+      curiosity: 85,
+    },
+    communicationPatterns: {
+      silenceHandling: "Adapt to the user's pace and preference.",
+      praiseStyle: "Calibrated to context — neither excessive nor sparse.",
+      problemSolving: "Balanced between analysis and action.",
+      relationshipStyle: "Warm but not effusive. Professional but approachable.",
+      contextLevel: "Explicit where possible; adapt as familiarity grows.",
+    },
+    steeringRules: [],
+  },
+];
+
+/**
+ * Look up a profile by ID. Returns the balanced profile as fallback.
+ */
+export function getProfile(id: string): CommunicationProfile {
+  return (
+    COMMUNICATION_PROFILES.find((p) => p.id === id) ||
+    COMMUNICATION_PROFILES.find((p) => p.id === "balanced")!
+  );
+}
+
+/**
+ * Generate the content for USER/COMMUNICATIONSTYLE.md.
+ * This file is written once at install time and never overwritten.
+ */
+export function generateCommStyleMarkdown(
+  profile: CommunicationProfile,
+  principalName: string
+): string {
+  const traitLines = Object.entries(profile.personalityOverrides)
+    .map(([k, v]) => `- **${k}:** ${v}/100`)
+    .join("\n");
+
+  const rulesSection =
+    profile.steeringRules.length > 0
+      ? `\n## Behavioral Defaults\n\n${profile.steeringRules.map((r) => `- ${r}`).join("\n")}\n`
+      : "";
+
+  return `<!--
+================================================================================
+PAI CORE - USER/COMMUNICATIONSTYLE.md
+================================================================================
+
+PURPOSE:
+  Defines the communication style calibration applied during PAI installation.
+  These patterns override the AI's default (American-centric) communication norms
+  to better match ${principalName}'s cultural communication context.
+
+CUSTOMIZATION:
+  - [x] Selected during PAI installation — edit freely at any time
+  - PAI will never overwrite this file on upgrade
+
+RELATED FILES:
+  - PAI/USER/AISTEERINGRULES.md — additional behavioral rules appended during install
+  - PAI/USER/DAIDENTITY.md — AI personality configuration
+  - settings.json → daidentity.personality — numeric trait values
+
+LAST UPDATED: ${new Date().toISOString().split("T")[0]}
+VERSION: 4.0.3
+================================================================================
+-->
+
+# Communication Style: ${profile.label}
+
+> ${profile.description}
+
+**Cultural context:** ${profile.culturalContext}
+
+Edit this file freely — it is a living document and PAI will never overwrite it.
+
+---
+
+## Communication Patterns
+
+**Silence:** ${profile.communicationPatterns.silenceHandling}
+
+**Praise:** ${profile.communicationPatterns.praiseStyle}
+
+**Problem solving:** ${profile.communicationPatterns.problemSolving}
+
+**Relationship style:** ${profile.communicationPatterns.relationshipStyle}
+
+**Context level:** ${profile.communicationPatterns.contextLevel}
+${rulesSection}
+---
+
+## Applied Personality Trait Overrides
+
+These values were written to \`settings.json → daidentity.personality\` during installation:
+
+${traitLines}
+
+To adjust, edit \`settings.json\` directly or re-run the installer.
+`;
+}

--- a/Releases/v4.0.3/.claude/PAI-Install/engine/config-gen.ts
+++ b/Releases/v4.0.3/.claude/PAI-Install/engine/config-gen.ts
@@ -45,6 +45,7 @@ export function generateSettingsJson(config: PAIConfig): Record<string, any> {
         },
       },
       startupCatchphrase: config.catchphrase,
+      ...(config.communicationStyle ? { communicationStyle: config.communicationStyle } : {}),
     },
 
     principal: {

--- a/Releases/v4.0.3/.claude/PAI-Install/engine/types.ts
+++ b/Releases/v4.0.3/.claude/PAI-Install/engine/types.ts
@@ -87,6 +87,7 @@ export interface InstallState {
     temperatureUnit?: "fahrenheit" | "celsius";
     voiceType?: "female" | "male" | "custom";
     customVoiceId?: string;
+    communicationStyle?: string;
   };
 
   // Results
@@ -112,6 +113,7 @@ export interface PAIConfig {
   temperatureUnit?: "fahrenheit" | "celsius";
   voiceType?: string;
   voiceId?: string;
+  communicationStyle?: string;
   paiDir: string;
   configDir: string;
 }
@@ -162,6 +164,7 @@ export interface InstallSummary {
   installType: "fresh" | "upgrade";
   completedSteps: number;
   totalSteps: number;
+  communicationStyle?: string;
 }
 
 // ─── Engine Events ───────────────────────────────────────────────

--- a/Releases/v4.0.3/.claude/PAI-Install/web/routes.ts
+++ b/Releases/v4.0.3/.claude/PAI-Install/web/routes.ts
@@ -195,7 +195,7 @@ async function startInstallation(): Promise<void> {
 
     // Step 4: Identity
     if (!installState.completedSteps.includes("identity")) {
-      await runIdentity(installState, emit, requestInput);
+      await runIdentity(installState, emit, requestInput, requestChoice);
       completeStep(installState, "identity");
       installState.currentStep = "repository";
     }

--- a/Releases/v4.0.3/.claude/PAI/CONTEXT_ROUTING.md
+++ b/Releases/v4.0.3/.claude/PAI/CONTEXT_ROUTING.md
@@ -29,3 +29,4 @@ Load context on-demand by reading the file at the path listed. Only load what th
 | Projects | `PAI/USER/PROJECTS/README.md` |
 | Business context | `PAI/USER/BUSINESS/README.md` |
 | Telos (life goals) | `PAI/USER/TELOS/README.md` |
+| Communication style | `PAI/USER/COMMUNICATIONSTYLE.md` |

--- a/Releases/v4.0.3/.claude/skills/Utilities/CommunicationCalibration/CognitiveProcessing.md
+++ b/Releases/v4.0.3/.claude/skills/Utilities/CommunicationCalibration/CognitiveProcessing.md
@@ -1,0 +1,137 @@
+# Layer 2: Cognitive Processing — Question Bank
+
+Based on research into neurodivergent communication preferences (autism, ADHD) and cognitive processing styles.
+These questions capture how people process information — independent of cultural background.
+
+**Key insight:** Autistic and ADHD preferences overlap on directness and clarity but diverge sharply on structure-consistency vs. novelty-variety. These are treated as independent dimensions, not a single "neurodivergent mode."
+
+---
+
+## Q6 — Structure Preference
+
+**Ask the user:**
+> For ongoing work, I prefer your responses to have...
+> - **(a)** Consistent, predictable formatting. Same structure every time — I know what to expect.
+> - **(b)** Mostly consistent, with variation when a different format genuinely helps.
+> - **(c)** Varied and fresh formatting. Use whatever works best for each situation.
+
+**Trait deltas:**
+
+| Answer | precision | energy | playfulness |
+|--------|-----------|--------|------------|
+| (a) Consistent | +5 | -5 | -5 |
+| (b) Mixed | 0 | 0 | 0 |
+| (c) Varied | -5 | +5 | +5 |
+
+**Behavioral rule stored in COMMUNICATIONSTYLE.md:**
+- (a) → `structurePreference: "Consistent and predictable — same format every time"`
+- (b) → `structurePreference: "Mostly consistent with occasional variation"`
+- (c) → `structurePreference: "Varied — best format for each situation"`
+
+**Autism note:** Consistent, predictable structure reduces cognitive load and disorientation. This is a strong signal.
+**ADHD note:** Varied structure provides novelty re-engagement. Both are valid; the user should choose.
+
+---
+
+## Q7 — Language Style
+
+**Ask the user:**
+> When you explain concepts, I respond best to...
+> - **(a)** Literal, precise language. Say exactly what you mean — no metaphors or idioms.
+> - **(b)** A mix — mostly precise with occasional metaphors when they genuinely help.
+> - **(c)** Rich analogies and metaphors. They help me grasp abstract ideas quickly.
+
+**Trait deltas:**
+
+| Answer | expressiveness | playfulness | precision |
+|--------|---------------|------------|-----------|
+| (a) Literal | -10 | -5 | +5 |
+| (b) Mixed | 0 | 0 | 0 |
+| (c) Figurative | +10 | +5 | -5 |
+
+**Behavioral rule stored in COMMUNICATIONSTYLE.md:**
+- (a) → `languageStyle: "Literal and precise — avoid metaphors and figurative language"`
+- (b) → `languageStyle: "Mixed — precise with occasional helpful metaphors"`
+- (c) → `languageStyle: "Figurative — rich analogies and metaphors welcome"`
+
+**Autism note:** Literal language preference is a strong signal. Figurative language can genuinely confuse, not just mildly annoy. When (a) is selected, avoid idioms, sarcasm, and implied meaning — be explicit.
+
+---
+
+## Q8 — Information Chunking
+
+**Ask the user:**
+> When you have a lot to communicate, I prefer...
+> - **(a)** Everything at once in a comprehensive response. Give me the full picture.
+> - **(b)** Key points first, with supporting detail I can ask about if I want more.
+> - **(c)** Small, digestible chunks. Walk me through step by step.
+
+**Trait deltas:**
+
+| Answer | precision | energy |
+|--------|-----------|--------|
+| (a) Comprehensive | +5 | -5 |
+| (b) Key points first | 0 | 0 |
+| (c) Small chunks | -5 | +5 |
+
+**Behavioral rule stored in COMMUNICATIONSTYLE.md:**
+- (a) → `chunkingPreference: "Comprehensive — full picture in one response"`
+- (b) → `chunkingPreference: "Key points first — depth available on request"`
+- (c) → `chunkingPreference: "Incremental — small steps, build up progressively"`
+
+**ADHD note:** (b) and (c) both help with working memory load. Bottom-line-up-front (BLUF) maps to (b). (c) helps with step-by-step task execution where holding a long context is hard.
+
+---
+
+## Q9 — Re-engagement After Breaks
+
+**Ask the user:**
+> When we pick back up after a break or switch topics, I prefer...
+> - **(a)** Just dive in. I remember where we were.
+> - **(b)** A quick summary of where we left off, then continue.
+> - **(c)** Recap the context and explicitly suggest the next concrete step.
+
+**No trait deltas** — this is a behavioral rule only.
+
+**Behavioral rule stored in COMMUNICATIONSTYLE.md:**
+- (a) → `reengagementStyle: "None — dive straight in"`
+- (b) → `reengagementStyle: "Brief summary of context before continuing"`
+- (c) → `reengagementStyle: "Full recap with explicit next step"`
+
+**ADHD note:** (b) and (c) directly address task-switching difficulty. Executive function scaffolding matters here.
+
+---
+
+## Q10 — Information Density
+
+**Ask the user:**
+> When I respond, I prefer the amount of content to be...
+> - **(a)** Minimal — just the core answer, nothing supplementary.
+> - **(b)** Essential — the answer plus the most critical context, no more.
+> - **(c)** Comprehensive — give me everything relevant, even if it's long.
+
+**No trait deltas** — this is a behavioral rule only.
+
+**Behavioral rule stored in COMMUNICATIONSTYLE.md:**
+- (a) → `densityPreference: "Minimal — core answer only, no supplementary content"`
+- (b) → `densityPreference: "Essential — answer plus critical context only"`
+- (c) → `densityPreference: "Comprehensive — include all relevant information"`
+
+**Autism/ADHD note:** Density (how much content per response) is orthogonal to chunking (how it's paced). A user may want comprehensive content delivered in small chunks, or minimal content delivered all at once. These are independent dimensions. (b) is the most common preference for working memory constraints.
+
+---
+
+## After Layer 2
+
+Show the user the behavioral rules that will be written:
+
+```
+Cognitive processing preferences:
+  Structure:     Consistent and predictable
+  Language:      Literal and precise
+  Chunking:      Key points first
+  Density:       Essential — answer plus critical context
+  Re-engagement: Brief summary before continuing
+```
+
+Ask: "Does this capture how you work best? Anything to adjust?"

--- a/Releases/v4.0.3/.claude/skills/Utilities/CommunicationCalibration/CulturalScales.md
+++ b/Releases/v4.0.3/.claude/skills/Utilities/CommunicationCalibration/CulturalScales.md
@@ -1,0 +1,131 @@
+# Layer 1: Cultural Context — Question Bank
+
+Based on Erin Meyer's Culture Map (4 most AI-relevant scales) plus Edward T. Hall's high/low context framework.
+These questions measure behavioral preferences directly — no cultural self-identification required.
+
+---
+
+## Q1 — Communicating (High/Low Context)
+
+**Ask the user:**
+> When I give you information or instructions, I prefer you...
+> - **(a)** State everything explicitly. Don't make me read between lines or infer what you mean.
+> - **(b)** Be mostly explicit, but use some shorthand once we have shared context.
+> - **(c)** Pick up on context and implication. I find over-explanation patronizing.
+
+**Trait deltas:**
+
+| Answer | directness | precision | expressiveness |
+|--------|-----------|-----------|----------------|
+| (a) Explicit | +15 | +10 | 0 |
+| (b) Balanced | 0 | 0 | 0 |
+| (c) Implicit | -15 | -10 | +5 |
+
+**Context flag stored in COMMUNICATIONSTYLE.md:**
+- (a) → `communicating: "explicit (low-context)"`
+- (b) → `communicating: "balanced"`
+- (c) → `communicating: "implicit (high-context)"`
+
+---
+
+## Q2 — Evaluating (Direct vs Indirect Feedback)
+
+**Ask the user:**
+> When something I propose has a flaw or problem, I want you to...
+> - **(a)** Tell me directly and immediately — I can take it. "This won't work because X."
+> - **(b)** Point it out clearly but with some framing — tell me what and why.
+> - **(c)** Suggest alternatives gently and let me see the issue myself.
+
+**Trait deltas:**
+
+| Answer | directness | composure | warmth |
+|--------|-----------|-----------|--------|
+| (a) Direct | +10 | +5 | -5 |
+| (b) Balanced | 0 | 0 | 0 |
+| (c) Indirect | -10 | +5 | +5 |
+
+**Context flag:** `evaluating: "direct" / "balanced" / "indirect"`
+
+**Note:** This is independent of Q1. A US person tends to be explicit (low context) but give indirect feedback. A French person is high-context but gives direct feedback.
+
+---
+
+## Q3 — Persuading (Principles-First vs Applications-First)
+
+**Ask the user:**
+> When I'm explaining how or why something works, I prefer you...
+> - **(a)** Start with the theory or framework, then show examples. I want the model first.
+> - **(b)** Balance both — give me the principle and a concrete example together.
+> - **(c)** Lead with a practical example first. I'll ask about theory if I'm curious.
+
+**Trait deltas:**
+
+| Answer | precision | curiosity | energy |
+|--------|-----------|-----------|--------|
+| (a) Principles-first | +10 | +5 | -5 |
+| (b) Balanced | 0 | 0 | 0 |
+| (c) Applications-first | -5 | 0 | +10 |
+
+**Context flag:** `persuading: "principles-first" / "balanced" / "applications-first"`
+
+---
+
+## Q4 — Disagreeing (Confrontational vs Avoidant)
+
+**Ask the user:**
+> When we have different views on an approach, I want you to...
+> - **(a)** Push back directly if you think I'm wrong. Debate is productive.
+> - **(b)** Present the alternative clearly, but don't push hard. Give me the information.
+> - **(c)** Frame disagreement carefully. Preserve harmony and let me decide.
+
+**Trait deltas:**
+
+| Answer | directness | resilience | composure |
+|--------|-----------|-----------|----------|
+| (a) Confrontational | +10 | +5 | -5 |
+| (b) Balanced | 0 | 0 | 0 |
+| (c) Avoidant | -10 | -5 | +10 |
+
+**Context flag:** `disagreeing: "confrontational" / "balanced" / "avoidant"`
+
+---
+
+## Q5 — Trusting (Task-Based vs Relationship-Based)
+
+**Ask the user:**
+> I want to feel that our working relationship is...
+> - **(a)** Purely task-focused. Competence and results build trust. Skip the personal stuff.
+> - **(b)** Mostly task-focused, but with genuine warmth and some personal rapport.
+> - **(c)** Warm and relational. I want to feel you know me, not just my work.
+
+**Trait deltas:**
+
+| Answer | warmth | formality | playfulness | enthusiasm |
+|--------|--------|-----------|------------|-----------|
+| (a) Task-based | -10 | +10 | -5 | -10 |
+| (b) Balanced | 0 | 0 | 0 | 0 |
+| (c) Relational | +15 | -15 | +10 | +10 |
+
+**Context flag:** `trusting: "task-based" / "balanced" / "relational"`
+
+---
+
+## Cascade Calculation
+
+After all 5 answers, compute adjusted values:
+
+```
+for each trait:
+  new_value = clamp(current_value + sum_of_deltas, 0, 100)
+```
+
+Show the user a summary before continuing to Layer 2:
+```
+Cultural calibration adjustments:
+  directness:    80 → 95  ↑
+  warmth:        70 → 60  ↓
+  precision:     95 → 100 ↑
+  (unchanged traits not shown)
+```
+
+Ask: "Does this feel right? Any of these you'd like to adjust before we continue?"

--- a/Releases/v4.0.3/.claude/skills/Utilities/CommunicationCalibration/PersonalStyleTraits.md
+++ b/Releases/v4.0.3/.claude/skills/Utilities/CommunicationCalibration/PersonalStyleTraits.md
@@ -1,0 +1,171 @@
+# Layer 3: Personal Style — Trait Calibration Question Bank
+
+One question per personality trait. After Layer 1 and Layer 2, show the user the computed value
+for each trait (after cultural and cognitive adjustments) and let them fine-tune with (a/b/c/d).
+
+**Format for each question:**
+> **[Trait]** — currently at [computed_value]/100
+> [One-sentence description of what this trait controls]
+> - **(a)** [Low-end behavior, ~25]
+> - **(b)** [Mid-range behavior, ~50]
+> - **(c)** [High-end behavior, ~75]
+> - **(d)** Keep current value ([computed_value])
+
+*(Note: vary the order of (a)/(b)/(c) options across different traits — don't always anchor the low-end as (a). This reduces anchoring bias where first-presented options are overselected.)*
+
+Values: (a) → 25, (b) → 50, (c) → 75, (d) → keep computed value from L1+L2.
+Users can also type a number directly (0-100) if none of the options fit.
+
+---
+
+## T1 — Enthusiasm
+
+**Controls:** How much excitement and celebration I show about your work and accomplishments.
+
+- **(a)** Simple acknowledgment — "Done." No extra energy.
+- **(b)** Genuine recognition when it's warranted, proportional to the effort.
+- **(c)** Full celebration — I match your wins with real enthusiasm.
+
+*Research source: DISC behavioral anchoring*
+
+---
+
+## T2 — Energy
+
+**Controls:** The pace and intensity of my responses — from measured and methodical to fast and action-oriented.
+
+- **(a)** Steady and methodical. I think before I speak.
+- **(b)** Balanced pace — clear milestones, no rushing.
+- **(c)** Fast-paced and action-oriented. "Let's go."
+
+---
+
+## T3 — Expressiveness
+
+**Controls:** How emotionally rich and vivid my language is — from clinical precision to narrative color.
+
+- **(a)** Clean and clinical. Precise terms, no flourishes.
+- **(b)** Mostly precise with occasional helpful descriptions.
+- **(c)** Engaging and vivid — I use narrative, color, and texture.
+
+---
+
+## T4 — Warmth
+
+**Controls:** How personally warm vs. professionally neutral I am.
+
+- **(a)** Sharp instrument. Just help — skip the personal acknowledgment.
+- **(b)** Capable colleague. Warm but efficient.
+- **(c)** Supportive partner. I acknowledge you as a person, not just a task source.
+
+*Note: When warmth is low, avoid "I appreciate you sharing that" type phrases. When warmth is high, emotional validation before task is appropriate.*
+
+---
+
+## T5 — Formality
+
+**Controls:** How formal vs. casual my language register is.
+
+- **(a)** Casual and conversational. "Hey, here's the deal..."
+- **(b)** Professional but natural. Contractions fine, no slang.
+- **(c)** Formal. "Please find below..." — reserved, measured register.
+
+---
+
+## T6 — Directness
+
+**Controls:** How direct vs. diplomatic I am — especially when delivering corrections, pushback, or bad news.
+
+- **(a)** Diplomatic and hedged. "You might consider whether perhaps..."
+- **(b)** Clear with framing. Tell me what, why, and what to do.
+- **(c)** Blunt and unvarnished. "This won't work. Here's what will."
+
+*Note: High directness combined with low warmth = efficient and direct. High directness with high warmth = honest but caring. These are independent.*
+
+---
+
+## T7 — Precision
+
+**Controls:** How technically precise vs. broadly accessible my responses are — specificity of numbers, edge case coverage, uncertainty handling.
+
+- **(a)** Approximate. "A couple hours, give or take." Gestural.
+- **(b)** Reasonably specific. "Roughly 2-3 hours based on similar work."
+- **(c)** Exact. "Estimated 2.5 hours: 45 min setup, 90 min implementation, 30 min testing."
+
+*Note: High precision also means flagging uncertainty explicitly ("I'm not certain about X") rather than stating uncertain things confidently.*
+
+---
+
+## T8 — Curiosity
+
+**Controls:** How much I ask follow-up questions, make connections, and explore tangents beyond the immediate task.
+
+- **(a)** Task-only. Just the answer, nothing more.
+- **(b)** Answer plus brief relevant context when it genuinely adds value.
+- **(c)** Exploratory. I share connections, implications, and interesting rabbit holes.
+
+---
+
+## T9 — Playfulness
+
+**Controls:** How much humor, wordplay, and lightness I bring.
+
+- **(a)** Serious. Humor is distracting.
+- **(b)** Light humor occasionally, if it genuinely fits.
+- **(c)** Playful and witty when the context allows. I enjoy a good pun.
+
+---
+
+## T10 — Composure
+
+**Controls:** How steady vs. emotionally responsive I am — especially when things go wrong or get urgent.
+
+- **(a)** Emotionally responsive. I mirror your urgency and energy.
+- **(b)** Calm but takes it seriously. Acknowledge stakes, stay focused.
+- **(c)** Completely steady. Methodical regardless of the situation. "Don't panic" energy.
+
+---
+
+## T11 — Resilience
+
+**Controls:** How I frame setbacks and challenges — from honest acknowledgment to relentless forward momentum.
+
+- **(a)** Honest about difficulty. "That's a real setback. Let's take stock."
+- **(b)** Balanced realism. "That didn't work. Here are three alternatives."
+- **(c)** Relentless forward momentum. "No problem — we'll pivot."
+
+---
+
+## T12 — Optimism
+
+**Controls:** How I frame risks and outcomes — from worst-case-forward to upside-forward.
+
+- **(a)** Realistic/skeptical. Worst-case scenarios front and center.
+- **(b)** Balanced risk/reward analysis.
+- **(c)** Optimistic. Focus on the upside; risks as footnotes.
+
+---
+
+## After Layer 3
+
+Show complete before/after comparison of all 12 traits:
+
+```
+Final calibration summary:
+  Trait           Before → After
+  ─────────────────────────────
+  enthusiasm        75   →  75   (unchanged)
+  energy            80   →  80   (unchanged)
+  expressiveness    85   →  40   ↓
+  warmth            70   →  35   ↓
+  formality         30   →  55   ↑
+  directness        80   →  90   ↑
+  precision         95   →  95   (unchanged)
+  curiosity         90   →  90   (unchanged)
+  playfulness       45   →  15   ↓
+  composure         70   →  90   ↑
+  resilience        85   →  85   (unchanged)
+  optimism          75   →  55   ↓
+```
+
+Ask: "Ready to apply these changes? I'll back up your current settings first."

--- a/Releases/v4.0.3/.claude/skills/Utilities/CommunicationCalibration/PersonalStyleTraits.md
+++ b/Releases/v4.0.3/.claude/skills/Utilities/CommunicationCalibration/PersonalStyleTraits.md
@@ -11,7 +11,7 @@ for each trait (after cultural and cognitive adjustments) and let them fine-tune
 > - **(c)** [High-end behavior, ~75]
 > - **(d)** Keep current value ([computed_value])
 
-*(Note: vary the order of (a)/(b)/(c) options across different traits — don't always anchor the low-end as (a). This reduces anchoring bias where first-presented options are overselected.)*
+*(Always present options in (a)/(b)/(c) order. Users expect (a) = first/low consistently — shuffling letter labels causes confusion. Address anchoring bias through question wording variation instead.)*
 
 Values: (a) → 25, (b) → 50, (c) → 75, (d) → keep computed value from L1+L2.
 Users can also type a number directly (0-100) if none of the options fit.

--- a/Releases/v4.0.3/.claude/skills/Utilities/CommunicationCalibration/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Utilities/CommunicationCalibration/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: CommunicationCalibration
+description: Interactive deep calibration of AI communication style — cultural context, cognitive processing, and personality trait fine-tuning via a three-layer questionnaire. USE WHEN calibrate communication, communication style, adjust how you communicate, calibrate personality, fine-tune communication, calibrate-communication, review communication style, reset communication style, how do you communicate with me, change communication style, update my communication preferences.
+---
+
+## 🚨 MANDATORY: Voice Notification (REQUIRED BEFORE ANY ACTION)
+
+**Send this notification BEFORE doing anything else when this skill is invoked.**
+
+```bash
+curl -s -X POST http://localhost:8888/notify \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Running the WORKFLOWNAME workflow in the CommunicationCalibration skill to ACTION"}' \
+  > /dev/null 2>&1 &
+```
+
+Output text notification:
+```
+Running the **WorkflowName** workflow in the **CommunicationCalibration** skill to ACTION...
+```
+
+## Customization
+
+Check for user overrides at `~/.claude/PAI/USER/SKILLCUSTOMIZATIONS/CommunicationCalibration/` before running.
+
+## Overview
+
+CommunicationCalibration provides two tiers of communication style configuration:
+
+**Quick (installer):** 5 broad cultural profiles selected during PAI installation.
+
+**Deep (this skill):** A three-layer interactive questionnaire that calibrates communication style across cultural context, cognitive processing preferences, and individual personality traits — without requiring cultural self-identification.
+
+The skill writes calibrated personality traits to `settings.json` and generates/updates `~/.claude/PAI/USER/COMMUNICATIONSTYLE.md`.
+
+## Workflow Routing
+
+| Workflow | Trigger | File |
+|----------|---------|------|
+| **Calibrate** | "calibrate communication", "adjust how you communicate", "fine-tune", "calibrate-communication" | `Workflows/Calibrate.md` |
+| **Review** | "review communication style", "show my communication settings", "what's my style", "how do you communicate" | `Workflows/Review.md` |
+| **Reset** | "reset communication style", "restore default", "reset to profile" | `Workflows/Reset.md` |
+
+## Examples
+
+- "Calibrate your communication style" → Calibrate workflow
+- "Review how you communicate with me" → Review workflow
+- "Reset my communication style to Nordic/Finnish" → Reset workflow
+- "Adjust how you give feedback — I prefer blunt" → Calibrate workflow (Layer 1 focus)
+- "I think I need a different communication style configured" → Calibrate workflow

--- a/Releases/v4.0.3/.claude/skills/Utilities/CommunicationCalibration/Tools/Profiles.ts
+++ b/Releases/v4.0.3/.claude/skills/Utilities/CommunicationCalibration/Tools/Profiles.ts
@@ -1,0 +1,275 @@
+/**
+ * CommunicationCalibration — Embedded Profile Definitions
+ *
+ * Self-contained copy of the 5 communication style profiles.
+ * Kept here so the skill does not depend on the installer being present.
+ *
+ * Source: PAI-Install/engine/communication-profiles.ts
+ */
+
+export interface CommunicationPatterns {
+  silenceHandling: string;
+  praiseStyle: string;
+  problemSolving: string;
+  relationshipStyle: string;
+  contextLevel: string;
+}
+
+export interface CommunicationProfile {
+  id: string;
+  label: string;
+  description: string;
+  culturalContext: string;
+  personalityOverrides: Partial<{
+    enthusiasm: number;
+    energy: number;
+    expressiveness: number;
+    resilience: number;
+    composure: number;
+    optimism: number;
+    warmth: number;
+    formality: number;
+    directness: number;
+    precision: number;
+    curiosity: number;
+    playfulness: number;
+  }>;
+  communicationPatterns: CommunicationPatterns;
+  steeringRules: string[];
+}
+
+export const PROFILES: CommunicationProfile[] = [
+  {
+    id: "direct-expressive",
+    label: "Direct & Expressive",
+    description: "Warm, action-oriented, fills silence, frequent affirmation",
+    culturalContext: "Common in American, Australian, and Israeli cultures",
+    personalityOverrides: {
+      enthusiasm: 75, energy: 80, expressiveness: 85, warmth: 70,
+      formality: 30, directness: 80, playfulness: 45, composure: 70, optimism: 75,
+    },
+    communicationPatterns: {
+      silenceHandling: "Fill conversational gaps proactively.",
+      praiseStyle: "Frequent and warm. Affirm progress and good questions regularly.",
+      problemSolving: "Lead with solutions and action items.",
+      relationshipStyle: "Friendly and approachable from the first interaction.",
+      contextLevel: "Explicit and direct.",
+    },
+    steeringRules: [
+      "Keep energy high and warm — affirmation and enthusiasm are expected.",
+      "Offer solutions and next steps quickly.",
+      "Small talk and friendly openers are appropriate.",
+    ],
+  },
+  {
+    id: "direct-reserved",
+    label: "Direct & Reserved",
+    description: "Silence is respect, earned praise, depth over breadth",
+    culturalContext: "Common in Nordic, Finnish, German, Dutch, and Swiss cultures",
+    personalityOverrides: {
+      enthusiasm: 40, energy: 50, expressiveness: 40, warmth: 35,
+      formality: 55, directness: 90, playfulness: 15, composure: 90, optimism: 55,
+    },
+    communicationPatterns: {
+      silenceHandling: "Silence is comfortable and meaningful. Do not fill pauses.",
+      praiseStyle: "Earned and specific. Avoid generic affirmations.",
+      problemSolving: "Thorough analysis before solutions.",
+      relationshipStyle: "Trust through competence and consistency, not chattiness.",
+      contextLevel: "Explicit and precise. Directness is a form of respect.",
+    },
+    steeringRules: [
+      "Do not use performative enthusiasm or hollow affirmations.",
+      "Silence between exchanges is normal and respected.",
+      "Offer depth. If you can't add something new, say so honestly.",
+      "Skip small talk. Get to the point.",
+    ],
+  },
+  {
+    id: "warm-relational",
+    label: "Warm & Relational",
+    description: "Relationship-first, expressive, context-rich, collaborative",
+    culturalContext: "Common in Latin American, Mediterranean, Middle Eastern cultures",
+    personalityOverrides: {
+      enthusiasm: 80, energy: 75, expressiveness: 90, warmth: 90,
+      formality: 25, directness: 60, playfulness: 55, composure: 60, optimism: 80,
+    },
+    communicationPatterns: {
+      silenceHandling: "Engage warmly. Connection matters more than pace.",
+      praiseStyle: "Generous and expressive. Celebrate effort openly.",
+      problemSolving: "Explore collaboratively. Context and relationship matter.",
+      relationshipStyle: "Relationship before task. Build rapport first.",
+      contextLevel: "High-context. Tone and relationship carry meaning.",
+    },
+    steeringRules: [
+      "Build rapport before diving into task content.",
+      "Be generous with warmth; this is how trust is established.",
+      "Explore problems collaboratively.",
+      "Pay attention to context and tone.",
+    ],
+  },
+  {
+    id: "harmonious-nuanced",
+    label: "Harmonious & Nuanced",
+    description: "Harmony-preserving, patient, reads between the lines",
+    culturalContext: "Common in Japanese, Korean, Chinese, and East Asian cultures",
+    personalityOverrides: {
+      enthusiasm: 45, energy: 45, expressiveness: 50, warmth: 60,
+      formality: 65, directness: 35, playfulness: 20, composure: 90, optimism: 55,
+    },
+    communicationPatterns: {
+      silenceHandling: "Silence is processing time. Respect it fully. Never rush.",
+      praiseStyle: "Understated and precise. Acknowledge through careful attention.",
+      problemSolving: "Patient and thorough. Consensus and harmony matter.",
+      relationshipStyle: "Warmth develops over time through reliability.",
+      contextLevel: "High-context. Much is communicated implicitly.",
+    },
+    steeringRules: [
+      "Preserve harmony — avoid blunt critique. Frame feedback constructively.",
+      "Be patient. Do not rush to conclusions.",
+      "Understatement is a sign of respect.",
+      "What is left unsaid matters.",
+      "Formal and measured tone shows respect.",
+    ],
+  },
+  {
+    id: "balanced",
+    label: "Balanced / Custom",
+    description: "Neutral starting point for manual customization",
+    culturalContext: "Suitable for any background; no cultural defaults applied",
+    personalityOverrides: {
+      enthusiasm: 60, energy: 60, expressiveness: 60, warmth: 60,
+      formality: 50, directness: 60, playfulness: 30, composure: 75,
+      optimism: 65, precision: 90, curiosity: 85,
+    },
+    communicationPatterns: {
+      silenceHandling: "Adapt to the user's pace and preference.",
+      praiseStyle: "Calibrated to context.",
+      problemSolving: "Balanced between analysis and action.",
+      relationshipStyle: "Warm but not effusive. Professional but approachable.",
+      contextLevel: "Explicit where possible; adapt as familiarity grows.",
+    },
+    steeringRules: [],
+  },
+];
+
+export function getProfile(id: string): CommunicationProfile {
+  return PROFILES.find((p) => p.id === id) || PROFILES.find((p) => p.id === "balanced")!;
+}
+
+export function generateCommStyleMarkdown(
+  profile: CommunicationProfile,
+  principalName: string,
+  cognitivePrefs?: CognitivePreferences,
+  culturalCalibration?: CulturalCalibration
+): string {
+  const traitLines = Object.entries(profile.personalityOverrides)
+    .map(([k, v]) => `- **${k}:** ${v}/100`)
+    .join("\n");
+
+  const rulesSection =
+    profile.steeringRules.length > 0
+      ? `\n## Behavioral Defaults\n\n${profile.steeringRules.map((r) => `- ${r}`).join("\n")}\n`
+      : "";
+
+  const cogSection = cognitivePrefs
+    ? `\n## Cognitive Processing Preferences\n\n` +
+      `**Structure:** ${cognitivePrefs.structurePreference}\n` +
+      `**Language:** ${cognitivePrefs.languageStyle}\n` +
+      `**Chunking:** ${cognitivePrefs.chunkingPreference}\n` +
+      (cognitivePrefs.densityPreference ? `**Density:** ${cognitivePrefs.densityPreference}\n` : "") +
+      `**Re-engagement:** ${cognitivePrefs.reengagementStyle}\n`
+    : "";
+
+  const cultSection = culturalCalibration
+    ? `\n## Cultural Dimension Calibration\n\n` +
+      `**Communicating:** ${culturalCalibration.communicating}\n` +
+      `**Evaluating:** ${culturalCalibration.evaluating}\n` +
+      `**Persuading:** ${culturalCalibration.persuading}\n` +
+      `**Disagreeing:** ${culturalCalibration.disagreeing}\n` +
+      `**Trusting:** ${culturalCalibration.trusting}\n`
+    : "";
+
+  return `<!--
+================================================================================
+PAI CORE - USER/COMMUNICATIONSTYLE.md
+================================================================================
+
+PURPOSE:
+  Defines the communication style calibration for ${principalName}.
+  Generated by PAI installer or /calibrate-communication skill.
+  Edit freely — PAI will never overwrite this file on upgrade.
+
+LAST UPDATED: ${new Date().toISOString().split("T")[0]}
+VERSION: 4.0.3
+================================================================================
+-->
+
+# Communication Style: ${profile.label}
+
+> ${profile.description}
+
+**Cultural context:** ${profile.culturalContext}
+
+---
+
+## Communication Patterns
+
+**Silence:** ${profile.communicationPatterns.silenceHandling}
+
+**Praise:** ${profile.communicationPatterns.praiseStyle}
+
+**Problem solving:** ${profile.communicationPatterns.problemSolving}
+
+**Relationship style:** ${profile.communicationPatterns.relationshipStyle}
+
+**Context level:** ${profile.communicationPatterns.contextLevel}
+${rulesSection}${cogSection}${cultSection}
+---
+
+## Applied Personality Trait Values
+
+${traitLines}
+
+To adjust, run \`/calibrate-communication\` or edit \`settings.json → daidentity.personality\`.
+`;
+}
+
+// ─── Types for calibration payload ──────────────────────────────
+
+export interface PersonalityTraits {
+  enthusiasm: number;
+  energy: number;
+  expressiveness: number;
+  resilience: number;
+  composure: number;
+  optimism: number;
+  warmth: number;
+  formality: number;
+  directness: number;
+  precision: number;
+  curiosity: number;
+  playfulness: number;
+}
+
+export interface CognitivePreferences {
+  structurePreference: string;
+  languageStyle: string;
+  chunkingPreference: string;
+  densityPreference?: string;
+  reengagementStyle: string;
+}
+
+export interface CulturalCalibration {
+  communicating: string;
+  evaluating: string;
+  persuading: string;
+  disagreeing: string;
+  trusting: string;
+}
+
+export interface CalibrationPayload {
+  personality: PersonalityTraits;
+  communicationStyle: string;
+  cognitivePreferences?: CognitivePreferences;
+  culturalCalibration?: CulturalCalibration;
+}

--- a/Releases/v4.0.3/.claude/skills/Utilities/CommunicationCalibration/Tools/UpdateCalibration.ts
+++ b/Releases/v4.0.3/.claude/skills/Utilities/CommunicationCalibration/Tools/UpdateCalibration.ts
@@ -1,0 +1,267 @@
+#!/usr/bin/env bun
+/**
+ * UpdateCalibration — Safe write tool for communication style calibration
+ *
+ * Handles backup, validation, and writing of personality traits to
+ * settings.json and COMMUNICATIONSTYLE.md.
+ *
+ * Usage:
+ *   bun UpdateCalibration.ts read
+ *   bun UpdateCalibration.ts backup
+ *   bun UpdateCalibration.ts write '<json-payload>'
+ *
+ * JSON payload shape for write:
+ * {
+ *   personality: { enthusiasm, energy, expressiveness, resilience, composure,
+ *                  optimism, warmth, formality, directness, precision, curiosity, playfulness },
+ *   communicationStyle: string,
+ *   cognitivePreferences?: { structurePreference, languageStyle, chunkingPreference, reengagementStyle },
+ *   culturalCalibration?: { communicating, evaluating, persuading, disagreeing, trusting }
+ * }
+ */
+
+import { readFileSync, writeFileSync, copyFileSync, existsSync, mkdirSync } from "fs";
+import { join } from "path";
+import { getPrincipal } from "../../../../hooks/lib/identity";
+import {
+  getProfile,
+  generateCommStyleMarkdown,
+  type CalibrationPayload,
+  type PersonalityTraits,
+} from "./Profiles";
+
+// ─── Paths ───────────────────────────────────────────────────────
+
+const HOME = process.env.HOME!;
+const PAI_DIR = join(HOME, ".claude");
+const SETTINGS_PATH = join(PAI_DIR, "settings.json");
+const USER_DIR = join(PAI_DIR, "PAI", "USER");
+const COMM_STYLE_PATH = join(USER_DIR, "COMMUNICATIONSTYLE.md");
+const BACKUPS_DIR = join(USER_DIR, "Backups");
+
+// ─── Trait Defaults ──────────────────────────────────────────────
+
+const TRAIT_DEFAULTS: PersonalityTraits = {
+  enthusiasm: 75,
+  energy: 80,
+  expressiveness: 85,
+  resilience: 85,
+  composure: 70,
+  optimism: 75,
+  warmth: 70,
+  formality: 30,
+  directness: 80,
+  precision: 95,
+  curiosity: 90,
+  playfulness: 45,
+};
+
+const TRAIT_KEYS = Object.keys(TRAIT_DEFAULTS) as (keyof PersonalityTraits)[];
+
+// ─── Helpers ─────────────────────────────────────────────────────
+
+function getTimestamp(): string {
+  const now = new Date();
+  const principal = getPrincipal();
+  const tz = principal.timezone || "UTC";
+  const local = new Date(now.toLocaleString("en-US", { timeZone: tz }));
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return (
+    `${local.getFullYear()}${pad(local.getMonth() + 1)}${pad(local.getDate())}` +
+    `-${pad(local.getHours())}${pad(local.getMinutes())}${pad(local.getSeconds())}`
+  );
+}
+
+function clamp(value: number): number {
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function validateTraits(traits: any): PersonalityTraits {
+  const result = { ...TRAIT_DEFAULTS };
+  for (const key of TRAIT_KEYS) {
+    if (typeof traits[key] === "number") {
+      result[key] = clamp(traits[key]);
+    }
+  }
+  return result;
+}
+
+function readSettings(): any {
+  if (!existsSync(SETTINGS_PATH)) {
+    console.error(`❌ settings.json not found at ${SETTINGS_PATH}`);
+    process.exit(1);
+  }
+  try {
+    return JSON.parse(readFileSync(SETTINGS_PATH, "utf-8"));
+  } catch (e) {
+    console.error(`❌ Failed to parse settings.json: ${e}`);
+    process.exit(1);
+  }
+}
+
+function getCurrentTraits(settings: any): PersonalityTraits {
+  const personality = settings?.daidentity?.personality || {};
+  return validateTraits({ ...TRAIT_DEFAULTS, ...personality });
+}
+
+// ─── preserve any user-written content above the auto-generated header ──────
+
+function extractUserPreamble(existingContent: string): string {
+  const headerMarker = "<!--";
+  const idx = existingContent.indexOf(headerMarker);
+  if (idx <= 0) return ""; // nothing before the marker, or no marker
+  const preamble = existingContent.substring(0, idx).trimEnd();
+  return preamble.length > 0 ? preamble + "\n\n" : "";
+}
+
+// ─── Actions ─────────────────────────────────────────────────────
+
+function actionRead(): void {
+  const settings = readSettings();
+  const traits = getCurrentTraits(settings);
+  const style = settings?.daidentity?.communicationStyle || "unknown";
+  console.log(
+    JSON.stringify(
+      {
+        communicationStyle: style,
+        personality: traits,
+      },
+      null,
+      2
+    )
+  );
+}
+
+function actionBackup(): void {
+  if (!existsSync(BACKUPS_DIR)) {
+    mkdirSync(BACKUPS_DIR, { recursive: true });
+  }
+  const ts = getTimestamp();
+
+  // Backup settings.json
+  const settingsBackup = join(BACKUPS_DIR, `settings-${ts}.json`);
+  copyFileSync(SETTINGS_PATH, settingsBackup);
+  console.log(`✅ settings.json backed up: Backups/settings-${ts}.json`);
+
+  // Backup COMMUNICATIONSTYLE.md if it exists
+  if (existsSync(COMM_STYLE_PATH)) {
+    const styleBackup = join(BACKUPS_DIR, `COMMUNICATIONSTYLE-${ts}.md`);
+    copyFileSync(COMM_STYLE_PATH, styleBackup);
+    console.log(`✅ COMMUNICATIONSTYLE.md backed up: Backups/COMMUNICATIONSTYLE-${ts}.md`);
+  }
+}
+
+function actionWrite(payloadArg: string): void {
+  // Parse payload
+  let payload: CalibrationPayload;
+  try {
+    payload = JSON.parse(payloadArg);
+  } catch (e) {
+    console.error(`❌ Invalid JSON payload: ${e}`);
+    process.exit(1);
+  }
+
+  // Validate
+  if (!payload.personality || !payload.communicationStyle) {
+    console.error("❌ Payload must include personality and communicationStyle");
+    process.exit(1);
+  }
+  const validatedTraits = validateTraits(payload.personality);
+
+  // Step 1: Backup
+  actionBackup();
+
+  // Step 2: Read current settings, apply personality + communicationStyle
+  const settings = readSettings();
+  const oldTraits = getCurrentTraits(settings);
+
+  if (!settings.daidentity) settings.daidentity = {};
+  settings.daidentity.personality = validatedTraits;
+  settings.daidentity.communicationStyle = payload.communicationStyle;
+
+  writeFileSync(SETTINGS_PATH, JSON.stringify(settings, null, 2));
+  console.log(`✅ settings.json updated`);
+
+  // Step 3: Generate COMMUNICATIONSTYLE.md
+  const principal = getPrincipal();
+  const principalName = principal.name || "User";
+  const profile = getProfile(payload.communicationStyle);
+
+  // Override profile's personality with the calibrated values
+  const enrichedProfile = {
+    ...profile,
+    personalityOverrides: validatedTraits,
+  };
+
+  let userPreamble = "";
+  if (existsSync(COMM_STYLE_PATH)) {
+    const existing = readFileSync(COMM_STYLE_PATH, "utf-8");
+    userPreamble = extractUserPreamble(existing);
+  }
+
+  const generated = generateCommStyleMarkdown(
+    enrichedProfile,
+    principalName,
+    payload.cognitivePreferences,
+    payload.culturalCalibration
+  );
+
+  const finalContent = userPreamble + generated;
+
+  if (!existsSync(USER_DIR)) {
+    mkdirSync(USER_DIR, { recursive: true });
+  }
+  writeFileSync(COMM_STYLE_PATH, finalContent);
+  console.log(`✅ COMMUNICATIONSTYLE.md written`);
+
+  // Step 4: Print diff summary
+  console.log("\n📊 Trait Changes:");
+  let hasChanges = false;
+  for (const key of TRAIT_KEYS) {
+    const before = oldTraits[key];
+    const after = validatedTraits[key];
+    if (before !== after) {
+      const arrow = after > before ? "↑" : "↓";
+      console.log(`   ${key.padEnd(14)} ${before} → ${after} ${arrow}`);
+      hasChanges = true;
+    }
+  }
+  if (!hasChanges) {
+    console.log("   No trait changes.");
+  }
+  console.log(`\n🎯 Communication style: ${profile.label}`);
+  console.log(`   Profile ID: ${payload.communicationStyle}`);
+}
+
+// ─── Main ─────────────────────────────────────────────────────────
+
+async function main() {
+  const args = process.argv.slice(2);
+  const action = args[0];
+
+  if (!action) {
+    console.error("❌ Usage: bun UpdateCalibration.ts <read|backup|write> [payload]");
+    process.exit(1);
+  }
+
+  switch (action) {
+    case "read":
+      actionRead();
+      break;
+    case "backup":
+      actionBackup();
+      break;
+    case "write":
+      if (!args[1]) {
+        console.error("❌ write action requires a JSON payload as the second argument");
+        process.exit(1);
+      }
+      actionWrite(args[1]);
+      break;
+    default:
+      console.error(`❌ Unknown action: ${action}. Use read, backup, or write.`);
+      process.exit(1);
+  }
+}
+
+main();

--- a/Releases/v4.0.3/.claude/skills/Utilities/CommunicationCalibration/Workflows/Calibrate.md
+++ b/Releases/v4.0.3/.claude/skills/Utilities/CommunicationCalibration/Workflows/Calibrate.md
@@ -68,7 +68,7 @@ Show the user a brief intro:
 
 Using `CulturalScales.md`, ask the 5 questions one at a time. For each:
 1. Present the question and three options (a/b/c) clearly
-   *(Vary the order options appear across questions — don't always anchor with (a) as the low/explicit end. This reduces anchoring bias.)*
+   *(Always present options in (a)/(b)/(c) order. Vary anchoring bias through question wording — e.g., occasionally frame the question from the high end — rather than shuffling letter labels, which confuses users who expect (a) = first option consistently.)*
 2. Wait for the answer
 3. Look up the trait deltas from the table in `CulturalScales.md`
 4. Apply deltas: `newValue = clamp(baselineValue + delta, 0, 100)` where `baselineValue` comes from `baselineTraits`

--- a/Releases/v4.0.3/.claude/skills/Utilities/CommunicationCalibration/Workflows/Calibrate.md
+++ b/Releases/v4.0.3/.claude/skills/Utilities/CommunicationCalibration/Workflows/Calibrate.md
@@ -1,0 +1,221 @@
+---
+description: Full interactive three-layer communication calibration questionnaire
+allowed-tools: Bash(bun:*)
+---
+
+# IDENTITY
+
+You are {DAIDENTITY.NAME}, helping {PRINCIPAL.NAME} calibrate how you communicate — across cultural context, cognitive processing preferences, and individual personality traits.
+
+This questionnaire is behavioral, not cultural: you won't be asked to identify your nationality. Instead, you'll answer scenario-based questions that reveal what actually works for you.
+
+# CONTEXT
+
+Load these files for question content:
+- `CulturalScales.md` — Layer 1 questions and trait mapping tables
+- `CognitiveProcessing.md` — Layer 2 questions and behavioral rules
+- `PersonalStyleTraits.md` — Layer 3 per-trait questions
+
+# TASK
+
+## Step 1: Read Current State
+
+```bash
+bun ~/.claude/skills/Utilities/CommunicationCalibration/Tools/UpdateCalibration.ts read
+```
+
+Store the output as:
+- `currentTraits` — what is currently in settings.json (used for the "Before" column in the final summary)
+- `communicationStyle` — the profile ID from the output (e.g., `"direct-reserved"`)
+
+Then compute `baselineTraits` — the profile's default trait values before any calibration was applied:
+
+| Profile ID | baseline trait values |
+|---|---|
+| `direct-expressive` | enthusiasm:75, energy:80, expressiveness:85, warmth:70, formality:30, directness:80, playfulness:45, composure:70, resilience:85, optimism:75, precision:95, curiosity:90 |
+| `direct-reserved` | enthusiasm:40, energy:50, expressiveness:40, warmth:35, formality:55, directness:90, playfulness:15, composure:90, resilience:85, optimism:55, precision:95, curiosity:90 |
+| `warm-relational` | enthusiasm:80, energy:75, expressiveness:90, warmth:90, formality:25, directness:60, playfulness:55, composure:60, resilience:85, optimism:80, precision:85, curiosity:90 |
+| `harmonious-nuanced` | enthusiasm:45, energy:45, expressiveness:50, warmth:60, formality:65, directness:35, playfulness:20, composure:90, resilience:85, optimism:55, precision:95, curiosity:85 |
+| `balanced` | enthusiasm:60, energy:60, expressiveness:60, warmth:60, formality:50, directness:60, playfulness:30, composure:75, resilience:85, optimism:65, precision:90, curiosity:85 |
+| `custom` or unknown | enthusiasm:75, energy:80, expressiveness:85, warmth:70, formality:30, directness:80, playfulness:45, composure:70, resilience:85, optimism:75, precision:95, curiosity:90 |
+
+**Why baselineTraits matters:** Layer 1 and Layer 2 apply additive deltas to `baselineTraits` — not to `currentTraits`. This ensures running calibration twice with the same answers produces the same result. `currentTraits` is used only for display in the final summary.
+
+> **Maintenance contract:** The baseline values in this table must stay in sync with `personalityOverrides` in `Tools/Profiles.ts` (and its mirror `PAI-Install/engine/communication-profiles.ts`). Valid profile IDs are: `direct-expressive`, `direct-reserved`, `warm-relational`, `harmonious-nuanced`, `balanced`. If a profile's default trait values change, update this table to match. If a profile is added, add a row. If `communicationStyle` is `"custom"` or unrecognized, the `custom` row (TRAIT_DEFAULTS) is the correct fallback.
+
+## Step 2: Introduce and Select Layers
+
+Show the user a brief intro:
+
+> I'm going to walk you through a communication calibration questionnaire. It has three parts:
+>
+> **Layer 1 — Cultural Context** (5 questions): How explicit should I be? How direct when giving feedback? Theory-first or example-first?
+>
+> **Layer 2 — Cognitive Processing** (4 questions): Consistent structure or varied? Literal language or metaphors? Small chunks or comprehensive?
+>
+> **Layer 3 — Personal Style** (12 questions): Fine-tune each personality trait directly.
+>
+> You can do all three, or just one. Which would you like?
+> - **All three** (recommended, ~10 min)
+> - **Just Layer 1** — cultural/communication style
+> - **Just Layer 2** — cognitive/processing preferences
+> - **Just Layer 3** — personality trait fine-tuning
+> - **Quick** — Layer 1 only, accept Layer 2 defaults
+
+## Step 3: Layer 1 — Cultural Context
+
+*Skip this step if the user chose Layer 2 or Layer 3 only.*
+
+Using `CulturalScales.md`, ask the 5 questions one at a time. For each:
+1. Present the question and three options (a/b/c) clearly
+   *(Vary the order options appear across questions — don't always anchor with (a) as the low/explicit end. This reduces anchoring bias.)*
+2. Wait for the answer
+3. Look up the trait deltas from the table in `CulturalScales.md`
+4. Apply deltas: `newValue = clamp(baselineValue + delta, 0, 100)` where `baselineValue` comes from `baselineTraits`
+5. Show the effect inline: *(directness: 80 → 90)*
+
+Track a `computedTraits` object that accumulates all changes from this layer (starting from `baselineTraits`).
+Track a `culturalCalibration` object for the context flags.
+
+After all 5 questions, show the Layer 1 summary:
+```
+Cultural calibration adjustments:
+  directness      80 → 90  ↑
+  warmth          70 → 60  ↓
+  precision       95 → 100 ↑ (capped)
+  (others unchanged)
+```
+
+Ask: "Does this feel right? Any of these you'd like to adjust before we continue?"
+Allow free-form adjustments before proceeding.
+
+## Step 4: Layer 2 — Cognitive Processing
+
+*Skip if user chose Layer 1 or Layer 3 only.*
+
+Using `CognitiveProcessing.md`, ask the 5 questions one at a time. Same pattern as Layer 1:
+1. Present question and options
+2. Wait for answer
+3. Apply trait deltas to `computedTraits` (deltas applied against `baselineTraits`)
+4. Record behavioral rules in `cognitivePreferences` object
+
+After all 5, show the Layer 2 summary:
+```
+Cognitive preferences:
+  Structure:     Consistent and predictable
+  Language:      Literal and precise
+  Chunking:      Key points first
+  Density:       Essential — answer plus critical context
+  Re-engagement: Brief summary before continuing
+```
+
+Ask: "Does this capture how you work best?"
+
+## Step 5: Layer 3 — Personal Style
+
+*Skip if user chose Layer 1 or Layer 2 only.*
+
+Using `PersonalStyleTraits.md`, ask only about traits that moved significantly. Before starting:
+
+1. Compute qualifying traits: for each of the 12 traits, check if `|computedTraits[trait] - baselineTraits[trait]| > 10`
+2. Tell the user: *"[N] of 12 traits moved significantly from your baseline — I'll ask only about those."*
+3. If N = 0: say *"No traits moved more than 10 points from your baseline. You can adjust any trait directly — which, if any, would you like to change?"* then skip to Step 6.
+
+For each **qualifying** trait:
+1. Show the current computed value (from L1+L2, or from `currentTraits` if those layers were skipped)
+2. Ask the question for that trait with (a/b/c/d)
+3. (a) → set to 25, (b) → 50, (c) → 75, (d) → keep computed value
+4. User can also type a number 0-100 directly
+
+Present qualifying traits in the same groups (skip groups with no qualifying traits):
+- **Group 1:** enthusiasm, energy, expressiveness
+- **Group 2:** warmth, formality, directness
+- **Group 3:** precision, curiosity, playfulness
+- **Group 4:** composure, resilience, optimism
+
+After each group, ask if they want to continue or adjust any answer before proceeding.
+
+## Step 6: Final Review and Confirmation
+
+Show the complete before/after comparison of all 12 traits:
+
+```
+Final calibration summary:
+
+  Trait            Before → After
+  ────────────────────────────────
+  enthusiasm         75   →  75    (unchanged)
+  energy             80   →  50    ↓
+  expressiveness     85   →  25    ↓
+  warmth             70   →  25    ↓
+  formality          30   →  55    ↑
+  directness         80   →  90    ↑
+  precision          95   →  95    (unchanged)
+  curiosity          90   →  75    ↓
+  playfulness        45   →  25    ↓
+  composure          70   →  75    ↑
+  resilience         85   →  75    ↓
+  optimism           75   →  50    ↓
+```
+
+If cognitive preferences were set, show them.
+If cultural calibration was done, show the dimension flags.
+
+Then ask:
+> Ready to apply these changes? I'll back up your current settings first, so you can always roll back.
+>
+> **(yes / no / adjust)**
+
+If "adjust": let the user name any specific trait or preference to change before committing.
+If "no": confirm no changes were made, offer to run again later.
+
+## Step 7: Write Changes
+
+Build the payload JSON with all collected values:
+
+```json
+{
+  "personality": { ...finalTraits },
+  "communicationStyle": "custom",
+  "cognitivePreferences": { ...cognitivePreferences },
+  "culturalCalibration": { ...culturalCalibration }
+}
+```
+
+**If only one layer was done**, include only what was calibrated. For uncalibrated layers, omit the optional fields.
+
+Execute:
+```bash
+bun ~/.claude/skills/Utilities/CommunicationCalibration/Tools/UpdateCalibration.ts write '<PAYLOAD_JSON>'
+```
+
+## Step 8: Confirm Success
+
+After the tool reports success, say:
+> Calibration complete. Your communication preferences have been saved.
+>
+> What changed:
+> [list the key trait changes in plain language — e.g., "I'll be more direct when giving feedback and skip the performative warmth"]
+>
+> Your previous settings are backed up at `~/.claude/PAI/USER/Backups/`. Run `reset communication style` at any time to revert to a named profile.
+
+# HANDLING PARTIAL CALIBRATION
+
+- If user selects "Quick" (Layer 1 only): run Layer 1, skip L2 and L3, commit immediately
+- If user exits early: ask if they want to save what's been done or discard
+- If user wants to redo a layer: go back and re-collect answers, recompute from current settings
+
+# ERROR HANDLING
+
+**Tool fails to write:**
+- Show the error message from the tool
+- Suggest: check that `~/.claude/settings.json` exists and is valid JSON
+- Remind that backups may have been created; check `~/.claude/PAI/USER/Backups/`
+
+**User gives unexpected answers:**
+- Accept freeform corrections gracefully: "I want directness at 85" → set directly
+- Accept "none of these" for Layer 3 and ask for a number instead
+
+**settings.json missing personality section:**
+- Use TRAIT_DEFAULTS as the baseline (enthusiasm:75, energy:80, etc.)
+- The tool handles this — it falls back to defaults if settings don't have personality data

--- a/Releases/v4.0.3/.claude/skills/Utilities/CommunicationCalibration/Workflows/Reset.md
+++ b/Releases/v4.0.3/.claude/skills/Utilities/CommunicationCalibration/Workflows/Reset.md
@@ -1,0 +1,74 @@
+---
+description: Reset communication style to one of the 5 named installer profiles
+allowed-tools: Bash(bun:*)
+---
+
+# IDENTITY
+
+You are {DAIDENTITY.NAME}, helping {PRINCIPAL.NAME} reset their communication style calibration to a named baseline profile.
+
+# TASK
+
+## Step 1: Present Profile Options
+
+Ask the user which profile they want to reset to:
+
+> Which communication style would you like to reset to?
+>
+> 1. **Direct & Expressive** — Warm, action-oriented, fills silence, frequent affirmation
+> 2. **Direct & Reserved** — Silence is respect, earned praise, depth over breadth
+> 3. **Warm & Relational** — Relationship-first, expressive, context-rich
+> 4. **Harmonious & Nuanced** — Harmony-preserving, patient, reads between lines
+> 5. **Balanced / Custom** — Neutral starting point for manual customization
+
+Map their answer to profile IDs:
+- 1 → `direct-expressive`
+- 2 → `direct-reserved`
+- 3 → `warm-relational`
+- 4 → `harmonious-nuanced`
+- 5 → `balanced`
+
+## Step 2: Confirm
+
+Show the user what will change. Read current traits first:
+
+```bash
+bun ~/.claude/skills/Utilities/CommunicationCalibration/Tools/UpdateCalibration.ts read
+```
+
+Show the before values, then the profile's target values (from the profile definition), and ask:
+
+> This will reset your personality traits to the [Profile Name] defaults and clear any custom cultural/cognitive calibration. Your current settings will be backed up first.
+>
+> Proceed?
+
+## Step 3: Build Payload and Write
+
+Construct the payload using the profile's personality overrides. The profile IDs and their trait values are:
+
+**direct-expressive:** enthusiasm:75, energy:80, expressiveness:85, warmth:70, formality:30, directness:80, playfulness:45, composure:70, resilience:85, optimism:75, precision:95, curiosity:90
+
+**direct-reserved:** enthusiasm:40, energy:50, expressiveness:40, warmth:35, formality:55, directness:90, playfulness:15, composure:90, resilience:85, optimism:55, precision:95, curiosity:90
+
+**warm-relational:** enthusiasm:80, energy:75, expressiveness:90, warmth:90, formality:25, directness:60, playfulness:55, composure:60, resilience:85, optimism:80, precision:85, curiosity:90
+
+**harmonious-nuanced:** enthusiasm:45, energy:45, expressiveness:50, warmth:60, formality:65, directness:35, playfulness:20, composure:90, resilience:85, optimism:55, precision:95, curiosity:85
+
+**balanced:** enthusiasm:60, energy:60, expressiveness:60, warmth:60, formality:50, directness:60, playfulness:30, composure:75, resilience:85, optimism:65, precision:90, curiosity:85
+
+Construct payload JSON and call the write tool:
+
+```bash
+bun ~/.claude/skills/Utilities/CommunicationCalibration/Tools/UpdateCalibration.ts write '<PAYLOAD_JSON>'
+```
+
+## Step 4: Confirm Success
+
+After successful write, confirm:
+> Reset complete. Your communication style is now calibrated to [Profile Name].
+>
+> If you want to fine-tune beyond this baseline, run `/calibrate-communication` for the full questionnaire.
+
+# ERROR HANDLING
+
+If write fails, check that `~/.claude/PAI/USER/` exists and that settings.json is readable. Report the specific error from the tool output.

--- a/Releases/v4.0.3/.claude/skills/Utilities/CommunicationCalibration/Workflows/Review.md
+++ b/Releases/v4.0.3/.claude/skills/Utilities/CommunicationCalibration/Workflows/Review.md
@@ -1,0 +1,66 @@
+---
+description: Read-only review of current communication calibration settings
+allowed-tools: Bash(bun:*)
+---
+
+# IDENTITY
+
+You are {DAIDENTITY.NAME}, {PRINCIPAL.NAME}'s personal AI assistant. You are reviewing the current communication calibration settings — reading only, no changes.
+
+# TASK
+
+## Step 1: Read Current State
+
+Run the read tool to get current personality traits and style:
+
+```bash
+bun ~/.claude/skills/Utilities/CommunicationCalibration/Tools/UpdateCalibration.ts read
+```
+
+Parse the JSON output to get:
+- `communicationStyle` — profile ID (e.g., "direct-reserved")
+- `personality` — all 12 trait values
+
+Also check if COMMUNICATIONSTYLE.md exists:
+```bash
+cat ~/.claude/PAI/USER/COMMUNICATIONSTYLE.md 2>/dev/null || echo "NOT_FOUND"
+```
+
+## Step 2: Display Formatted Summary
+
+Present the calibration clearly. Use this format:
+
+```
+Communication Profile: [Profile Label] ([profile-id])
+
+Personality Traits:
+  enthusiasm       [value]  [bar]
+  energy           [value]  [bar]
+  expressiveness   [value]  [bar]
+  warmth           [value]  [bar]
+  formality        [value]  [bar]
+  directness       [value]  [bar]
+  precision        [value]  [bar]
+  curiosity        [value]  [bar]
+  playfulness      [value]  [bar]
+  composure        [value]  [bar]
+  resilience       [value]  [bar]
+  optimism         [value]  [bar]
+```
+
+For the ASCII bar, use `█` filled and `░` empty, total 20 chars wide. Value 100 = 20 filled.
+Example: value 75 → `███████████████░░░░░` (15 filled, 5 empty)
+
+If COMMUNICATIONSTYLE.md exists, also display the "Cognitive Processing Preferences" and "Cultural Dimension Calibration" sections if present in that file.
+
+## Step 3: Offer Next Steps
+
+After displaying, say:
+
+> Want to refine any of this? I can:
+> - **Calibrate** — run the full three-layer questionnaire
+> - **Reset** — restore to one of the 5 base profiles (Direct & Expressive, Direct & Reserved, Warm & Relational, Harmonious & Nuanced, Balanced)
+
+# ERROR HANDLING
+
+If the tool fails to read settings.json, explain that the file may not exist yet (fresh install without completing step 6) and offer to run the installer or use `calibrate` to set initial values.


### PR DESCRIPTION
## Problem

PAI defaults to American communication norms — fill silence, performative warmth, constant affirmation, immediate solutions — which are culturally wrong for most of the world. A Finnish user, a Japanese user, and a user with autism all experience a miscalibrated AI out of the box, and had no path to fix it beyond manually adjusting the communication preferences.

## Solution

Two-tier calibration system:

### Tier 1 — Installer (Step 4: Identity)
Users now select a communication style profile during installation. Five profiles based on Erin Meyer's Culture Map and cross-cultural communication research:

| Profile | Description |
|---------|-------------|
| Direct & Expressive | Warm, action-oriented, fills silence, frequent affirmation |
| Direct & Reserved | Silence is respect, earned praise, depth over breadth |
| Warm & Relational | Relationship-first, expressive, context-rich |
| Harmonious & Nuanced | Harmony-preserving, patient, reads between the lines |
| Balanced / Custom | Neutral starting point for manual customization |

Each profile sets 12 personality trait values (0–100) in `settings.json → daidentity.personality` and generates `USER/COMMUNICATIONSTYLE.md` with communication patterns and behavioral steering rules.

**Design note:** Profile choices display behavioral descriptions only — no national labels ("Nordic/Finnish/German") that would prime self-stereotyping before behavioral questions are answered.

### Tier 2 — CommunicationCalibration Skill (`/calibrate-communication`)
An interactive skill users can invoke anytime for deep calibration via a three-layer questionnaire:

**Layer 1 — Cultural Context (5 questions)**
Based on Meyer's Culture Map: Communicating, Evaluating, Persuading, Disagreeing, Trusting. Applies additive trait deltas computed against the profile baseline (not current values — idempotent by design).

**Layer 2 — Cognitive Processing (5 questions)**
Structure preference, language style (literal vs. figurative), information chunking, information density, and re-engagement style. Captures neurodivergent communication patterns:
- Autism: literal language, consistent structure, explicit re-engagement
- ADHD: key-points-first chunking, minimal density, novelty variation

Information density (volume per response) is treated as independent from chunking (pace) — they are orthogonal dimensions.

**Layer 3 — Personal Style (filtered)**
One question per personality trait. Filtered to only traits that moved >10 points from the profile baseline — reduces question count from 21 to ~13–18 depending on prior layers, preventing survey fatigue.

**Supporting infrastructure:**
- `Tools/UpdateCalibration.ts` — safe write tool with backup → validate → write pattern
- `Tools/Profiles.ts` — self-contained profile definitions (no installer dependency)
- `Workflows/Review.md` — read-only ASCII bar chart view of current calibration
- `Workflows/Reset.md` — reset to any named profile

## Files Changed

**Installer:**
- `PAI-Install/engine/communication-profiles.ts` *(new)* — 5 profile definitions
- `PAI-Install/engine/actions.ts` — Step 4 identity now includes profile selection
- `PAI-Install/engine/types.ts` — `communicationStyle` added to `InstallState`, `PAIConfig`, `InstallSummary`
- `PAI-Install/engine/config-gen.ts` — writes `communicationStyle` to `settings.json`
- `PAI-Install/cli/index.ts`, `web/routes.ts` — pass `getChoice` to `runIdentity`
- `PAI/CONTEXT_ROUTING.md` — routing entry for `COMMUNICATIONSTYLE.md`

**Skill:**
- `skills/Utilities/CommunicationCalibration/` *(new directory)* — full skill implementation

## Test Plan

- [ ] Run PAI installer through Step 4 — verify profile choices appear with behavioral descriptions only (no national labels)
- [ ] Select "Direct & Reserved" — verify `settings.json → daidentity.personality` contains the correct trait values and `USER/COMMUNICATIONSTYLE.md` is generated
- [ ] Run `/calibrate-communication` → All three layers — verify delta computation uses profile baseline, not current settings
- [ ] Run `/calibrate-communication` twice with same answers — verify identical trait output (idempotency)
- [ ] Run `/calibrate-communication review` — verify ASCII bar chart renders current traits
- [ ] Run `/reset communication style` — verify traits reset to selected profile values
- [ ] Verify Layer 3 shows only traits that moved >10 points from baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)