### PR TITLE
fix: cross-platform desktop notifications in VoiceServer

### DIFF
--- a/Releases/v4.0.3/.claude/VoiceServer/server.ts
+++ b/Releases/v4.0.3/.claude/VoiceServer/server.ts
@@ -260,6 +260,23 @@ function escapeForAppleScript(input: string): string {
   return input.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 }
 
+// Send desktop notification using OS-appropriate mechanism
+async function sendDesktopNotification(title: string, message: string): Promise<void> {
+  const platform = process.platform;
+  if (platform === 'darwin') {
+    const escapedTitle = escapeForAppleScript(title);
+    const escapedMessage = escapeForAppleScript(message);
+    const script = `display notification "${escapedMessage}" with title "${escapedTitle}" sound name ""`;
+    await spawnSafe('/usr/bin/osascript', ['-e', script]);
+  } else if (platform === 'linux') {
+    if (existsSync('/usr/bin/notify-send')) {
+      await spawnSafe('/usr/bin/notify-send', [title, message]);
+    } else {
+      console.log('⚠️ notify-send not found — skipping desktop notification');
+    }
+  }
+}
+
 // Extract emotional marker from message
 function extractEmotionalMarker(message: string): { cleaned: string; emotion?: string } {
   const emojiToEmotion: Record<string, string> = {
@@ -512,13 +529,10 @@ async function sendNotification(
     }
   }
 
-  // Display macOS notification (can be disabled via settings.json: notifications.desktop.enabled: false)
+  // Display desktop notification (can be disabled via settings.json: notifications.desktop.enabled: false)
   if (voiceConfig.desktopNotifications) {
     try {
-      const escapedTitle = escapeForAppleScript(safeTitle);
-      const escapedMessage = escapeForAppleScript(safeMessage);
-      const script = `display notification "${escapedMessage}" with title "${escapedTitle}" sound name ""`;
-      await spawnSafe('/usr/bin/osascript', ['-e', script]);
+      await sendDesktopNotification(safeTitle, safeMessage);
     } catch (error) {
       console.error("Notification display error:", error);
     }


### PR DESCRIPTION
## Summary
- Replaces hardcoded `/usr/bin/osascript` call with cross-platform `sendDesktopNotification()` function
- macOS: unchanged behavior (osascript with AppleScript escaping)
- Linux: uses `notify-send` if available, logs warning if not
- Follows the same pattern as the existing `getAudioPlayer()` which already handles cross-platform audio

## Problem
On Linux, every notification triggers an ENOENT error:
```
ENOENT: no such file or directory, posix_spawn '/usr/bin/osascript'
```

## Test plan
- [x] Verified on Ubuntu 24.04 — notify-send called, no ENOENT
- [x] macOS path unchanged — same osascript call with AppleScript escaping
- [x] Graceful fallback when neither tool available

Fixes #855
Relates to #685