### PR TITLE
fix: Respect PAI_DIR environment variable in v4.0.3 installer

### DIFF
--- a/Releases/v4.0.3/.claude/PAI-Install/engine/actions.ts
+++ b/Releases/v4.0.3/.claude/PAI-Install/engine/actions.ts
@@ -500,7 +500,7 @@ export async function runRepository(
   emit: EngineEventHandler
 ): Promise<void> {
   await emit({ event: "step_start", step: "repository" });
-  const paiDir = state.detection?.paiDir || join(homedir(), ".claude");
+  const paiDir = state.detection?.paiDir || process.env.PAI_DIR || join(homedir(), ".claude");
 
   if (state.installType === "upgrade") {
     await emit({ event: "progress", step: "repository", percent: 20, detail: "Existing installation found, updating..." });
@@ -585,7 +585,7 @@ export async function runConfiguration(
   emit: EngineEventHandler
 ): Promise<void> {
   await emit({ event: "step_start", step: "configuration" });
-  const paiDir = state.detection?.paiDir || join(homedir(), ".claude");
+  const paiDir = state.detection?.paiDir || process.env.PAI_DIR || join(homedir(), ".claude");
   const configDir = state.detection?.configDir || join(homedir(), ".config", "PAI");
 
   // Generate settings.json
@@ -985,7 +985,7 @@ export async function runVoiceSetup(
   }
 
   // ── Start voice server (works with or without ElevenLabs key) ──
-  const paiDir = state.detection?.paiDir || join(homedir(), ".claude");
+  const paiDir = state.detection?.paiDir || process.env.PAI_DIR || join(homedir(), ".claude");
   await emit({ event: "progress", step: "voice", percent: 25, detail: "Starting voice server..." });
   const voiceServerReady = await startVoiceServer(paiDir, emit);
 

--- a/Releases/v4.0.3/.claude/PAI-Install/engine/detect.ts
+++ b/Releases/v4.0.3/.claude/PAI-Install/engine/detect.ts
@@ -126,7 +126,7 @@ function detectExisting(
  */
 export function detectSystem(): DetectionResult {
   const home = homedir();
-  const paiDir = join(home, ".claude");
+  const paiDir = process.env.PAI_DIR || join(home, ".claude");
   const configDir = process.env.PAI_CONFIG_DIR || join(home, ".config", "PAI");
 
   return {

--- a/Releases/v4.0.3/.claude/PAI-Install/engine/validate.ts
+++ b/Releases/v4.0.3/.claude/PAI-Install/engine/validate.ts
@@ -25,7 +25,7 @@ async function checkVoiceServerHealth(): Promise<boolean> {
  * Run all validation checks against the current state.
  */
 export async function runValidation(state: InstallState): Promise<ValidationCheck[]> {
-  const paiDir = state.detection?.paiDir || join(homedir(), ".claude");
+  const paiDir = state.detection?.paiDir || process.env.PAI_DIR || join(homedir(), ".claude");
   const configDir = state.detection?.configDir || join(homedir(), ".config", "PAI");
   const checks: ValidationCheck[] = [];
 

--- a/Releases/v4.0.3/.claude/PAI-Install/install.sh
+++ b/Releases/v4.0.3/.claude/PAI-Install/install.sh
@@ -57,6 +57,14 @@ echo ""
 echo -e "${STEEL}┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛${RESET}"
 echo ""
 
+# ─── Custom PAI_DIR Support ──────────────────────────────
+# Set PAI_DIR to install PAI into a non-default directory.
+# Default: ~/.claude   Example: PAI_DIR=~/Albert/.claude bash install.sh
+if [ -n "${PAI_DIR:-}" ]; then
+  info "Custom PAI_DIR: $PAI_DIR"
+  export PAI_DIR
+fi
+
 # ─── Resolve Script Directory ─────────────────────────────
 # Follow symlinks so install.sh works from ~/.claude/ symlink
 SOURCE="${BASH_SOURCE[0]}"
@@ -155,7 +163,7 @@ info "Launching installer..."
 echo ""
 
 # Auto-detect headless/SSH environments and fall back to CLI mode
-if [ -z "$DISPLAY" ] && [ -z "$WAYLAND_DISPLAY" ] && [ "$(uname)" != "Darwin" ]; then
+if [ -z "${DISPLAY:-}" ] && [ -z "${WAYLAND_DISPLAY:-}" ] && [ "$(uname)" != "Darwin" ]; then
     INSTALL_MODE="cli"
     info "Headless environment detected — using CLI installer."
 else


### PR DESCRIPTION
## Summary

The v4.0.3 installer hardcodes `~/.claude` as the PAI directory in several fallback paths, ignoring the `PAI_DIR` environment variable. Users who set `PAI_DIR` to a custom path get a broken installation because detection, configuration, validation, and voice setup all fall back to `~/.claude` instead of respecting the env var.

## Changes

4 files in `Releases/v4.0.3/.claude/PAI-Install/`:

- **`engine/detect.ts`** — Read `PAI_DIR` from `process.env` when detecting system paths
- **`engine/actions.ts`** — Add `process.env.PAI_DIR` fallback in repository, configuration, and voice setup steps (3 locations)
- **`engine/validate.ts`** — Add `process.env.PAI_DIR` fallback in validation checks
- **`install.sh`** — Pass through `PAI_DIR` if set; fix unbound variable errors for `DISPLAY`/`WAYLAND_DISPLAY` in headless detection (`set -euo pipefail` compatibility)

## Test plan

- [ ] Run `bash install.sh` without `PAI_DIR` set — should default to `~/.claude` (no behavior change)
- [ ] Run `PAI_DIR=~/custom/.claude bash install.sh` — should install to `~/custom/.claude`
- [ ] Run installer on headless Linux without `DISPLAY` set — should not error on unbound variable