### PR TITLE
fix(hooks): use getPaiDir() instead of hardcoded ~/.claude paths

### DIFF
--- a/Releases/v4.0.3/.claude/hooks/LastResponseCache.hook.ts
+++ b/Releases/v4.0.3/.claude/hooks/LastResponseCache.hook.ts
@@ -12,9 +12,9 @@
  */
 
 import { readHookInput, parseTranscriptFromInput } from './lib/hook-io';
+import { getPaiDir } from './lib/paths';
 import { writeFileSync } from 'fs';
 import { join } from 'path';
-import { homedir } from 'os';
 
 async function main() {
   const input = await readHookInput();
@@ -29,8 +29,7 @@ async function main() {
 
   if (lastResponse) {
     try {
-      const paiDir = process.env.PAI_DIR || join(homedir(), '.claude');
-      const cachePath = join(paiDir, 'MEMORY', 'STATE', 'last-response.txt');
+      const cachePath = join(getPaiDir(), 'MEMORY', 'STATE', 'last-response.txt');
       writeFileSync(cachePath, lastResponse.slice(0, 2000), 'utf-8');
     } catch (err) {
       console.error('[LastResponseCache] Failed to write:', err);

--- a/Releases/v4.0.3/.claude/hooks/RatingCapture.hook.ts
+++ b/Releases/v4.0.3/.claude/hooks/RatingCapture.hook.ts
@@ -30,6 +30,7 @@
 
 import { appendFileSync, mkdirSync, existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
+import { getPaiDir } from './lib/paths';
 import { inference } from '../PAI/Tools/Inference';
 import { getIdentity, getPrincipal, getPrincipalName } from './lib/identity';
 import { getLearningCategory } from './lib/learning-utils';
@@ -60,7 +61,7 @@ interface RatingEntry {
 
 // ── Shared Constants ──
 
-const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
+const BASE_DIR = getPaiDir();
 const SIGNALS_DIR = join(BASE_DIR, 'MEMORY', 'LEARNING', 'SIGNALS');
 const RATINGS_FILE = join(SIGNALS_DIR, 'ratings.jsonl');
 const LAST_RESPONSE_CACHE = join(BASE_DIR, 'MEMORY', 'STATE', 'last-response.txt');

--- a/Releases/v4.0.3/.claude/hooks/SessionCleanup.hook.ts
+++ b/Releases/v4.0.3/.claude/hooks/SessionCleanup.hook.ts
@@ -35,10 +35,11 @@
 
 import { writeFileSync, existsSync, readFileSync, unlinkSync } from 'fs';
 import { join } from 'path';
+import { getPaiDir } from './lib/paths';
 import { getISOTimestamp } from './lib/time';
 import { setTabState, cleanupKittySession } from './lib/tab-setter';
 
-const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
+const BASE_DIR = getPaiDir();
 const MEMORY_DIR = join(BASE_DIR, 'MEMORY');
 const STATE_DIR = join(MEMORY_DIR, 'STATE');
 const WORK_DIR = join(MEMORY_DIR, 'WORK');

--- a/Releases/v4.0.3/.claude/hooks/WorkCompletionLearning.hook.ts
+++ b/Releases/v4.0.3/.claude/hooks/WorkCompletionLearning.hook.ts
@@ -51,10 +51,11 @@
 
 import { writeFileSync, existsSync, readFileSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
+import { getPaiDir } from './lib/paths';
 import { getISOTimestamp, getPSTDate } from './lib/time';
 import { getLearningCategory } from './lib/learning-utils';
 
-const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
+const BASE_DIR = getPaiDir();
 const MEMORY_DIR = join(BASE_DIR, 'MEMORY');
 const STATE_DIR = join(MEMORY_DIR, 'STATE');
 const WORK_DIR = join(MEMORY_DIR, 'WORK');


### PR DESCRIPTION
## Summary

Replaces hardcoded `join(HOME, '.claude')` fallbacks with `getPaiDir()` from `hooks/lib/paths.ts` in 4 hooks:

- **LastResponseCache.hook.ts** — cache path via `getPaiDir()`
- **RatingCapture.hook.ts** — `BASE_DIR` via `getPaiDir()`
- **SessionCleanup.hook.ts** — `BASE_DIR` via `getPaiDir()`
- **WorkCompletionLearning.hook.ts** — `BASE_DIR` via `getPaiDir()`

## Motivation

Claude Code v2.1.78+ hardened `~/.claude/` as a protected directory, blocking writes even with `--dangerously-skip-permissions`. Users who set `PAI_DIR` to install PAI outside `~/.claude/` need hooks to respect that variable.

`getPaiDir()` already exists in `hooks/lib/paths.ts` and is used by SecurityValidator, SessionAutoName, RelationshipMemory, KittyEnvPersist, and LoadContext. This completes the migration for the remaining 4 hooks.

Related: #992, #873, #994

## Backward Compatible

Yes — `getPaiDir()` falls back to `~/.claude` when `PAI_DIR` is not set.

## Test plan

- [ ] Hooks work with default `PAI_DIR=~/.claude`
- [ ] Hooks work with custom `PAI_DIR=~/pai`

🤖 Generated with [Claude Code](https://claude.com/claude-code)