### PR TITLE
Update PAI skill path in validate.ts to the correct path

### DIFF
--- a/Releases/v4.0.3/.claude/PAI-Install/engine/validate.ts
+++ b/Releases/v4.0.3/.claude/PAI-Install/engine/validate.ts
@@ -107,7 +107,7 @@ export async function runValidation(state: InstallState): Promise<ValidationChec
   }
 
   // 4. PAI skill present
-  const skillPath = join(paiDir, "skills", "PAI", "SKILL.md");
+  const skillPath = join(paiDir, "PAI", "SKILL.md");
   checks.push({
     name: "PAI core skill",
     passed: existsSync(skillPath),


### PR DESCRIPTION
Simple one-line fix so the validator checks the correct path for the PAI core skill. 

The validation step reports "PAI core skill: Not found - clone PAI repo to enable" even though the PAI core skill exists. The validator looks for ~/.claude/skills/PAI/SKILL.md, but the actual file lives at ~/.claude/PAI/SKILL.md.