### PR TITLE
feat: add USER-tier MCP shortcut/description overrides in pai.ts

### DIFF
--- a/Releases/v4.0.3/.claude/PAI/Tools/pai.ts
+++ b/Releases/v4.0.3/.claude/PAI/Tools/pai.ts
@@ -35,8 +35,39 @@ const BANNER_SCRIPT = join(CLAUDE_DIR, "PAI", "Tools", "Banner.ts");
 const VOICE_SERVER = "http://localhost:8888/notify/personality";
 const WALLPAPER_DIR = join(homedir(), "Projects", "Wallpaper");
 // Note: RAW archiving removed - Claude Code handles its own cleanup (30-day retention in projects/)
+const PAI_USER_DIR = join(CLAUDE_DIR, "PAI", "USER");
+
+// Merge (not replace) USER overrides over SYSTEM defaults for additive lookup tables.
+// See PAI/SYSTEM_USER_EXTENDABILITY.md for the two-tier pattern.
+function loadUserConfig(
+  filename: string,
+  systemDefaults: Record<string, string>
+): Record<string, string> {
+  const userPath = join(PAI_USER_DIR, filename);
+  try {
+    const raw = readFileSync(userPath, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      console.error(`⚠️  ${filename}: expected object. Using defaults.`);
+      return systemDefaults;
+    }
+    return { ...systemDefaults, ...parsed };
+  } catch (e: unknown) {
+    // ENOENT (no user file) is the common case — silent fallback.
+    // Parse errors get a warning so the user knows their file is broken.
+    const code = e && typeof e === "object" && "code" in e ? (e as any).code : null;
+    if (code !== "ENOENT") {
+      const msg = e instanceof Error ? e.message : "parse error";
+      console.error(`⚠️  ${filename}: ${msg}. Using defaults.`);
+    }
+    return systemDefaults;
+  }
+}
 
 // MCP shorthand mappings
