### PR TITLE
Add ISC Contradiction Gate to Algorithm OBSERVE phase

### DIFF
--- a/Releases/v4.0.3/.claude/PAI/Algorithm/v3.7.0.md
+++ b/Releases/v4.0.3/.claude/PAI/Algorithm/v3.7.0.md
@@ -189,6 +189,25 @@ Count the criteria just written. Compare against effort tier minimum:
 
 **If ISC count < floor: DO NOT proceed.** Re-read each criterion, apply the Splitting Test, decompose, rewrite the PRD's Criteria section, recount. Repeat until floor is met. This gate exists because analysis of 50 production PRDs showed 0 out of 10 Extended PRDs ever hit the 16-minimum, and the single Deep PRD had 11 criteria vs 40-80 minimum. The gate is the fix.
 
+**ISC CONTRADICTION GATE (MANDATORY — cannot proceed to THINK without passing):**
+
+Re-read every ISC criterion against the REVERSE ENGINEERING output above. For each criterion, check: does this criterion contradict, undermine, or selectively preserve something the user explicitly said they DON'T want? Explicit user guidance overrides prior work, prior PRDs, and your own judgment about what "should" stay.
+
+The test for each criterion:
+1. Read the "explicitly didn't want" and "implied didn't want" lines from reverse engineering
+2. Does this criterion keep, protect, or preserve something covered by those lines?
+3. If yes → **remove or rewrite the criterion**. Do not rationalize exceptions ("but this one is different"). The user said what they said.
+
+**If any contradictions are found:** Remove or rewrite the contradicting criteria, update the PRD, recount, and re-run the ISC COUNT GATE if the count dropped below floor.
+
+OUTPUT:
+
+⚖️ CONTRADICTION CHECK:
+ ⚖️ [For each criterion that was flagged, removed, or rewritten: what it said, which explicit guidance it contradicted, and what was done]
+ ⚖️ [If no contradictions: "All N criteria align with explicit guidance."]
+
+This gate exists because production analysis showed the AI generating criteria that directly contradicted explicit user guidance — then defending those criteria through merge conflicts and verification. Explicit guidance is not a suggestion. It is a constraint.
+
 - CAPABILITY SELECTION (CRITICAL, MANDATORY):
 
 NOTE: Use as many perfectly selected CAPABILITIES for the task as you can that will allow you to still finish under the time SLA of the EFFORT LEVEL. Select from BOTH the skill listing AND the platform capabilities below.
@@ -364,6 +383,7 @@ Fill in all bracketed values from the current session. `implied_sentiment` is yo
 - No silent stalls — Ensure that no processes are hung, such as explore or research agents not returning results, etc.
 - **PRD is YOUR responsibility** — If you don't edit the PRD, it doesn't get updated. There is no hook safety net. Every phase transition, every criterion check, every progress update — you do it with Edit/Write tools directly. If you skip it, the PRD stays stale. Period.
 - **ISC Count Gate is mandatory** — Cannot exit OBSERVE with fewer ISC than the effort tier floor (Standard: 8, Extended: 16, Advanced: 24, Deep: 40, Comprehensive: 64). If below floor, decompose until met. No exceptions.
+- **ISC Contradiction Gate is mandatory** — Cannot exit OBSERVE with any criterion that contradicts explicit user guidance. Explicit guidance overrides prior work, prior PRDs, and AI judgment. No rationalized exceptions.
 - **Atomic criteria only** — Every criterion must pass the Splitting Test. No compound criteria with "and"/"with" joining independent verifiables. No scope words ("all", "every") without enumeration.
 
 ### Context Recovery


### PR DESCRIPTION
## Summary

- Adds a mandatory **ISC Contradiction Gate** to the Algorithm v3.7.0 OBSERVE phase, positioned between the existing ISC Count Gate and Capability Selection
- Cross-references every generated ISC criterion against the user's explicit "don't want" guidance from reverse engineering
- Adds corresponding entry to the Critical Rules section

## Problem

The Algorithm's OBSERVE phase generates ISC criteria and validates them for atomicity (Splitting Test) and quantity (Count Gate), but never checks whether criteria **contradict what the user explicitly said they don't want**.

In production, this caused the AI to:
1. Record "user explicitly doesn't want: version pinning" in reverse engineering
2. Generate ISC-9: "pai.yaml Ubuntu image URL kept pinned to specific release" — directly contradicting the guidance
3. Defend that criterion through execution, including resolving a merge conflict in favor of the stale pin
4. The pinned URL had already expired, requiring a second commit to fix

The AI rationalized the exception ("the Ubuntu image is different from tool versions") instead of following the explicit instruction.

## Solution

A new mandatory gate after ISC Count Gate:

```
ISC CONTRADICTION GATE (MANDATORY — cannot proceed to THINK without passing)

For each criterion:
1. Read the "explicitly didn't want" and "implied didn't want" lines
2. Does this criterion keep, protect, or preserve something covered by those lines?
3. If yes → remove or rewrite. Do not rationalize exceptions.
```

Key design choice: the gate explicitly calls out rationalization ("but this one is different") as the failure mode, because that's exactly what happened in production.

## Test plan

- [ ] Run an Algorithm session where the user says "don't do X" and verify the Contradiction Gate fires and removes any criterion that preserves X
- [ ] Verify the gate output format (⚖️ CONTRADICTION CHECK) appears in OBSERVE output
- [ ] Confirm ISC Count Gate re-runs if contradictions reduce the count below the effort tier floor

🤖 Generated with [Claude Code](https://claude.com/claude-code)