### PR TITLE
Fix RelationshipMemory hook: parsed.userPrompt doesn't exist

### DIFF
--- a/Releases/v4.0.3/.claude/hooks/RelationshipMemory.hook.ts
+++ b/Releases/v4.0.3/.claude/hooks/RelationshipMemory.hook.ts
@@ -33,7 +33,7 @@ import { join } from 'path';
 import { getPaiDir } from './lib/paths';
 import { getPSTComponents } from './lib/time';
 import { getDAName, getPrincipalName } from './lib/identity';
-import { parseTranscript } from '../PAI/Tools/TranscriptParser';
+import { parseTranscript, contentToText } from '../PAI/Tools/TranscriptParser';
 
 interface HookInput {
   session_id: string;
@@ -74,14 +74,31 @@ function readTranscriptEntries(path: string): TranscriptEntry[] {
 
   try {
     const parsed = parseTranscript(path);
-    // Combine user prompts and assistant completions into entry pairs
     const entries: TranscriptEntry[] = [];
-    if (parsed.userPrompt) {
-      entries.push({ type: 'user', text: parsed.userPrompt });
+
+    // Parse user and assistant messages from the raw JSONL transcript.
+    // parsed.userPrompt does not exist on ParsedTranscript; the previous
+    // code silently returned no user entries. parsed.plainCompletion is a
+    // short tab-title string, too small for the relationship regexes.
+    // Instead, iterate the raw JSONL lines (same approach TranscriptParser
+    // uses internally in parseLastAssistantMessage / collectCurrentResponseText).
+    const lines = parsed.raw.split('\n');
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const entry = JSON.parse(line) as any;
+        if ((entry.type === 'human' || entry.type === 'user') && entry.message?.content) {
+          const text = contentToText(entry.message.content);
+          if (text) entries.push({ type: 'user', text });
+        } else if (entry.type === 'assistant' && entry.message?.content) {
+          const text = contentToText(entry.message.content);
+          if (text) entries.push({ type: 'assistant', text });
+        }
+      } catch {
+        // Skip invalid JSON lines
+      }
     }
-    if (parsed.plainCompletion) {
-      entries.push({ type: 'assistant', text: parsed.plainCompletion });
-    }
+
     return entries;
   } catch {
     return [];


### PR DESCRIPTION
## Summary

- `RelationshipMemory.hook.ts` references `parsed.userPrompt` which doesn't exist on `ParsedTranscript` — always `undefined`, so user messages are never captured
- `parsed.plainCompletion` (tab-title string) is too short for relationship pattern regexes to match against assistant content
- Fix: parse both user and assistant messages from `parsed.raw` JSONL lines using the existing `contentToText()` helper, matching the same approach used internally by `parseLastAssistantMessage()` and `collectCurrentResponseText()`

## Test plan

- [ ] Run a session with preference-indicating user messages (e.g. "I prefer when you...") and verify entries appear in `MEMORY/RELATIONSHIP/`
- [ ] Run a session with `SUMMARY:` lines in assistant output and verify biographical notes are captured
- [ ] Confirm no regressions in other Stop hooks (VoiceCompletion, LastResponseCache, UpdateTabTitle)

Fixes #971