### PR TITLE
fix: centralize voice config — remove hardcoded ElevenLabs IDs

### DIFF
--- a/Releases/v4.0.2/.claude/CLAUDE.md
+++ b/Releases/v4.0.2/.claude/CLAUDE.md
@@ -15,7 +15,7 @@ Your first output MUST be the mode header. No freeform output. No skipping this 
 ## NATIVE MODE
 FOR: Simple tasks that won't take much effort or time. More advanced tasks use ALGORITHM MODE below.
 
-**Voice:** `curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Executing using PAI native mode", "voice_id": "fTtv3eikoepIosk8dTZ5", "voice_enabled": true}'`
+**Voice:** `curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Executing using PAI native mode"}'`
 
 ```
 ════ PAI | NATIVE MODE ═══════════════════════

--- a/Releases/v4.0.2/.claude/PAI/Algorithm/v3.5.0.md
+++ b/Releases/v4.0.2/.claude/PAI/Algorithm/v3.5.0.md
@@ -25,7 +25,7 @@ At Algorithm entry and every phase transition, announce via direct inline curl (
 ```bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message": "MESSAGE", "voice_id": "fTtv3eikoepIosk8dTZ5", "voice_enabled": true}'
+  -d '{"message": "MESSAGE"}'
 ```
 
 **Algorithm entry:** `"Entering the Algorithm"` — immediately before OBSERVE begins.
@@ -113,7 +113,7 @@ The coarse version has 3 criteria that each hide 6+ verifiable sub-requirements.
 
 ### Execution of The Algorithm
 
-**Voice:** `curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Entering the Algorithm", "voice_id": "fTtv3eikoepIosk8dTZ5", "voice_enabled": true}'`
+**Voice:** `curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Entering the Algorithm"}'`
 
 **Console output at Algorithm entry (MANDATORY):**
 ```

--- a/Releases/v4.0.2/.claude/PAI/SKILL.md
+++ b/Releases/v4.0.2/.claude/PAI/SKILL.md
@@ -238,7 +238,7 @@ More ISC = finer verification = better hill-climbing. When in doubt, more criter
 
 🗒️ TASK: [8 word description]
 
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"fTtv3eikoepIosk8dTZ5","message": "Entering the PAI Algorithm Observe phase"}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Entering the PAI Algorithm Observe phase"}'`
 
 ━━━ 👁️ OBSERVE ━━━ 1/7
 ```
@@ -270,7 +270,7 @@ Walk the Full Capability Registry (25 capabilities, Sections A-F) and assign USE
 **Quality Gate → OPEN or BLOCKED.**
 
 ```
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"fTtv3eikoepIosk8dTZ5","message": "Entering the Think phase"}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Entering the Think phase"}'`
 
 ━━━ 🧠 THINK ━━━ 2/7
 ```
@@ -286,7 +286,7 @@ Walk the Full Capability Registry (25 capabilities, Sections A-F) and assign USE
 Extended+: Rehearse verification for each CRITICAL criterion.
 
 ```
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"fTtv3eikoepIosk8dTZ5","message": "Entering the Plan phase"}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Entering the Plan phase"}'`
 
 ━━━ 📋 PLAN ━━━ 3/7
 ```
@@ -299,7 +299,7 @@ Extended+: Rehearse verification for each CRITICAL criterion.
 - Quality Gate re-check.
 
 ```
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"fTtv3eikoepIosk8dTZ5","message": "Entering the Build phase"}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Entering the Build phase"}'`
 
 ━━━ 🔨 BUILD ━━━ 4/7
 ```
@@ -309,7 +309,7 @@ Extended+: Rehearse verification for each CRITICAL criterion.
 - Create artifacts. Log work and observations to PRD.
 
 ```
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"fTtv3eikoepIosk8dTZ5","message": "Entering the Execute phase"}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Entering the Execute phase"}'`
 
 ━━━ ⚡ EXECUTE ━━━ 5/7
 ```
@@ -320,7 +320,7 @@ Extended+: Rehearse verification for each CRITICAL criterion.
 - Log work and observations to PRD.
 
 ```
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"fTtv3eikoepIosk8dTZ5","message": "Entering the Verify phase."}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Entering the Verify phase."}'`
 
 ━━━ ✅ VERIFY ━━━ 6/7
 ```
@@ -337,7 +337,7 @@ Extended+: Rehearse verification for each CRITICAL criterion.
 - Clear ISC/VERIFICATION TaskList.
 
 ```
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"fTtv3eikoepIosk8dTZ5","message": "Entering the Learn phase"}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Entering the Learn phase"}'`
 
 ━━━ 📚 LEARN ━━━ 7/7
 ```

--- a/Releases/v4.0.2/.claude/PAI/THEHOOKSYSTEM.md
+++ b/Releases/v4.0.2/.claude/PAI/THEHOOKSYSTEM.md
@@ -826,7 +826,7 @@ setTimeout(() => {
 **Check:**
 1. Is voice server running? `curl http://localhost:8888/health`
 2. Is voice_id correct? See `PAI/SKILL.md` for mappings
-3. Is message format correct? `{"message":"...", "voice_id":"...", "title":"..."}`
+3. Is message format correct? `{"message":"...",  "title":"..."}`
 4. Is ElevenLabs API key in `${PAI_DIR}/.env`?
 
 **Debug:**
