### PR TITLE
fix(tools): use PAI_DIR env var instead of hardcoded ~/.claude paths

### DIFF
--- a/Releases/v4.0.3/.claude/PAI/Tools/ActivityParser.ts
+++ b/Releases/v4.0.3/.claude/PAI/Tools/ActivityParser.ts
@@ -21,7 +21,7 @@ import * as path from "path";
 // Configuration
 // ============================================================================
 
-const CLAUDE_DIR = path.join(process.env.HOME!, ".claude");
+const CLAUDE_DIR = process.env.PAI_DIR || path.join(process.env.HOME!, ".claude");
 const MEMORY_DIR = path.join(CLAUDE_DIR, "MEMORY");
 const USERNAME = process.env.USER || require("os").userInfo().username;
 const PROJECTS_DIR = path.join(CLAUDE_DIR, "projects", `-Users-${USERNAME}--claude`);  // Claude Code native storage

--- a/Releases/v4.0.3/.claude/PAI/Tools/AlgorithmPhaseReport.ts
+++ b/Releases/v4.0.3/.claude/PAI/Tools/AlgorithmPhaseReport.ts
@@ -15,7 +15,8 @@ import { join } from "path";
 import { homedir } from "os";
 import { parseArgs } from "util";
 
-const STATE_DIR = join(homedir(), ".claude", "MEMORY", "STATE");
+const PAI_DIR = process.env.PAI_DIR || join(homedir(), ".claude");
+const STATE_DIR = join(PAI_DIR, "MEMORY", "STATE");
 const STATE_FILE = join(STATE_DIR, "algorithm-phase.json");
 
 interface AlgorithmState {

--- a/Releases/v4.0.3/.claude/PAI/Tools/Banner.ts
+++ b/Releases/v4.0.3/.claude/PAI/Tools/Banner.ts
@@ -13,7 +13,7 @@ import { join } from "path";
 import { spawnSync } from "child_process";
 
 const HOME = process.env.HOME!;
-const CLAUDE_DIR = join(HOME, ".claude");
+const CLAUDE_DIR = process.env.PAI_DIR || join(HOME, ".claude");
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Terminal Width Detection

--- a/Releases/v4.0.3/.claude/PAI/Tools/BannerMatrix.ts
+++ b/Releases/v4.0.3/.claude/PAI/Tools/BannerMatrix.ts
@@ -22,7 +22,7 @@ import { join } from "path";
 import { spawnSync } from "child_process";
 
 const HOME = process.env.HOME!;
-const CLAUDE_DIR = join(HOME, ".claude");
+const CLAUDE_DIR = process.env.PAI_DIR || join(HOME, ".claude");
 
 // =============================================================================
 // Terminal Width Detection

--- a/Releases/v4.0.3/.claude/PAI/Tools/BannerNeofetch.ts
+++ b/Releases/v4.0.3/.claude/PAI/Tools/BannerNeofetch.ts
@@ -15,7 +15,7 @@ import { join } from "path";
 import { spawnSync } from "child_process";
 
 const HOME = process.env.HOME!;
-const CLAUDE_DIR = join(HOME, ".claude");
+const CLAUDE_DIR = process.env.PAI_DIR || join(HOME, ".claude");
 
 // ═══════════════════════════════════════════════════════════════════════
 // Terminal Width Detection

--- a/Releases/v4.0.3/.claude/PAI/Tools/BannerRetro.ts
+++ b/Releases/v4.0.3/.claude/PAI/Tools/BannerRetro.ts
@@ -20,7 +20,7 @@ import { join } from "path";
 import { spawnSync } from "child_process";
 
 const HOME = process.env.HOME!;
-const CLAUDE_DIR = join(HOME, ".claude");
+const CLAUDE_DIR = process.env.PAI_DIR || join(HOME, ".claude");
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Terminal Width Detection

--- a/Releases/v4.0.3/.claude/PAI/Tools/BuildCLAUDE.ts
+++ b/Releases/v4.0.3/.claude/PAI/Tools/BuildCLAUDE.ts
@@ -15,9 +15,9 @@
 import { readFileSync, writeFileSync, existsSync } from "fs";
 import { join } from "path";
 
-const PAI_DIR = join(process.env.HOME!, ".claude");
+const PAI_DIR = process.env.PAI_DIR || join(process.env.HOME!, ".claude");
 const TEMPLATE_PATH = join(PAI_DIR, "CLAUDE.md.template");
-const OUTPUT_PATH = join(PAI_DIR, "CLAUDE.md");
+const OUTPUT_PATH = join(process.env.HOME!, ".claude", "CLAUDE.md");  // Always ~/.claude/ — Claude Code reads from fixed location
 const SETTINGS_PATH = join(PAI_DIR, "settings.json");
 const ALGORITHM_DIR = join(PAI_DIR, "PAI/Algorithm");
 const LATEST_PATH = join(ALGORITHM_DIR, "LATEST");

--- a/Releases/v4.0.3/.claude/PAI/Tools/FeatureRegistry.ts
+++ b/Releases/v4.0.3/.claude/PAI/Tools/FeatureRegistry.ts
@@ -55,7 +55,8 @@ interface FeatureRegistry {
   };
 }
 