+// TODO(#901): MCP config in settings.json is silently ignored by Claude Code.
+// Claude Code reads from .mcp.json (project) or ~/.claude.json (global).
+// pai.ts correctly writes to .mcp.json via symlink. See issues #901, #646.
 const MCP_SHORTCUTS: Record<string, string> = {
   bd: "Brightdata-MCP.json",
   brightdata: "Brightdata-MCP.json",
@@ -66,6 +97,15 @@ const PROFILE_DESCRIPTIONS: Record<string, string> = {
   clickup: "Official ClickUp MCP (tasks, time tracking, docs)",
   full: "All available MCPs",
 };
+
+// Merged accessors — USER overrides SYSTEM for both maps
+function getMcpShortcuts(): Record<string, string> {
+  return loadUserConfig("MCP_SHORTCUTS.json", MCP_SHORTCUTS);
+}
+
+function getProfileDescriptions(): Record<string, string> {
+  return loadUserConfig("PROFILE_DESCRIPTIONS.json", PROFILE_DESCRIPTIONS);
+}
 
 // ============================================================================
 // Utilities
@@ -234,9 +274,10 @@ function setMcpProfile(profile: string) {
 
 function setMcpCustom(mcpNames: string[]) {
   const files: string[] = [];
+  const shortcuts = getMcpShortcuts();
 
   for (const name of mcpNames) {
-    const file = MCP_SHORTCUTS[name.toLowerCase()];
+    const file = shortcuts[name.toLowerCase()];
     if (file) {
       files.push(file);
     } else {
@@ -507,10 +548,11 @@ function cmdProfiles() {
 
   const current = getCurrentProfile();
   const profiles = getMcpProfiles();
+  const descriptions = getProfileDescriptions();
 
   for (const profile of profiles) {
     const isCurrent = profile === current;
-    const desc = PROFILE_DESCRIPTIONS[profile] || "";
+    const desc = descriptions[profile] || "";
     const marker = isCurrent ? "→ " : "  ";
     const badge = isCurrent ? " (active)" : "";
     console.log(`${marker}${profile}${badge}`);
@@ -528,8 +570,9 @@ function cmdMcpList() {
   // Individual MCPs
   log("Individual MCPs (use with -m):", "📦");
   const mcps = getIndividualMcps();
+  const allShortcuts = getMcpShortcuts();
   for (const mcp of mcps) {
-    const shortcut = Object.entries(MCP_SHORTCUTS)
+    const shortcut = Object.entries(allShortcuts)
       .filter(([_, v]) => v === `${mcp}-MCP.json`)
       .map(([k]) => k);
     const shortcuts = shortcut.length > 0 ? ` (${shortcut.join(", ")})` : "";
@@ -539,8 +582,9 @@ function cmdMcpList() {
   console.log();
   log("Profiles (use with 'k mcp set'):", "📁");
   const profiles = getMcpProfiles();
+  const allDescriptions = getProfileDescriptions();
   for (const profile of profiles) {
-    const desc = PROFILE_DESCRIPTIONS[profile] || "";
+    const desc = allDescriptions[profile] || "";
     console.log(`  ${profile}${desc ? ` - ${desc}` : ""}`);
   }
 


### PR DESCRIPTION
## Summary

- Adds `loadUserConfig()` to `pai.ts` that reads `PAI/USER/MCP_SHORTCUTS.json` and `PAI/USER/PROFILE_DESCRIPTIONS.json`, merging USER keys over SYSTEM defaults
- Users can now add custom MCP shortcuts without modifying `pai.ts` (system-tier file)
- Follows the SYSTEM/USER two-tier pattern documented in `SYSTEM_USER_EXTENDABILITY.md`
- Adds `TODO(#901)` comment documenting the known `settings.json` vs `.mcp.json` config mismatch

## Problem

`MCP_SHORTCUTS` and `PROFILE_DESCRIPTIONS` are hardcoded constants in `pai.ts`. Users who add custom MCP servers (Telegram, Affine, Cloudflare, etc.) must either:
1. Modify `pai.ts` directly — breaks on every PAI update
2. Skip shortcuts entirely — lose the ergonomic `k -m name` CLI experience

This violates PAI's own SYSTEM/USER extensibility pattern, which already works for security patterns (`PAISECURITYSYSTEM/`), skills (`SKILLCUSTOMIZATIONS/`), and response formats.

Related issues: #901, #646, #650

## Implementation

**1 file changed, 48 insertions, 4 deletions.**

### `loadUserConfig(filename, systemDefaults)` (~25 lines)
- Reads `PAI/USER/{filename}` JSON
- Merges via `{ ...systemDefaults, ...parsed }` — USER keys win on collision, SYSTEM keys persist
- ENOENT (no file): silent fallback — this is the common case
- Parse error: `console.error` warning + fallback to SYSTEM defaults
- Non-object JSON (array, null): warning + fallback

### `getMcpShortcuts()` / `getProfileDescriptions()`
- Accessor functions replacing 4 direct constant accesses
- Hoisted before loops to avoid repeated file reads

### Design decisions
- **Merge, not replace:** Shortcuts are additive lookup tables. A user adding `tg: Telegram-MCP.json` shouldn't lose 13 SYSTEM shortcuts. This is a documented exception to the "USER replaces SYSTEM" convention — additive maps deserve additive semantics.
- **JSON format:** Zero dependency (`JSON.parse` built-in). Consistent with `*.mcp.json` files already in `MCPs/`.
- **PAI/USER/ location:** Consistent with all other USER overrides in the codebase.
- **Scope:** Does NOT bundle the #901 settings.json mismatch fix — separate concern, different risk surface. Adds a `TODO(#901)` comment instead.

## User experience

```bash
# Create PAI/USER/MCP_SHORTCUTS.json:
echo '{"tg": "Telegram-MCP.json", "atlas": "atlas.mcp.json"}' > ~/.claude/PAI/USER/MCP_SHORTCUTS.json

# Now works:
k -m tg          # Resolves to Telegram-MCP.json from MCPs/
k mcp set atlas  # Resolves atlas.mcp.json from MCPs/

# SYSTEM shortcuts unaffected:
k -m bd          # Still resolves Brightdata-MCP.json
```

## Test plan

Tested on WSL2 (Ubuntu, Linux 6.6.87.2) with Bun runtime.

- [x] USER shortcuts resolve via `k -m <name>` and `k mcp set <profile>`
- [x] USER descriptions display in `k mcp list` and `k profiles`
- [x] Missing USER file: silent fallback, 0 warnings, SYSTEM shortcuts work
- [x] Malformed USER JSON: warning printed, falls back to SYSTEM defaults
- [x] Array JSON (`[1,2,3]`): warning + fallback (not a valid object)
- [x] SYSTEM shortcuts persist when USER file adds new keys (merge, not replace)
- [x] Zero breaking changes to existing CLI behavior

```bash
# Verification commands:
bun PAI/Tools/pai.ts mcp list           # Should show USER + SYSTEM entries
bun PAI/Tools/pai.ts mcp set <profile>  # Should resolve USER profiles

# Error handling:
echo "broken" > ~/.claude/PAI/USER/MCP_SHORTCUTS.json
bun PAI/Tools/pai.ts mcp list 2>&1      # Should show warning + SYSTEM defaults
```

Generated with [Claude Code](https://claude.ai/code)