### PR TITLE
fix(telos): rename LESSONS.md to LEARNED.md and fix Update.md script path

### DIFF
--- a/Packs/Telos/src/Tools/UpdateTelos.ts
+++ b/Packs/Telos/src/Tools/UpdateTelos.ts
@@ -19,7 +19,7 @@
  * - CHALLENGES.md - Current challenges
  * - FRAMES.md - Mental frames and perspectives
  * - GOALS.md - Life goals
- * - LESSONS.md - Lessons learned
+ * - LEARNED.md - Lessons learned
  * - MISSION.md - Life mission
  * - MODELS.md - Mental models
  * - MOVIES.md - Favorite movies
@@ -45,7 +45,7 @@ const UPDATES_FILE = join(TELOS_DIR, 'updates.md');
 // Valid TELOS files
 const VALID_FILES = [
   'BELIEFS.md', 'BOOKS.md', 'CHALLENGES.md', 'FRAMES.md', 'GOALS.md',
-  'LESSONS.md', 'MISSION.md', 'MODELS.md', 'MOVIES.md', 'NARRATIVES.md',
+  'LEARNED.md', 'MISSION.md', 'MODELS.md', 'MOVIES.md', 'NARRATIVES.md',
   'PREDICTIONS.md', 'PROBLEMS.md', 'PROJECTS.md', 'STRATEGIES.md',
   'TELOS.md', 'TRAUMAS.md', 'WISDOM.md', 'WRONG.md'
 ];

--- a/Packs/Telos/src/Workflows/Update.md
+++ b/Packs/Telos/src/Workflows/Update.md
@@ -22,7 +22,7 @@ TELOS is {PRINCIPAL.NAME}'s life framework stored in `~/.claude/PAI/USER/TELOS/`
 **Life Data:**
 - BOOKS.md - Favorite books
 - MOVIES.md - Favorite movies
-- LESSONS.md - Lessons learned
+- LEARNED.md - Lessons learned
 - WRONG.md - Things {PRINCIPAL.NAME} was wrong about
 
 **Mental Models:**
@@ -78,7 +78,7 @@ This is the main command you'll use. It takes three parameters:
 - Content to add (the actual text)
 - Description of the change (for the changelog)
 
-!`FILE="$1"; CONTENT="$2"; DESCRIPTION="$3"; bun ~/.claude/commands/update-telos.ts "$FILE" "$CONTENT" "$DESCRIPTION"`
+!`FILE="$1"; CONTENT="$2"; DESCRIPTION="$3"; bun ~/.claude/skills/Telos/Tools/UpdateTelos.ts "$FILE" "$CONTENT" "$DESCRIPTION"`
 
 ## List Valid TELOS Files
 !`echo "Valid TELOS files:
@@ -87,7 +87,7 @@ This is the main command you'll use. It takes three parameters:
 - CHALLENGES.md - Current challenges
 - FRAMES.md - Mental frames and perspectives
 - GOALS.md - Life goals
-- LESSONS.md - Lessons learned
+- LEARNED.md - Lessons learned
 - MISSION.md - Life mission
 - MODELS.md - Mental models
 - MOVIES.md - Favorite movies
@@ -113,7 +113,7 @@ This is the main command you'll use. It takes three parameters:
 
 When {PRINCIPAL.NAME} mentions updating TELOS, determine:
 - **What is being added?** (a book, a lesson, a belief, etc.)
-- **Which file should it go in?** (BOOKS.md, LESSONS.md, BELIEFS.md, etc.)
+- **Which file should it go in?** (BOOKS.md, LEARNED.md, BELIEFS.md, etc.)
 - **What's the context?** (why is this important to him?)
 
 ## Step 2: Prepare the Update
@@ -140,7 +140,7 @@ Use the update-telos command with:
 
 Example:
 ```bash
-bun ~/.claude/commands/update-telos.ts "BOOKS.md" "- *Project Hail Mary* by Andy Weir" "Added favorite book: Project Hail Mary"
+bun ~/.claude/skills/Telos/Tools/UpdateTelos.ts "BOOKS.md" "- *Project Hail Mary* by Andy Weir" "Added favorite book: Project Hail Mary"
 ```
 
 ## Step 4: Confirm and Engage
@@ -182,7 +182,7 @@ That book has such an interesting take on problem-solving under pressure. Anythi
 
 **Your Response:**
 ```
-Important lesson! I'll add that to LESSONS.md with proper formatting.
+Important lesson! I'll add that to LEARNED.md with proper formatting.
 
 [Execute the update command]
 
@@ -286,7 +286,7 @@ The TypeScript implementation handles:
 - Content appending (preserves existing content)
 - Pacific Time timezone for consistency
 
-The script is at: `~/.claude/commands/update-telos.ts`
+The script is at: `~/.claude/skills/Telos/Tools/UpdateTelos.ts`
 
 All backups are stored in: `~/.claude/PAI/USER/TELOS/Backups/`
 


### PR DESCRIPTION
## Summary

Two bugs in the Telos skill that cause the TELOS update command to silently fail:

### Bug 1 — Wrong filename: `LESSONS.md` vs `LEARNED.md`

`SKILL.md` consistently documents the lessons file as `LEARNED.md`:
```
- **LEARNED.md** - Lessons learned over time
```

But `Tools/UpdateTelos.ts` VALID_FILES and `Workflows/Update.md` both reference `LESSONS.md`.

**Effect:** The file on disk is `LEARNED.md`. If a user tries to update it:
- Via the tool directly (`update-telos LEARNED.md ...`) → `❌ Invalid file: LEARNED.md`
- Via the workflow examples (`update-telos LESSONS.md ...`) → `❌ File does not exist`

Both paths fail. Lessons cannot be updated at all.

### Bug 2 — Stale script path in `Update.md`

`Workflows/Update.md` invokes the update script as:
```bash
bun ~/.claude/commands/update-telos.ts
```

But `~/.claude/commands/` does not exist. The correct installed path is:
```bash
bun ~/.claude/skills/Telos/Tools/UpdateTelos.ts
```

This was partially addressed in #930/#929 for `UpdateTelos.ts` but not for `Update.md`.

## Changes

- `Packs/Telos/src/Tools/UpdateTelos.ts` — renamed `'LESSONS.md'` → `'LEARNED.md'` in VALID_FILES array and JSDoc comment
- `Packs/Telos/src/Workflows/Update.md` — renamed all `LESSONS.md` → `LEARNED.md` references; fixed script invocation path from `~/.claude/commands/update-telos.ts` to `~/.claude/skills/Telos/Tools/UpdateTelos.ts`

## Test plan

- [ ] `update-telos LEARNED.md "- New lesson" "Test lesson"` succeeds (was rejected as invalid file)
- [ ] `update-telos LESSONS.md "..." "..."` correctly rejected (file doesn't exist)
- [ ] `LEARNED.md` appears in the valid files list printed by the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)