### PR TITLE
fix(Inference.ts): add --no-session-persistence to prevent orphan session files

### DIFF
--- a/Releases/v4.0.3/.claude/PAI/Tools/Inference.ts
+++ b/Releases/v4.0.3/.claude/PAI/Tools/Inference.ts
@@ -82,6 +82,7 @@ export async function inference(options: InferenceOptions): Promise<InferenceRes
       '--tools', '',  // Disable tools for faster response
       '--output-format', 'text',
       '--setting-sources', '',  // Disable hooks to prevent recursion
+      '--no-session-persistence',  // Prevent orphan .jsonl files (fixes #947)
       '--system-prompt', options.systemPrompt,
     ];
 


### PR DESCRIPTION
## Summary

Adds `--no-session-persistence` flag to the `claude --print` args in `Inference.ts`. Without this flag, every hook that calls `Inference.ts` (SessionAutoName on 2nd+ turn, RatingCapture on responses) creates a new `.jsonl` session file per invocation, producing dozens of orphan files per conversation that clutter the `claude --resume` picker.

## The Fix

One line added to the args array in `Inference.ts` (line 85), after `--setting-sources`:

```typescript
'--no-session-persistence',  // Prevent orphan .jsonl files (fixes #947)
```

The `--no-session-persistence` flag is compatible with `--print` (which `Inference.ts` already uses) and simply tells the CLI not to write a session file for transient inference calls.

## Testing

- Ran PAI with this fix applied for several days of active use
- Confirmed: zero new orphan `.jsonl` files created after the fix
- Confirmed: SessionAutoName and RatingCapture continue to function normally
- Confirmed: `claude --resume` picker shows only real sessions

## Context

Fixes #947. Previous attempts at this fix (#635, #956) were either mis-targeted at older release paths or bundled with unrelated changes. This PR is scoped to the single flag addition only.