-const REGISTRY_DIR = join(process.env.HOME || '', '.claude', 'MEMORY', 'progress');
+const PAI_DIR = process.env.PAI_DIR || join(process.env.HOME || '', '.claude');
+const REGISTRY_DIR = join(PAI_DIR, 'MEMORY', 'progress');
 
 function getRegistryPath(project: string): string {
   return join(REGISTRY_DIR, `${project}-features.json`);

--- a/Releases/v4.0.3/.claude/PAI/Tools/LearningPatternSynthesis.ts
+++ b/Releases/v4.0.3/.claude/PAI/Tools/LearningPatternSynthesis.ts
@@ -24,7 +24,7 @@ import * as path from "path";
 // Configuration
 // ============================================================================
 
-const CLAUDE_DIR = path.join(process.env.HOME!, ".claude");
+const CLAUDE_DIR = process.env.PAI_DIR || path.join(process.env.HOME!, ".claude");
 const LEARNING_DIR = path.join(CLAUDE_DIR, "MEMORY", "LEARNING");
 const RATINGS_FILE = path.join(LEARNING_DIR, "SIGNALS", "ratings.jsonl");
 const SYNTHESIS_DIR = path.join(LEARNING_DIR, "SYNTHESIS");

--- a/Releases/v4.0.3/.claude/PAI/Tools/LoadSkillConfig.ts
+++ b/Releases/v4.0.3/.claude/PAI/Tools/LoadSkillConfig.ts
@@ -35,7 +35,8 @@ interface ExtendManifest {
 
 // Constants
 const HOME = homedir();
-const CUSTOMIZATION_DIR = join(HOME, '.claude', 'PAI', 'USER', 'SKILLCUSTOMIZATIONS');
+const PAI_DIR = process.env.PAI_DIR || join(HOME, '.claude');
+const CUSTOMIZATION_DIR = join(PAI_DIR, 'PAI', 'USER', 'SKILLCUSTOMIZATIONS');
 
 /**
  * Deep merge two objects recursively

--- a/Releases/v4.0.3/.claude/PAI/Tools/NeofetchBanner.ts
+++ b/Releases/v4.0.3/.claude/PAI/Tools/NeofetchBanner.ts
@@ -20,7 +20,7 @@ import { join } from "path";
 import { spawnSync } from "child_process";
 
 const HOME = process.env.HOME!;
-const CLAUDE_DIR = join(HOME, ".claude");
+const CLAUDE_DIR = process.env.PAI_DIR || join(HOME, ".claude");
 
 // ═══════════════════════════════════════════════════════════════════════
 // Terminal Width Detection

--- a/Releases/v4.0.3/.claude/PAI/Tools/RebuildPAI.ts
+++ b/Releases/v4.0.3/.claude/PAI/Tools/RebuildPAI.ts
@@ -13,11 +13,12 @@ import { readdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 
 const HOME = process.env.HOME!;
-const PAI_DIR = join(HOME, ".claude/PAI");
+const CLAUDE_DIR = process.env.PAI_DIR || join(HOME, ".claude");
+const PAI_DIR = join(CLAUDE_DIR, "PAI");
 const COMPONENTS_DIR = join(PAI_DIR, "Components");
 const ALGORITHM_DIR = join(COMPONENTS_DIR, "Algorithm");
 const OUTPUT_FILE = join(PAI_DIR, "SKILL.md");
-const SETTINGS_PATH = join(HOME, ".claude/settings.json");
+const SETTINGS_PATH = join(CLAUDE_DIR, "settings.json");
 
 /**
  * Load identity variables from settings.json for template resolution

--- a/Releases/v4.0.3/.claude/PAI/Tools/SessionHarvester.ts
+++ b/Releases/v4.0.3/.claude/PAI/Tools/SessionHarvester.ts
@@ -25,7 +25,7 @@ import { getLearningCategory, isLearningCapture } from "../../hooks/lib/learning
 // Configuration
 // ============================================================================
 
-const CLAUDE_DIR = path.join(process.env.HOME!, ".claude");
+const CLAUDE_DIR = process.env.PAI_DIR || path.join(process.env.HOME!, ".claude");
 // Derive the project slug dynamically from CLAUDE_DIR (works on macOS and Linux)
 // macOS: ${HOME}/.claude → -Users-username--claude
 // Linux: /home/username/.claude → -home-username--claude

--- a/Releases/v4.0.3/.claude/PAI/Tools/SessionProgress.ts
+++ b/Releases/v4.0.3/.claude/PAI/Tools/SessionProgress.ts
@@ -44,7 +44,8 @@ interface SessionProgress {
 }
 
 // Progress files are now in STATE/progress/ (consolidated from MEMORY/PROGRESS/)
-const PROGRESS_DIR = join(process.env.HOME || '', '.claude', 'MEMORY', 'STATE', 'progress');
+const PAI_DIR = process.env.PAI_DIR || join(process.env.HOME || '', '.claude');
+const PROGRESS_DIR = join(PAI_DIR, 'MEMORY', 'STATE', 'progress');
 
 function getProgressPath(project: string): string {
   return join(PROGRESS_DIR, `${project}-progress.json`);

--- a/Releases/v4.0.3/.claude/PAI/Tools/pai.ts
+++ b/Releases/v4.0.3/.claude/PAI/Tools/pai.ts
@@ -28,7 +28,7 @@ import { join, basename } from "path";
 // Configuration
 // ============================================================================
 
-const CLAUDE_DIR = join(homedir(), ".claude");
+const CLAUDE_DIR = process.env.PAI_DIR || join(homedir(), ".claude");
 const MCP_DIR = join(CLAUDE_DIR, "MCPs");
 const ACTIVE_MCP = join(CLAUDE_DIR, ".mcp.json");
 const BANNER_SCRIPT = join(CLAUDE_DIR, "PAI", "Tools", "Banner.ts");

--- a/Releases/v4.0.3/.claude/hooks/LastResponseCache.hook.ts
+++ b/Releases/v4.0.3/.claude/hooks/LastResponseCache.hook.ts
@@ -12,9 +12,9 @@
  */
 
 import { readHookInput, parseTranscriptFromInput } from './lib/hook-io';
+import { getPaiDir } from './lib/paths';
 import { writeFileSync } from 'fs';
 import { join } from 'path';
-import { homedir } from 'os';
 
 async function main() {
   const input = await readHookInput();
@@ -29,8 +29,7 @@ async function main() {
 
   if (lastResponse) {
     try {
-      const paiDir = process.env.PAI_DIR || join(homedir(), '.claude');
-      const cachePath = join(paiDir, 'MEMORY', 'STATE', 'last-response.txt');
+      const cachePath = join(getPaiDir(), 'MEMORY', 'STATE', 'last-response.txt');
       writeFileSync(cachePath, lastResponse.slice(0, 2000), 'utf-8');
     } catch (err) {
       console.error('[LastResponseCache] Failed to write:', err);

--- a/Releases/v4.0.3/.claude/hooks/RatingCapture.hook.ts
+++ b/Releases/v4.0.3/.claude/hooks/RatingCapture.hook.ts
@@ -30,6 +30,7 @@
 
 import { appendFileSync, mkdirSync, existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
+import { getPaiDir } from './lib/paths';
 import { inference } from '../PAI/Tools/Inference';
 import { getIdentity, getPrincipal, getPrincipalName } from './lib/identity';
 import { getLearningCategory } from './lib/learning-utils';
@@ -60,7 +61,7 @@ interface RatingEntry {
 
 // ── Shared Constants ──
 
-const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
+const BASE_DIR = getPaiDir();
 const SIGNALS_DIR = join(BASE_DIR, 'MEMORY', 'LEARNING', 'SIGNALS');
 const RATINGS_FILE = join(SIGNALS_DIR, 'ratings.jsonl');
 const LAST_RESPONSE_CACHE = join(BASE_DIR, 'MEMORY', 'STATE', 'last-response.txt');

--- a/Releases/v4.0.3/.claude/hooks/SessionCleanup.hook.ts
+++ b/Releases/v4.0.3/.claude/hooks/SessionCleanup.hook.ts
@@ -35,10 +35,11 @@
 
 import { writeFileSync, existsSync, readFileSync, unlinkSync } from 'fs';
 import { join } from 'path';
+import { getPaiDir } from './lib/paths';
 import { getISOTimestamp } from './lib/time';
 import { setTabState, cleanupKittySession } from './lib/tab-setter';
 
-const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
+const BASE_DIR = getPaiDir();
 const MEMORY_DIR = join(BASE_DIR, 'MEMORY');
 const STATE_DIR = join(MEMORY_DIR, 'STATE');
 const WORK_DIR = join(MEMORY_DIR, 'WORK');

--- a/Releases/v4.0.3/.claude/hooks/WorkCompletionLearning.hook.ts
+++ b/Releases/v4.0.3/.claude/hooks/WorkCompletionLearning.hook.ts
@@ -51,10 +51,11 @@
 
 import { writeFileSync, existsSync, readFileSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
+import { getPaiDir } from './lib/paths';
 import { getISOTimestamp, getPSTDate } from './lib/time';
 import { getLearningCategory } from './lib/learning-utils';
 
-const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
+const BASE_DIR = getPaiDir();
 const MEMORY_DIR = join(BASE_DIR, 'MEMORY');
 const STATE_DIR = join(MEMORY_DIR, 'STATE');
 const WORK_DIR = join(MEMORY_DIR, 'WORK');


### PR DESCRIPTION
## Summary

Adds `process.env.PAI_DIR` fallback to 15 PAI Tools that hardcode `~/.claude` as the base directory. Each tool now checks `PAI_DIR` first, falling back to `~/.claude` for backward compatibility.

**Tools fixed:** ActivityParser, AlgorithmPhaseReport, Banner, BannerMatrix, BannerNeofetch, BannerRetro, BuildCLAUDE, FeatureRegistry, LearningPatternSynthesis, LoadSkillConfig, NeofetchBanner, pai, RebuildPAI, SessionHarvester, SessionProgress.

Also includes the 4 hook fixes from #1039 (LastResponseCache, RatingCapture, SessionCleanup, WorkCompletionLearning) since the tools branch was built on top of that work.

## Motivation

Claude Code v2.1.78+ hardened `~/.claude/` as a protected directory. Users who set `PAI_DIR` outside `~/.claude/` need tools to respect that variable. Currently, 15 tools ignore `PAI_DIR` entirely.

Related: #992, #873, #994, #1039

## Special case: BuildCLAUDE.ts

`BuildCLAUDE.ts` reads PAI content from `PAI_DIR` but ALWAYS writes `CLAUDE.md` to `~/.claude/CLAUDE.md` since Claude Code reads it from that fixed location.

## Backward Compatible

Yes — all tools fall back to `~/.claude` when `PAI_DIR` is not set.

## Test plan

- [ ] Tools work with default `PAI_DIR=~/.claude`
- [ ] Tools work with custom `PAI_DIR=~/pai`
- [ ] BuildCLAUDE.ts writes to `~/.claude/CLAUDE.md` regardless of `PAI_DIR`

🤖 Generated with [Claude Code](https://claude.com/claude-code)