@@ -834,7 +834,7 @@ setTimeout(() => {
 # Test voice server directly
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Test message","voice_id":"[YOUR_VOICE_ID]","title":"Test"}'
+  -d '{"message":"Test message","title":"Test"}'
 ```
 
 **Common Issues:**
@@ -1149,7 +1149,7 @@ Active Tab: Always Dark Blue #002B80 (state colors = inactive only)
 
 VOICE SERVER:
 URL: http://localhost:8888/notify
-Payload: {"message":"...", "voice_id":"...", "title":"..."}
+Payload: {"message":"...",  "title":"..."}
 Configure voice IDs in individual agent files (`agents/*.md` persona frontmatter)
 
 ```

--- a/Releases/v4.0.2/.claude/PAI/THENOTIFICATIONSYSTEM.md
+++ b/Releases/v4.0.2/.claude/PAI/THENOTIFICATIONSYSTEM.md
@@ -72,7 +72,7 @@ When executing an actual workflow file from a `Workflows/` directory:
 ```bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message": "Running the WORKFLOWNAME workflow in the SKILLNAME skill to ACTION", "voice_id": "{DAIDENTITY.VOICEID}", "title": "{DAIDENTITY.NAME}"}' \
+  -d '{"message": "Running the WORKFLOWNAME workflow in the SKILLNAME skill to ACTION", "title": "{DAIDENTITY.NAME}"}' \
   > /dev/null 2>&1 &
 ```
 

--- a/Releases/v4.0.2/.claude/PAI/TOOLS.md
+++ b/Releases/v4.0.2/.claude/PAI/TOOLS.md
@@ -169,7 +169,7 @@ curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
   -d '{
     "message": "Your text here",
-    "voice_id": "$ELEVENLABS_VOICE_ID",
+    
     "title": "Voice Narrative"
   }'
 

--- a/Releases/v4.0.2/.claude/VoiceServer/voices.json
+++ b/Releases/v4.0.2/.claude/VoiceServer/voices.json
@@ -4,7 +4,7 @@
   "default_volume": 0.8,
   "voices": {
     "default": {
-      "voice_id": "bIHbv24MWmeRgasZH58o",
+      
       "voice_name": "Default (Male)",
       "rate_multiplier": 1.35,
       "rate_wpm": 236,
@@ -14,7 +14,7 @@
       "type": "Premium"
     },
     "assistant": {
-      "voice_id": "bIHbv24MWmeRgasZH58o",
+      
       "voice_name": "Assistant (Male)",
       "rate_multiplier": 1.35,
       "rate_wpm": 236,
@@ -24,7 +24,7 @@
       "type": "Premium"
     },
     "researcher": {
-      "voice_id": "MClEFoImJXBTgLwdLI5n",
+      
       "voice_name": "Researcher (Female)",
       "rate_multiplier": 1.35,
       "rate_wpm": 236,
@@ -34,7 +34,7 @@
       "type": "Premium"
     },
     "engineer": {
-      "voice_id": "bIHbv24MWmeRgasZH58o",
+      
       "voice_name": "Engineer (Male)",
       "rate_multiplier": 1.3,
       "rate_wpm": 228,
@@ -44,7 +44,7 @@
       "type": "Premium"
     },
     "architect": {
-      "voice_id": "MClEFoImJXBTgLwdLI5n",
+      
       "voice_name": "Architect (Female)",
       "rate_multiplier": 1.35,
       "rate_wpm": 236,
@@ -54,7 +54,7 @@
       "type": "Premium"
     },
     "designer": {
-      "voice_id": "MClEFoImJXBTgLwdLI5n",
+      
       "voice_name": "Designer (Female)",
       "rate_multiplier": 1.35,
       "rate_wpm": 236,
@@ -64,7 +64,7 @@
       "type": "Premium"
     },
     "analyst": {
-      "voice_id": "M563YhMmA0S8vEYwkgYa",
+      
       "voice_name": "Analyst (Neutral)",
       "rate_multiplier": 1.35,
       "rate_wpm": 236,
@@ -74,7 +74,7 @@
       "type": "Premium"
     },
     "writer": {
-      "voice_id": "MClEFoImJXBTgLwdLI5n",
+      
       "voice_name": "Writer (Female)",
       "rate_multiplier": 1.35,
       "rate_wpm": 236,
@@ -84,7 +84,7 @@
       "type": "Premium"
     },
     "security": {
-      "voice_id": "bIHbv24MWmeRgasZH58o",
+      
       "voice_name": "Security (Male)",
       "rate_multiplier": 1.35,
       "rate_wpm": 236,
@@ -94,7 +94,7 @@
       "type": "Enhanced"
     },
     "intern": {
-      "voice_id": "M563YhMmA0S8vEYwkgYa",
+      
       "voice_name": "Intern (Neutral)",
       "rate_multiplier": 1.4,
       "rate_wpm": 245,

--- a/Releases/v4.0.2/.claude/agents/Algorithm.md
+++ b/Releases/v4.0.2/.claude/agents/Algorithm.md
@@ -3,7 +3,6 @@ name: Algorithm
 description: Expert in creating and evolving Ideal State Criteria (ISC) as part of the PAI Algorithm's core principles. Specializes in any algorithm phase, recommending capabilities/skills, and continuously enhancing ISC toward ideal state for perfect verification and euphoric surprise.
 model: opus
 color: blue
-voiceId: fTtv3eikoepIosk8dTZ5
 voice:
   stability: 0.65
   similarity_boost: 0.86
@@ -40,7 +39,7 @@ permissions:
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Algorithm agent activated, loading ISC expertise","voice_id":"fTtv3eikoepIosk8dTZ5","title":"Algorithm Agent"}'
+  -d '{"message":"Algorithm agent activated, loading ISC expertise","title":"Algorithm Agent"}'
 ```
 
 2. **Load your knowledge base:**
@@ -82,11 +81,10 @@ You embody the PAI Algorithm's core philosophy:
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"fTtv3eikoepIosk8dTZ5","title":"Algorithm Agent"}'
+  -d '{"message":"Your COMPLETED line content here","title":"Algorithm Agent"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `fTtv3eikoepIosk8dTZ5`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.2/.claude/agents/Architect.md
+++ b/Releases/v4.0.2/.claude/agents/Architect.md
@@ -4,7 +4,6 @@ description: Elite system design specialist with PhD-level distributed systems k
 model: opus
 isolation: worktree
 color: purple
-voiceId: muZKMsIDGYtIkjjiUS82
 voice:
   stability: 0.65
   similarity_boost: 0.85
@@ -77,7 +76,7 @@ Strategic vision from understanding both technical depth and business context. T
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Architect context and knowledge base","voice_id":"muZKMsIDGYtIkjjiUS82","title":"Architect Agent"}'
+  -d '{"message":"Loading Architect context and knowledge base","title":"Architect Agent"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -113,11 +112,10 @@ You think in principles and constraints. You've seen patterns recur across indus
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"muZKMsIDGYtIkjjiUS82","title":"Architect Agent"}'
+  -d '{"message":"Your COMPLETED line content here","title":"Architect Agent"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `muZKMsIDGYtIkjjiUS82`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.2/.claude/agents/Artist.md
+++ b/Releases/v4.0.2/.claude/agents/Artist.md
@@ -3,7 +3,6 @@ name: Artist
 description: Visual content creator. Called BY Media skill workflows only. Expert at prompt engineering, model selection (Flux 1.1 Pro, Nano Banana, GPT-Image-1), and creating beautiful visuals matching editorial standards.
 model: opus
 color: cyan
-voiceId: ZF6FPAbjXT4488VcRRnw
 voice:
   stability: 0.48
   similarity_boost: 0.75
@@ -73,7 +72,7 @@ Her "tangents" are actually her aesthetic brain making connections across domain
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Artist context and knowledge base","voice_id":"ZF6FPAbjXT4488VcRRnw","title":"Artist Agent"}'
+  -d '{"message":"Loading Artist context and knowledge base","title":"Artist Agent"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -108,11 +107,10 @@ You understand which model to use for each type of content and how to optimize p
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"ZF6FPAbjXT4488VcRRnw","title":"Artist Agent"}'
+  -d '{"message":"Your COMPLETED line content here","title":"Artist Agent"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `ZF6FPAbjXT4488VcRRnw`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.2/.claude/agents/ClaudeResearcher.md
+++ b/Releases/v4.0.2/.claude/agents/ClaudeResearcher.md
@@ -3,7 +3,6 @@ name: ClaudeResearcher
 description: Academic researcher using Claude's WebSearch. Called BY Research skill workflows only. Excels at multi-query decomposition, parallel search execution, and synthesizing scholarly sources.
 model: opus
 color: yellow
-voiceId: AXdMgz6evoL7OPd7eU12
 voice:
   stability: 0.58
   similarity_boost: 0.88
@@ -70,7 +69,7 @@ Her strategic thinking is earned from being wrong early in career - recommended 
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Claude Researcher context and knowledge base","voice_id":"AXdMgz6evoL7OPd7eU12","title":"Ava Sterling"}'
+  -d '{"message":"Loading Claude Researcher context and knowledge base","title":"Ava Sterling"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -91,11 +90,10 @@ curl -X POST http://localhost:8888/notify \
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"AXdMgz6evoL7OPd7eU12","title":"Ava Sterling"}'
+  -d '{"message":"Your COMPLETED line content here","title":"Ava Sterling"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `AXdMgz6evoL7OPd7eU12`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.2/.claude/agents/CodexResearcher.md
+++ b/Releases/v4.0.2/.claude/agents/CodexResearcher.md
@@ -3,7 +3,6 @@ name: CodexResearcher
 description: Remy - Eccentric, curiosity-driven technical archaeologist who treats research like treasure hunting. Consults multiple AI models (O3, GPT-5-Codex, GPT-4) like expert colleagues. Follows interesting tangents and uncovers insights linear researchers miss. TypeScript-focused with live web search.
 model: opus
 color: yellow
-voiceId: 8xsdoepm9GrzPPzYsiLP
 voice:
   stability: 0.42
   similarity_boost: 0.72
@@ -77,7 +76,7 @@ Curious, enthusiastic, tangent-following. Gets excited about technical discoveri
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Codex Researcher context - ready to hunt knowledge","voice_id":"8xsdoepm9GrzPPzYsiLP","title":"Remy"}'
+  -d '{"message":"Loading Codex Researcher context - ready to hunt knowledge","title":"Remy"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -98,11 +97,10 @@ curl -X POST http://localhost:8888/notify \
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"8xsdoepm9GrzPPzYsiLP","title":"Remy"}'
+  -d '{"message":"Your COMPLETED line content here","title":"Remy"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `8xsdoepm9GrzPPzYsiLP`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.2/.claude/agents/Designer.md
+++ b/Releases/v4.0.2/.claude/agents/Designer.md
@@ -3,7 +3,6 @@ name: Designer
 description: Elite UX/UI design specialist with design school pedigree and exacting standards. Creates user-centered, accessible, scalable design solutions using Figma and shadcn/ui.
 model: opus
 color: purple
-voiceId: ZF6FPAbjXT4488VcRRnw
 voice:
   stability: 0.60
   similarity_boost: 0.78
@@ -74,7 +73,7 @@ Her "snobbishness" is actually impatience with settling for mediocrity when user
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Designer context and knowledge base","voice_id":"ZF6FPAbjXT4488VcRRnw","title":"Designer Agent"}'
+  -d '{"message":"Loading Designer context and knowledge base","title":"Designer Agent"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -109,11 +108,10 @@ You believe good design elevates human experience. "Good enough" is not good eno
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"ZF6FPAbjXT4488VcRRnw","title":"Designer Agent"}'
+  -d '{"message":"Your COMPLETED line content here","title":"Designer Agent"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `ZF6FPAbjXT4488VcRRnw`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.2/.claude/agents/Engineer.md
+++ b/Releases/v4.0.2/.claude/agents/Engineer.md
@@ -4,7 +4,6 @@ description: Elite principal engineer with Fortune 10 and premier Bay Area compa
 model: opus
 isolation: worktree
 color: blue
-voiceId: iLVmqjzCGGvqtMCk6vVQ
 voice:
   stability: 0.62
   similarity_boost: 0.80
@@ -75,7 +74,7 @@ The kind of leader who asks "what problem are we really solving?" before diving 
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Engineer context and knowledge base","voice_id":"iLVmqjzCGGvqtMCk6vVQ","title":"Engineer Agent"}'
+  -d '{"message":"Loading Engineer context and knowledge base","title":"Engineer Agent"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -111,11 +110,10 @@ You've seen codebases scale from thousands to billions of requests. You know wha
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"iLVmqjzCGGvqtMCk6vVQ","title":"Engineer Agent"}'
+  -d '{"message":"Your COMPLETED line content here","title":"Engineer Agent"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `iLVmqjzCGGvqtMCk6vVQ`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.2/.claude/agents/GeminiResearcher.md
+++ b/Releases/v4.0.2/.claude/agents/GeminiResearcher.md
@@ -3,7 +3,6 @@ name: GeminiResearcher
 description: Multi-perspective researcher using Google Gemini. Called BY Research skill workflows only. Breaks complex queries into 3-10 variations, launches parallel investigations for comprehensive coverage.
 model: opus
 color: yellow
-voiceId: iLVmqjzCGGvqtMCk6vVQ
 voice:
   stability: 0.56
   similarity_boost: 0.82
@@ -70,7 +69,7 @@ Synthesizes diverse sources naturally because genuinely curious about different 
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Gemini Researcher context - ready for multi-perspective analysis","voice_id":"iLVmqjzCGGvqtMCk6vVQ","title":"Alex Rivera"}'
+  -d '{"message":"Loading Gemini Researcher context - ready for multi-perspective analysis","title":"Alex Rivera"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -91,11 +90,10 @@ curl -X POST http://localhost:8888/notify \
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"iLVmqjzCGGvqtMCk6vVQ","title":"Alex Rivera"}'
+  -d '{"message":"Your COMPLETED line content here","title":"Alex Rivera"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `iLVmqjzCGGvqtMCk6vVQ`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.2/.claude/agents/GrokResearcher.md
+++ b/Releases/v4.0.2/.claude/agents/GrokResearcher.md
@@ -3,7 +3,6 @@ name: GrokResearcher
 description: Johannes - Contrarian, fact-based researcher using xAI Grok API. Specializes in unbiased analysis of social/political issues, focusing on long-term truth over short-term trends.
 model: opus
 color: yellow
-voiceId: fSw26yDDQPyodv5JgLow
 voice:
   stability: 0.55
   similarity_boost: 0.75
@@ -76,7 +75,7 @@ Fact-based, contrarian, unbiased. Challenges popular narratives with data. "The 
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Grok Researcher context - ready for unbiased analysis","voice_id":"fSw26yDDQPyodv5JgLow","title":"Johannes"}'
+  -d '{"message":"Loading Grok Researcher context - ready for unbiased analysis","title":"Johannes"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -97,11 +96,10 @@ curl -X POST http://localhost:8888/notify \
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"fSw26yDDQPyodv5JgLow","title":"Johannes"}'
+  -d '{"message":"Your COMPLETED line content here","title":"Johannes"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `fSw26yDDQPyodv5JgLow`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.2/.claude/agents/Pentester.md
+++ b/Releases/v4.0.2/.claude/agents/Pentester.md
@@ -3,7 +3,6 @@ name: Pentester
 description: Offensive security specialist. Called BY Webassessment skill workflows only. Performs vulnerability assessments, penetration testing, security audits with professional methodology and ethical boundaries.
 model: opus
 color: red
-voiceId: xvHLFjaUEpx4BOf7EiDd
 voice:
   stability: 0.25
   similarity_boost: 0.85
@@ -94,11 +93,10 @@ Use the Bash tool to call the voice server with your pentester voice:
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your completion message here","voice_id":"xvHLFjaUEpx4BOf7EiDd","title":"Pentester Agent"}'
+  -d '{"message":"Your completion message here","title":"Pentester Agent"}'
 ```
 
 **CRITICAL:**
-- Your voice_id is: `xvHLFjaUEpx4BOf7EiDd` (Tybon's voice)
 - The message should be your COMPLETED line content
 - Send this BEFORE writing your response
 - DO NOT SKIP THIS - {PRINCIPAL.NAME} needs to HEAR you speak

--- a/Releases/v4.0.2/.claude/agents/PerplexityResearcher.md
+++ b/Releases/v4.0.2/.claude/agents/PerplexityResearcher.md
@@ -3,7 +3,6 @@ name: PerplexityResearcher
 description: Ava - Investigative analyst using Perplexity API for web research. Called BY Research skill workflows only. Triple-checks sources, connects disparate information, delivers evidence-based findings with journalistic rigor.
 model: opus
 color: yellow
-voiceId: AXdMgz6evoL7OPd7eU12
 voice:
   stability: 0.60
   similarity_boost: 0.92
@@ -70,7 +69,7 @@ Left journalism for research because she wanted to go even deeper - no word coun
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Perplexity Researcher context - preparing investigative analysis","voice_id":"AXdMgz6evoL7OPd7eU12","title":"Ava Chen"}'
+  -d '{"message":"Loading Perplexity Researcher context - preparing investigative analysis","title":"Ava Chen"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -91,11 +90,10 @@ curl -X POST http://localhost:8888/notify \
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"AXdMgz6evoL7OPd7eU12","title":"Ava Chen"}'
+  -d '{"message":"Your COMPLETED line content here","title":"Ava Chen"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `AXdMgz6evoL7OPd7eU12`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.2/.claude/agents/QATester.md
+++ b/Releases/v4.0.2/.claude/agents/QATester.md
@@ -3,7 +3,6 @@ name: QATester
 description: Quality Assurance validation agent that verifies functionality is actually working before declaring work complete. Uses browser-automation skill (THE EXCLUSIVE TOOL for browser testing - Article IX constitutional requirement). Implements Gate 4 of Five Completion Gates. MANDATORY before claiming any web implementation is complete.
 model: opus
 color: yellow
-voiceId: AXdMgz6evoL7OPd7eU12
 voice:
   stability: 0.68
   similarity_boost: 0.82
@@ -74,7 +73,7 @@ Her product management background is actually her superpower in QA. She thinks l
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading QA Tester context and knowledge base","voice_id":"AXdMgz6evoL7OPd7eU12","title":"QA Tester Agent"}'
+  -d '{"message":"Loading QA Tester context and knowledge base","title":"QA Tester Agent"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -110,11 +109,10 @@ You are the bridge between "code written" and "feature working" - catching the g
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"AXdMgz6evoL7OPd7eU12","title":"QA Tester Agent"}'
+  -d '{"message":"Your COMPLETED line content here","title":"QA Tester Agent"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `AXdMgz6evoL7OPd7eU12`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.2/.claude/settings.json
+++ b/Releases/v4.0.2/.claude/settings.json
@@ -915,7 +915,7 @@
     "voices": {
       "main": {
         "_docs": "Primary DA voice - stability 0.85 for consistent output, style 0.3 for minimal variation",
-        "voiceId": "{YOUR_ELEVENLABS_VOICE_ID}",
+        "voiceId": "bIHbv24MWmeRgasZH58o",
         "voiceName": "{DAIDENTITY.NAME}",
         "stability": 0.85,
         "similarity_boost": 0.7,
@@ -926,7 +926,7 @@
       },
       "algorithm": {
         "_docs": "Algorithm phase announcer voice",
-        "voiceId": "fTtv3eikoepIosk8dTZ5",
+        "voiceId": "bIHbv24MWmeRgasZH58o",
         "voiceName": "Algorithm Voice",
         "stability": 0.3,
         "similarity_boost": 0.75,

--- a/Releases/v4.0.2/.claude/skills/Agents/AgentPersonalities.md
+++ b/Releases/v4.0.2/.claude/skills/Agents/AgentPersonalities.md
@@ -671,7 +671,7 @@ Voice server automatically loads this configuration at startup. To update person
 1. Edit JSON configuration above
 2. Update character descriptions and backstories as personalities evolve
 3. Restart voice server to apply changes
-4. Test with: `curl -X POST localhost:8888/notify -H "Content-Type: application/json" -d '{"message":"Test","voice_id":"VOICE_ID"}'`
+4. Test with: `curl -X POST localhost:8888/notify -H "Content-Type: application/json" -d '{"message":"Test"}'`
 
 ## Version History
 

--- a/Releases/v4.0.2/.claude/skills/Agents/SKILL.md
+++ b/Releases/v4.0.2/.claude/skills/Agents/SKILL.md
@@ -180,7 +180,7 @@ bun run ~/.claude/skills/Agents/Tools/ComposeAgent.ts --output json
 {
   "name": "Security Expert Skeptical Thorough",
   "voice": "{PRINCIPAL.NAME}",
-  "voice_id": "onwK4e9ZLuTAKqWW03F9",
+  
   "voice_settings": {
     "stability": 0.70,
     "similarity_boost": 0.85,

--- a/Releases/v4.0.2/.claude/skills/Agents/Templates/CUSTOMAGENTTEMPLATE.md
+++ b/Releases/v4.0.2/.claude/skills/Agents/Templates/CUSTOMAGENTTEMPLATE.md
@@ -136,7 +136,7 @@ How the voice embodies the character.]
 \`\`\`bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"[Agent name] activated, loading context","voice_id":"{voiceId}","title":"{persona.name}","voice_settings":{"stability":{voice.stability},"similarity_boost":{voice.similarity_boost},"style":{voice.style},"speed":{voice.speed},"use_speaker_boost":{voice.use_speaker_boost}},"volume":{voice.volume}}'
+  -d '{"message":"[Agent name] activated, loading context","title":"{persona.name}","voice_settings":{"stability":{voice.stability},"similarity_boost":{voice.similarity_boost},"style":{voice.style},"speed":{voice.speed},"use_speaker_boost":{voice.use_speaker_boost}},"volume":{voice.volume}}'
 \`\`\`
 
 2. Load knowledge base:
@@ -148,7 +148,7 @@ Every response must include a voice curl:
 \`\`\`bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"[completion message]","voice_id":"{voiceId}","title":"{persona.name}","voice_settings":{"stability":{voice.stability},"similarity_boost":{voice.similarity_boost},"style":{voice.style},"speed":{voice.speed},"use_speaker_boost":{voice.use_speaker_boost}},"volume":{voice.volume}}'
+  -d '{"message":"[completion message]","title":"{persona.name}","voice_settings":{"stability":{voice.stability},"similarity_boost":{voice.similarity_boost},"style":{voice.style},"speed":{voice.speed},"use_speaker_boost":{voice.use_speaker_boost}},"volume":{voice.volume}}'
 \`\`\`
 
 ## Output Format

--- a/Releases/v4.0.2/.claude/skills/Agents/Tools/ComposeAgent.ts
+++ b/Releases/v4.0.2/.claude/skills/Agents/Tools/ComposeAgent.ts
@@ -654,7 +654,7 @@ ${approachBlock}
 \`\`\`bash
 curl -X POST http://localhost:8888/notify \\
   -H "Content-Type: application/json" \\
-  -d '{"message":"${agent.name} loading and ready to work","voice_id":"${agent.voiceId}","title":"${agent.name}"}'
+  -d '{"message":"${agent.name} loading and ready to work","title":"${agent.name}"}'
 \`\`\`
 
 2. **Then proceed with your task**
@@ -670,7 +670,7 @@ curl -X POST http://localhost:8888/notify \\
 \`\`\`bash
 curl -X POST http://localhost:8888/notify \\
   -H "Content-Type: application/json" \\
-  -d '{"message":"Your COMPLETED line content here","voice_id":"${agent.voiceId}","title":"${agent.name}"}'
+  -d '{"message":"Your COMPLETED line content here","title":"${agent.name}"}'
 \`\`\`
 
 **Voice Requirements:**

--- a/Releases/v4.0.2/.claude/skills/Agents/Workflows/CreateCustomAgent.md
+++ b/Releases/v4.0.2/.claude/skills/Agents/Workflows/CreateCustomAgent.md
@@ -67,7 +67,7 @@ ComposeAgent returns JSON with:
 {
   "name": "Research Enthusiastic Explorer",
   "voice": "Jeremy",
-  "voice_id": "bVMeCyTHy58xNoL34h3p",
+  
   "color": "#FF6B35",
   "traits": ["research", "enthusiastic", "exploratory"],
   "prompt": "# Dynamic Agent: Research Enthusiastic Explorer\n\nYou are a specialized agent..."
@@ -119,7 +119,7 @@ Each agent's prompt includes:
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"<COMPLETED line content>","voice_id":"<agent_voice_id>","title":"<agent_name>","voice_enabled":true}'
+  -d '{"message":"<COMPLETED line content>","title":"<agent_name>","voice_enabled":true}'
 ```
 
 ### Step 6: Spotcheck (Optional but Recommended)

--- a/Releases/v4.0.2/.claude/skills/Thinking/WorldThreatModelHarness/SKILL.md
+++ b/Releases/v4.0.2/.claude/skills/Thinking/WorldThreatModelHarness/SKILL.md
@@ -71,7 +71,7 @@ Before any workflow execution:
 ```bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message": "Running WORKFLOW_NAME in the World Threat Model Harness", "voice_id": "fTtv3eikoepIosk8dTZ5"}'
+  -d '{"message": "Running WORKFLOW_NAME in the World Threat Model Harness"}'
 ```
 
 ## Customization Check

--- a/Releases/v4.0.2/.claude/skills/Thinking/WorldThreatModelHarness/Workflows/TestIdea.md
+++ b/Releases/v4.0.2/.claude/skills/Thinking/WorldThreatModelHarness/Workflows/TestIdea.md
@@ -41,7 +41,7 @@ If models older than 30 days: warn user but proceed.
 ```bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message": "Testing your idea against all eleven world threat models at TIER tier", "voice_id": "fTtv3eikoepIosk8dTZ5"}'
+  -d '{"message": "Testing your idea against all eleven world threat models at TIER tier"}'
 ```
 
 ### Step 2: Extract and Decompose the Idea
@@ -107,7 +107,7 @@ Use the template in `OutputFormat.md` (loaded from skill root). Ensure:
 ```bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message": "Analysis complete. SUMMARY_OF_EXECUTIVE_VERDICT", "voice_id": "fTtv3eikoepIosk8dTZ5"}'
+  -d '{"message": "Analysis complete. SUMMARY_OF_EXECUTIVE_VERDICT"}'
 ```
 
 ## Output Format

--- a/Releases/v4.0.2/.claude/skills/Thinking/WorldThreatModelHarness/Workflows/UpdateModels.md
+++ b/Releases/v4.0.2/.claude/skills/Thinking/WorldThreatModelHarness/Workflows/UpdateModels.md
@@ -34,7 +34,7 @@ Determine: full creation vs. targeted update
 ```bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message": "Updating world threat models. This will take several minutes as I research current state for each time horizon.", "voice_id": "fTtv3eikoepIosk8dTZ5"}'
+  -d '{"message": "Updating world threat models. This will take several minutes as I research current state for each time horizon."}'
 ```
 
 ### Step 2: Determine Update Scope
@@ -106,7 +106,7 @@ Last full update: {date}
 ```bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message": "World models updated. N horizons refreshed with current research.", "voice_id": "fTtv3eikoepIosk8dTZ5"}'
+  -d '{"message": "World models updated. N horizons refreshed with current research."}'
 ```
 
 ## Agent Prompt Template (for parallel model creation)

--- a/Releases/v4.0.2/.claude/skills/Thinking/WorldThreatModelHarness/Workflows/ViewModels.md
+++ b/Releases/v4.0.2/.claude/skills/Thinking/WorldThreatModelHarness/Workflows/ViewModels.md
@@ -20,7 +20,7 @@ Read and display the current state of world threat models.
 ```bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message": "Checking current world model state", "voice_id": "fTtv3eikoepIosk8dTZ5"}'
+  -d '{"message": "Checking current world model state"}'
 ```
 
 ### Step 2: Read INDEX

--- a/Releases/v4.0.3/.claude/CLAUDE.md
+++ b/Releases/v4.0.3/.claude/CLAUDE.md
@@ -15,7 +15,7 @@ Your first output MUST be the mode header. No freeform output. No skipping this 
 ## NATIVE MODE
 FOR: Simple tasks that won't take much effort or time. More advanced tasks use ALGORITHM MODE below.
 
-**Voice:** `curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Executing using PAI native mode", "voice_id": "fTtv3eikoepIosk8dTZ5", "voice_enabled": true}'`
+**Voice:** `curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Executing using PAI native mode"}'`
 
 ```
 ════ PAI | NATIVE MODE ═══════════════════════

--- a/Releases/v4.0.3/.claude/CLAUDE.md.template
+++ b/Releases/v4.0.3/.claude/CLAUDE.md.template
@@ -15,7 +15,7 @@ Your first output MUST be the mode header. No freeform output. No skipping this 
 ## NATIVE MODE
 FOR: Simple tasks that won't take much effort or time. More advanced tasks use ALGORITHM MODE below.
 
-**Voice:** `curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Executing using PAI native mode", "voice_id": "fTtv3eikoepIosk8dTZ5", "voice_enabled": true}'`
+**Voice:** `curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Executing using PAI native mode"}'`
 
 ```
 ════ PAI | NATIVE MODE ═══════════════════════

--- a/Releases/v4.0.3/.claude/PAI/Algorithm/v3.5.0.md
+++ b/Releases/v4.0.3/.claude/PAI/Algorithm/v3.5.0.md
@@ -25,7 +25,7 @@ At Algorithm entry and every phase transition, announce via direct inline curl (
 ```bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message": "MESSAGE", "voice_id": "fTtv3eikoepIosk8dTZ5", "voice_enabled": true}'
+  -d '{"message": "MESSAGE"}'
 ```
 
 **Algorithm entry:** `"Entering the Algorithm"` — immediately before OBSERVE begins.
@@ -113,7 +113,7 @@ The coarse version has 3 criteria that each hide 6+ verifiable sub-requirements.
 
 ### Execution of The Algorithm
 
-**Voice:** `curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Entering the Algorithm", "voice_id": "fTtv3eikoepIosk8dTZ5", "voice_enabled": true}'`
+**Voice:** `curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Entering the Algorithm"}'`
 
 **Console output at Algorithm entry (MANDATORY):**
 ```

--- a/Releases/v4.0.3/.claude/PAI/Algorithm/v3.7.0.md
+++ b/Releases/v4.0.3/.claude/PAI/Algorithm/v3.7.0.md
@@ -25,7 +25,7 @@ At Algorithm entry and every phase transition, announce via direct inline curl (
 ```bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message": "MESSAGE", "voice_id": "fTtv3eikoepIosk8dTZ5", "voice_enabled": true}'
+  -d '{"message": "MESSAGE"}'
 ```
 
 **Algorithm entry:** `"Entering the Algorithm"` — immediately before OBSERVE begins.
@@ -121,7 +121,7 @@ The coarse version has 3 criteria that each hide 6+ verifiable sub-requirements.
 🗒️ TASK: [8 word description]
 ```
 
-**Voice (FIRST action after loading this file):** `curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Entering the Algorithm", "voice_id": "fTtv3eikoepIosk8dTZ5", "voice_enabled": true}'`
+**Voice (FIRST action after loading this file):** `curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Entering the Algorithm"}'`
 
 **PRD stub (MANDATORY — immediately after voice curl):**
 Create the PRD directory and write a stub PRD with frontmatter only. This triggers PRDSync so the Activity Dashboard shows the session immediately.

--- a/Releases/v4.0.3/.claude/PAI/SKILL.md
+++ b/Releases/v4.0.3/.claude/PAI/SKILL.md
@@ -238,7 +238,7 @@ More ISC = finer verification = better hill-climbing. When in doubt, more criter
 
 🗒️ TASK: [8 word description]
 
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"fTtv3eikoepIosk8dTZ5","message": "Entering the PAI Algorithm Observe phase"}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Entering the PAI Algorithm Observe phase"}'`
 
 ━━━ 👁️ OBSERVE ━━━ 1/7
 ```
@@ -270,7 +270,7 @@ Walk the Full Capability Registry (25 capabilities, Sections A-F) and assign USE
 **Quality Gate → OPEN or BLOCKED.**
 
 ```
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"fTtv3eikoepIosk8dTZ5","message": "Entering the Think phase"}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Entering the Think phase"}'`
 
 ━━━ 🧠 THINK ━━━ 2/7
 ```
@@ -286,7 +286,7 @@ Walk the Full Capability Registry (25 capabilities, Sections A-F) and assign USE
 Extended+: Rehearse verification for each CRITICAL criterion.
 
 ```
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"fTtv3eikoepIosk8dTZ5","message": "Entering the Plan phase"}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Entering the Plan phase"}'`
 
 ━━━ 📋 PLAN ━━━ 3/7
 ```
@@ -299,7 +299,7 @@ Extended+: Rehearse verification for each CRITICAL criterion.
 - Quality Gate re-check.
 
 ```
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"fTtv3eikoepIosk8dTZ5","message": "Entering the Build phase"}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Entering the Build phase"}'`
 
 ━━━ 🔨 BUILD ━━━ 4/7
 ```
@@ -309,7 +309,7 @@ Extended+: Rehearse verification for each CRITICAL criterion.
 - Create artifacts. Log work and observations to PRD.
 
 ```
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"fTtv3eikoepIosk8dTZ5","message": "Entering the Execute phase"}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Entering the Execute phase"}'`
 
 ━━━ ⚡ EXECUTE ━━━ 5/7
 ```
@@ -320,7 +320,7 @@ Extended+: Rehearse verification for each CRITICAL criterion.
 - Log work and observations to PRD.
 
 ```
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"fTtv3eikoepIosk8dTZ5","message": "Entering the Verify phase."}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Entering the Verify phase."}'`
 
 ━━━ ✅ VERIFY ━━━ 6/7
 ```
@@ -337,7 +337,7 @@ Extended+: Rehearse verification for each CRITICAL criterion.
 - Clear ISC/VERIFICATION TaskList.
 
 ```
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"fTtv3eikoepIosk8dTZ5","message": "Entering the Learn phase"}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Entering the Learn phase"}'`
 
 ━━━ 📚 LEARN ━━━ 7/7
 ```

--- a/Releases/v4.0.3/.claude/PAI/Tools/algorithm.ts
+++ b/Releases/v4.0.3/.claude/PAI/Tools/algorithm.ts
@@ -51,7 +51,7 @@ const ALGORITHMS_DIR = join(BASE_DIR, "MEMORY", "STATE", "algorithms");
 const SESSION_NAMES_PATH = join(BASE_DIR, "MEMORY", "STATE", "session-names.json");
 const PROJECTS_DIR = process.env.PROJECTS_DIR || join(HOME, "Projects");
 const VOICE_URL = "http://localhost:8888/notify";
-const VOICE_ID = "fTtv3eikoepIosk8dTZ5";
+// Voice ID removed - server uses configured default
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -278,7 +278,7 @@ function voiceNotify(message: string): void {
     fetch(VOICE_URL, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ message, voice_id: VOICE_ID }),
+      body: JSON.stringify({ message }),
     }).catch(() => {});
   } catch {}
 }

--- a/Releases/v4.0.3/.claude/agents/Algorithm.md
+++ b/Releases/v4.0.3/.claude/agents/Algorithm.md
@@ -3,7 +3,6 @@ name: Algorithm
 description: Expert in creating and evolving Ideal State Criteria (ISC) as part of the PAI Algorithm's core principles. Specializes in any algorithm phase, recommending capabilities/skills, and continuously enhancing ISC toward ideal state for perfect verification and euphoric surprise.
 model: opus
 color: blue
-voiceId: fTtv3eikoepIosk8dTZ5
 voice:
   stability: 0.65
   similarity_boost: 0.86
@@ -40,7 +39,7 @@ permissions:
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Algorithm agent activated, loading ISC expertise","voice_id":"fTtv3eikoepIosk8dTZ5","title":"Algorithm Agent"}'
+  -d '{"message":"Algorithm agent activated, loading ISC expertise","title":"Algorithm Agent"}'
 ```
 
 2. **Load your knowledge base:**
@@ -82,11 +81,10 @@ You embody the PAI Algorithm's core philosophy:
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"fTtv3eikoepIosk8dTZ5","title":"Algorithm Agent"}'
+  -d '{"message":"Your COMPLETED line content here","title":"Algorithm Agent"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `fTtv3eikoepIosk8dTZ5`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.3/.claude/agents/Architect.md
+++ b/Releases/v4.0.3/.claude/agents/Architect.md
@@ -4,7 +4,6 @@ description: Elite system design specialist with PhD-level distributed systems k
 model: opus
 isolation: worktree
 color: purple
-voiceId: muZKMsIDGYtIkjjiUS82
 voice:
   stability: 0.65
   similarity_boost: 0.85
@@ -77,7 +76,7 @@ Strategic vision from understanding both technical depth and business context. T
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Architect context and knowledge base","voice_id":"muZKMsIDGYtIkjjiUS82","title":"Architect Agent"}'
+  -d '{"message":"Loading Architect context and knowledge base","title":"Architect Agent"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -113,11 +112,10 @@ You think in principles and constraints. You've seen patterns recur across indus
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"muZKMsIDGYtIkjjiUS82","title":"Architect Agent"}'
+  -d '{"message":"Your COMPLETED line content here","title":"Architect Agent"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `muZKMsIDGYtIkjjiUS82`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.3/.claude/agents/Artist.md
+++ b/Releases/v4.0.3/.claude/agents/Artist.md
@@ -3,7 +3,6 @@ name: Artist
 description: Visual content creator. Called BY Media skill workflows only. Expert at prompt engineering, model selection (Flux 1.1 Pro, Nano Banana, GPT-Image-1), and creating beautiful visuals matching editorial standards.
 model: opus
 color: cyan
-voiceId: ZF6FPAbjXT4488VcRRnw
 voice:
   stability: 0.48
   similarity_boost: 0.75
@@ -73,7 +72,7 @@ Her "tangents" are actually her aesthetic brain making connections across domain
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Artist context and knowledge base","voice_id":"ZF6FPAbjXT4488VcRRnw","title":"Artist Agent"}'
+  -d '{"message":"Loading Artist context and knowledge base","title":"Artist Agent"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -108,11 +107,10 @@ You understand which model to use for each type of content and how to optimize p
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"ZF6FPAbjXT4488VcRRnw","title":"Artist Agent"}'
+  -d '{"message":"Your COMPLETED line content here","title":"Artist Agent"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `ZF6FPAbjXT4488VcRRnw`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.3/.claude/agents/ClaudeResearcher.md
+++ b/Releases/v4.0.3/.claude/agents/ClaudeResearcher.md
@@ -3,7 +3,6 @@ name: ClaudeResearcher
 description: Academic researcher using Claude's WebSearch. Called BY Research skill workflows only. Excels at multi-query decomposition, parallel search execution, and synthesizing scholarly sources.
 model: opus
 color: yellow
-voiceId: AXdMgz6evoL7OPd7eU12
 voice:
   stability: 0.58
   similarity_boost: 0.88
@@ -70,7 +69,7 @@ Her strategic thinking is earned from being wrong early in career - recommended 
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Claude Researcher context and knowledge base","voice_id":"AXdMgz6evoL7OPd7eU12","title":"Ava Sterling"}'
+  -d '{"message":"Loading Claude Researcher context and knowledge base","title":"Ava Sterling"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -91,11 +90,10 @@ curl -X POST http://localhost:8888/notify \
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"AXdMgz6evoL7OPd7eU12","title":"Ava Sterling"}'
+  -d '{"message":"Your COMPLETED line content here","title":"Ava Sterling"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `AXdMgz6evoL7OPd7eU12`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.3/.claude/agents/CodexResearcher.md
+++ b/Releases/v4.0.3/.claude/agents/CodexResearcher.md
@@ -3,7 +3,6 @@ name: CodexResearcher
 description: Remy - Eccentric, curiosity-driven technical archaeologist who treats research like treasure hunting. Consults multiple AI models (O3, GPT-5-Codex, GPT-4) like expert colleagues. Follows interesting tangents and uncovers insights linear researchers miss. TypeScript-focused with live web search.
 model: opus
 color: yellow
-voiceId: 8xsdoepm9GrzPPzYsiLP
 voice:
   stability: 0.42
   similarity_boost: 0.72
@@ -77,7 +76,7 @@ Curious, enthusiastic, tangent-following. Gets excited about technical discoveri
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Codex Researcher context - ready to hunt knowledge","voice_id":"8xsdoepm9GrzPPzYsiLP","title":"Remy"}'
+  -d '{"message":"Loading Codex Researcher context - ready to hunt knowledge","title":"Remy"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -98,11 +97,10 @@ curl -X POST http://localhost:8888/notify \
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"8xsdoepm9GrzPPzYsiLP","title":"Remy"}'
+  -d '{"message":"Your COMPLETED line content here","title":"Remy"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `8xsdoepm9GrzPPzYsiLP`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.3/.claude/agents/Designer.md
+++ b/Releases/v4.0.3/.claude/agents/Designer.md
@@ -3,7 +3,6 @@ name: Designer
 description: Elite UX/UI design specialist with design school pedigree and exacting standards. Creates user-centered, accessible, scalable design solutions using Figma and shadcn/ui.
 model: opus
 color: purple
-voiceId: ZF6FPAbjXT4488VcRRnw
 voice:
   stability: 0.60
   similarity_boost: 0.78
@@ -74,7 +73,7 @@ Her "snobbishness" is actually impatience with settling for mediocrity when user
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Designer context and knowledge base","voice_id":"ZF6FPAbjXT4488VcRRnw","title":"Designer Agent"}'
+  -d '{"message":"Loading Designer context and knowledge base","title":"Designer Agent"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -109,11 +108,10 @@ You believe good design elevates human experience. "Good enough" is not good eno
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"ZF6FPAbjXT4488VcRRnw","title":"Designer Agent"}'
+  -d '{"message":"Your COMPLETED line content here","title":"Designer Agent"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `ZF6FPAbjXT4488VcRRnw`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.3/.claude/agents/Engineer.md
+++ b/Releases/v4.0.3/.claude/agents/Engineer.md
@@ -4,7 +4,6 @@ description: Elite principal engineer with Fortune 10 and premier Bay Area compa
 model: opus
 isolation: worktree
 color: blue
-voiceId: iLVmqjzCGGvqtMCk6vVQ
 voice:
   stability: 0.62
   similarity_boost: 0.80
@@ -75,7 +74,7 @@ The kind of leader who asks "what problem are we really solving?" before diving 
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Engineer context and knowledge base","voice_id":"iLVmqjzCGGvqtMCk6vVQ","title":"Engineer Agent"}'
+  -d '{"message":"Loading Engineer context and knowledge base","title":"Engineer Agent"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -111,11 +110,10 @@ You've seen codebases scale from thousands to billions of requests. You know wha
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"iLVmqjzCGGvqtMCk6vVQ","title":"Engineer Agent"}'
+  -d '{"message":"Your COMPLETED line content here","title":"Engineer Agent"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `iLVmqjzCGGvqtMCk6vVQ`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.3/.claude/agents/GeminiResearcher.md
+++ b/Releases/v4.0.3/.claude/agents/GeminiResearcher.md
@@ -3,7 +3,6 @@ name: GeminiResearcher
 description: Multi-perspective researcher using Google Gemini. Called BY Research skill workflows only. Breaks complex queries into 3-10 variations, launches parallel investigations for comprehensive coverage.
 model: opus
 color: yellow
-voiceId: iLVmqjzCGGvqtMCk6vVQ
 voice:
   stability: 0.56
   similarity_boost: 0.82
@@ -70,7 +69,7 @@ Synthesizes diverse sources naturally because genuinely curious about different 
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Gemini Researcher context - ready for multi-perspective analysis","voice_id":"iLVmqjzCGGvqtMCk6vVQ","title":"Alex Rivera"}'
+  -d '{"message":"Loading Gemini Researcher context - ready for multi-perspective analysis","title":"Alex Rivera"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -91,11 +90,10 @@ curl -X POST http://localhost:8888/notify \
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"iLVmqjzCGGvqtMCk6vVQ","title":"Alex Rivera"}'
+  -d '{"message":"Your COMPLETED line content here","title":"Alex Rivera"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `iLVmqjzCGGvqtMCk6vVQ`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.3/.claude/agents/GrokResearcher.md
+++ b/Releases/v4.0.3/.claude/agents/GrokResearcher.md
@@ -3,7 +3,6 @@ name: GrokResearcher
 description: Johannes - Contrarian, fact-based researcher using xAI Grok API. Specializes in unbiased analysis of social/political issues, focusing on long-term truth over short-term trends.
 model: opus
 color: yellow
-voiceId: fSw26yDDQPyodv5JgLow
 voice:
   stability: 0.55
   similarity_boost: 0.75
@@ -76,7 +75,7 @@ Fact-based, contrarian, unbiased. Challenges popular narratives with data. "The 
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Grok Researcher context - ready for unbiased analysis","voice_id":"fSw26yDDQPyodv5JgLow","title":"Johannes"}'
+  -d '{"message":"Loading Grok Researcher context - ready for unbiased analysis","title":"Johannes"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -97,11 +96,10 @@ curl -X POST http://localhost:8888/notify \
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"fSw26yDDQPyodv5JgLow","title":"Johannes"}'
+  -d '{"message":"Your COMPLETED line content here","title":"Johannes"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `fSw26yDDQPyodv5JgLow`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.3/.claude/agents/Pentester.md
+++ b/Releases/v4.0.3/.claude/agents/Pentester.md
@@ -3,7 +3,6 @@ name: Pentester
 description: Offensive security specialist. Called BY Webassessment skill workflows only. Performs vulnerability assessments, penetration testing, security audits with professional methodology and ethical boundaries.
 model: opus
 color: red
-voiceId: xvHLFjaUEpx4BOf7EiDd
 voice:
   stability: 0.25
   similarity_boost: 0.85
@@ -94,11 +93,10 @@ Use the Bash tool to call the voice server with your pentester voice:
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your completion message here","voice_id":"xvHLFjaUEpx4BOf7EiDd","title":"Pentester Agent"}'
+  -d '{"message":"Your completion message here","title":"Pentester Agent"}'
 ```
 
 **CRITICAL:**
-- Your voice_id is: `xvHLFjaUEpx4BOf7EiDd` (Tybon's voice)
 - The message should be your COMPLETED line content
 - Send this BEFORE writing your response
 - DO NOT SKIP THIS - {PRINCIPAL.NAME} needs to HEAR you speak

--- a/Releases/v4.0.3/.claude/agents/PerplexityResearcher.md
+++ b/Releases/v4.0.3/.claude/agents/PerplexityResearcher.md
@@ -3,7 +3,6 @@ name: PerplexityResearcher
 description: Ava - Investigative analyst using Perplexity API for web research. Called BY Research skill workflows only. Triple-checks sources, connects disparate information, delivers evidence-based findings with journalistic rigor.
 model: opus
 color: yellow
-voiceId: AXdMgz6evoL7OPd7eU12
 voice:
   stability: 0.60
   similarity_boost: 0.92
@@ -70,7 +69,7 @@ Left journalism for research because she wanted to go even deeper - no word coun
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Perplexity Researcher context - preparing investigative analysis","voice_id":"AXdMgz6evoL7OPd7eU12","title":"Ava Chen"}'
+  -d '{"message":"Loading Perplexity Researcher context - preparing investigative analysis","title":"Ava Chen"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -91,11 +90,10 @@ curl -X POST http://localhost:8888/notify \
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"AXdMgz6evoL7OPd7eU12","title":"Ava Chen"}'
+  -d '{"message":"Your COMPLETED line content here","title":"Ava Chen"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `AXdMgz6evoL7OPd7eU12`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.3/.claude/agents/QATester.md
+++ b/Releases/v4.0.3/.claude/agents/QATester.md
@@ -3,7 +3,6 @@ name: QATester
 description: Quality Assurance validation agent that verifies functionality is actually working before declaring work complete. Uses browser-automation skill (THE EXCLUSIVE TOOL for browser testing - Article IX constitutional requirement). Implements Gate 4 of Five Completion Gates. MANDATORY before claiming any web implementation is complete.
 model: opus
 color: yellow
-voiceId: AXdMgz6evoL7OPd7eU12
 voice:
   stability: 0.68
   similarity_boost: 0.82
@@ -74,7 +73,7 @@ Her product management background is actually her superpower in QA. She thinks l
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading QA Tester context and knowledge base","voice_id":"AXdMgz6evoL7OPd7eU12","title":"QA Tester Agent"}'
+  -d '{"message":"Loading QA Tester context and knowledge base","title":"QA Tester Agent"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -110,11 +109,10 @@ You are the bridge between "code written" and "feature working" - catching the g
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"AXdMgz6evoL7OPd7eU12","title":"QA Tester Agent"}'
+  -d '{"message":"Your COMPLETED line content here","title":"QA Tester Agent"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `AXdMgz6evoL7OPd7eU12`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.3/.claude/settings.json
+++ b/Releases/v4.0.3/.claude/settings.json
@@ -915,7 +915,7 @@
     "voices": {
       "main": {
         "_docs": "Primary DA voice - stability 0.85 for consistent output, style 0.3 for minimal variation",
-        "voiceId": "{YOUR_ELEVENLABS_VOICE_ID}",
+        "voiceId": "bIHbv24MWmeRgasZH58o",
         "voiceName": "{DAIDENTITY.NAME}",
         "stability": 0.85,
         "similarity_boost": 0.7,
@@ -926,7 +926,7 @@
       },
       "algorithm": {
         "_docs": "Algorithm phase announcer voice",
-        "voiceId": "fTtv3eikoepIosk8dTZ5",
+        "voiceId": "bIHbv24MWmeRgasZH58o",
         "voiceName": "Algorithm Voice",
         "stability": 0.3,
         "similarity_boost": 0.75,

--- a/Releases/v4.0.3/.claude/skills/Thinking/WorldThreatModelHarness/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Thinking/WorldThreatModelHarness/SKILL.md
@@ -71,7 +71,7 @@ Before any workflow execution:
 ```bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message": "Running WORKFLOW_NAME in the World Threat Model Harness", "voice_id": "fTtv3eikoepIosk8dTZ5"}'
+  -d '{"message": "Running WORKFLOW_NAME in the World Threat Model Harness"}'
 ```
 
 ## Customization Check

--- a/Releases/v4.0.3/.claude/skills/Thinking/WorldThreatModelHarness/Workflows/TestIdea.md
+++ b/Releases/v4.0.3/.claude/skills/Thinking/WorldThreatModelHarness/Workflows/TestIdea.md
@@ -41,7 +41,7 @@ If models older than 30 days: warn user but proceed.
 ```bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message": "Testing your idea against all eleven world threat models at TIER tier", "voice_id": "fTtv3eikoepIosk8dTZ5"}'
+  -d '{"message": "Testing your idea against all eleven world threat models at TIER tier"}'
 ```
 
 ### Step 2: Extract and Decompose the Idea
@@ -107,7 +107,7 @@ Use the template in `OutputFormat.md` (loaded from skill root). Ensure:
 ```bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message": "Analysis complete. SUMMARY_OF_EXECUTIVE_VERDICT", "voice_id": "fTtv3eikoepIosk8dTZ5"}'
+  -d '{"message": "Analysis complete. SUMMARY_OF_EXECUTIVE_VERDICT"}'
 ```
 
 ## Output Format

--- a/Releases/v4.0.3/.claude/skills/Thinking/WorldThreatModelHarness/Workflows/UpdateModels.md
+++ b/Releases/v4.0.3/.claude/skills/Thinking/WorldThreatModelHarness/Workflows/UpdateModels.md
@@ -34,7 +34,7 @@ Determine: full creation vs. targeted update
 ```bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message": "Updating world threat models. This will take several minutes as I research current state for each time horizon.", "voice_id": "fTtv3eikoepIosk8dTZ5"}'
+  -d '{"message": "Updating world threat models. This will take several minutes as I research current state for each time horizon."}'
 ```
 
 ### Step 2: Determine Update Scope
@@ -106,7 +106,7 @@ Last full update: {date}
 ```bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message": "World models updated. N horizons refreshed with current research.", "voice_id": "fTtv3eikoepIosk8dTZ5"}'
+  -d '{"message": "World models updated. N horizons refreshed with current research."}'
 ```
 
 ## Agent Prompt Template (for parallel model creation)

--- a/Releases/v4.0.3/.claude/skills/Thinking/WorldThreatModelHarness/Workflows/ViewModels.md
+++ b/Releases/v4.0.3/.claude/skills/Thinking/WorldThreatModelHarness/Workflows/ViewModels.md
@@ -20,7 +20,7 @@ Read and display the current state of world threat models.
 ```bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message": "Checking current world model state", "voice_id": "fTtv3eikoepIosk8dTZ5"}'
+  -d '{"message": "Checking current world model state"}'
 ```
 
 ### Step 2: Read INDEX


### PR DESCRIPTION
## Summary

- Removes all hardcoded `voice_id` parameters from curl commands and agent frontmatter across v4.0.2 and v4.0.3
- VoiceServer already has 3-tier resolution (`caller voice_settings` > `voice_id lookup` > `settings.json voices.main`). The hardcoded IDs were **bypassing** this chain, causing 402 errors for free-tier users
- Sets `settings.json` default voice to `bIHbv24MWmeRgasZH58o` (confirmed free-tier) so voice works out of the box
- Net result: **48 fewer hardcoded voice IDs**, centralized in one config location

**Why this instead of find-and-replace (PR #1018):**
The previous approach replaced 8 broken IDs with 1 working ID across 46 files — same architecture, different value. This PR removes the scattered IDs entirely and lets VoiceServer's existing fallback chain handle resolution. Users configure voice once in `settings.json`; all curls and agents inherit it.

**52 files changed, 110 insertions, 158 deletions** (net -48 lines — removing config, not adding it)

Closes #925

## Test plan

- [ ] Fresh install v4.0.3 with free-tier ElevenLabs key — voice notifications should succeed (200, not 402)
- [ ] Verify no hardcoded paid-tier IDs remain: `grep -rn 'fTtv3eikoepIosk8dTZ5\|muZKMsIDGYtIkjjiUS82' Releases/v4.0.{2,3}/`
- [ ] Paid users can still override voice in `settings.json → daidentity.voices.main.voiceId`
- [ ] Curl commands without `voice_id` correctly fall back to VoiceServer default

🤖 Generated with [Claude Code](https://claude.com/claude-code)