### PR TITLE
feat: add research vault recall to Algorithm, Research, and WorldThreatModel workflows

### DIFF
--- a/Releases/v4.0.3/.claude/PAI/Algorithm/v3.7.0.md
+++ b/Releases/v4.0.3/.claude/PAI/Algorithm/v3.7.0.md
@@ -147,6 +147,8 @@ The effort level defaults to `standard` here and gets refined later in OBSERVE a
 
 **FIRST ACTION:** Voice announce `"Entering the Observe phase."`, then Edit PRD frontmatter `updated: {timestamp}`. Then thinking-only, no tool calls except context recovery (Grep/Glob/Read <=34s)
 
+- **RESEARCH VAULT CHECK (all tasks):** Scan `MEMORY/RESEARCH/` for prior research relevant to the current request. List files (`ls MEMORY/RESEARCH/`), read file names and frontmatter titles, match against request keywords. If relevant research exists, note it in the ISC context and include it as a resource for subsequent phases. If no relevant research exists, note "no relevant prior research in vault" and move on. This is a fast check — `ls` + at most 2-3 frontmatter reads, no spawned agents.
+
 - REQUEST REVERSE ENGINEERING: explicit wants, implied wants, explicit not-wanted, implied not-wanted, common gotchas, previous work
 
 OUTPUT:

--- a/Releases/v4.0.3/.claude/skills/Research/Workflows/DeepInvestigation.md
+++ b/Releases/v4.0.3/.claude/skills/Research/Workflows/DeepInvestigation.md
@@ -51,6 +51,12 @@ Read `~/.claude/MEMORY/STATE/current-work.json` for the active work directory.
 ### Step 0: Detect Iteration State
 
 ```
+CHECK broader research vault for related prior work:
+  - List all directories/files in MEMORY/RESEARCH/
+  - If OTHER research topics (not this investigation's vault) have keyword overlap,
+    note them as supplementary context for landscape and entity research
+  - Include relevant prior findings in agent briefs during Steps 1 and 4
+
 READ vault directory for existing artifacts:
   - LANDSCAPE.md exists? → This is a CONTINUATION (skip to Step 3 or 4)
   - ENTITIES.md exists? → This is a CONTINUATION (skip to Step 3 or 4)

--- a/Releases/v4.0.3/.claude/skills/Research/Workflows/ExtensiveResearch.md
+++ b/Releases/v4.0.3/.claude/skills/Research/Workflows/ExtensiveResearch.md
@@ -21,9 +21,26 @@ See `SKILL.md` for full URL Verification Protocol.
 
 ## Workflow
 
-### Step 0: Generate Creative Research Angles (deep thinking)
+### Step 0: Check Research Vault for Prior Work
 
-**Use deep thinking to generate diverse research angles:**
+Before generating angles, check if the research vault already has relevant coverage:
+
+```
+1. List files in MEMORY/RESEARCH/ (recursive, .md files only)
+2. Match file names and directory names against the research topic keywords
+3. If matches found: read the matched file's frontmatter/first 20 lines for a summary
+```
+
+**If relevant prior research exists:**
+- Use prior findings to inform angle generation in Step 0.5 — avoid re-researching known territory, focus angles on gaps
+- Include a brief summary in each agent's prompt: "Prior research on this topic found: [summary]. Focus on NEW findings beyond what's already known."
+- If prior research is comprehensive and recent (<30 days), suggest: "We have existing research on this topic from [date]. Want to extend it rather than start fresh?"
+
+**If no relevant research:** Proceed normally.
+
+### Step 0.5: Generate Creative Research Angles (deep thinking)
+
+**Use deep thinking to generate diverse research angles** (informed by any prior vault findings from Step 0):
 
 Think deeply about the research topic:
 - Explore multiple unusual perspectives and domains

--- a/Releases/v4.0.3/.claude/skills/Research/Workflows/QuickResearch.md
+++ b/Releases/v4.0.3/.claude/skills/Research/Workflows/QuickResearch.md
@@ -11,6 +11,22 @@
 
 ## Workflow
 
+### Step 0.5: Check Research Vault for Prior Work
+
+Before spawning the agent, do a fast check of the research vault:
+
+```
+1. List files in MEMORY/RESEARCH/ (recursive, .md files only)
+2. Match file names and directory names against the research topic keywords
+3. If matches found: read the matched file's frontmatter/first 20 lines for a summary
+```
+
+**If relevant prior research exists:**
+- Include a brief summary in the agent's prompt: "Prior research on this topic found: [summary]. Build on these findings."
+- If prior research is comprehensive and recent (<30 days), suggest: "We have existing research on this topic from [date]. Want to extend it rather than start fresh?"
+
+**If no relevant research:** Proceed normally.
+
 ### Step 1: Launch Single Claude Agent
 
 **ONE Task call - Claude researcher with a single focused query:**

--- a/Releases/v4.0.3/.claude/skills/Research/Workflows/StandardResearch.md
+++ b/Releases/v4.0.3/.claude/skills/Research/Workflows/StandardResearch.md
@@ -20,6 +20,22 @@ See `SKILL.md` for full URL Verification Protocol.
 
 ## Workflow
 
+### Step 0.5: Check Research Vault for Prior Work
+
+Before spawning agents, check if the research vault already has relevant coverage:
+
+```
+1. List files in MEMORY/RESEARCH/ (recursive, .md files only)
+2. Match file names and directory names against the research topic keywords
+3. If matches found: read the matched file's frontmatter/first 20 lines for a summary
+```
+
+**If relevant prior research exists:**
+- Include a brief summary in each agent's prompt as context: "Prior research on this topic found: [summary]. Build on these findings."
+- If prior research is comprehensive and recent (<30 days), suggest to the user: "We have existing research on this topic from [date]. Want to extend it rather than start fresh?"
+
+**If no relevant research:** Proceed normally.
+
 ### Step 1: Craft One Query Per Researcher
 
 Create ONE focused query optimized for each researcher's strengths:

--- a/Releases/v4.0.3/.claude/skills/Thinking/WorldThreatModelHarness/Workflows/TestIdea.md
+++ b/Releases/v4.0.3/.claude/skills/Thinking/WorldThreatModelHarness/Workflows/TestIdea.md
@@ -44,6 +44,23 @@ curl -s -X POST http://localhost:8888/notify \
   -d '{"message": "Testing your idea against all eleven world threat models at TIER tier", "voice_id": "fTtv3eikoepIosk8dTZ5"}'
 ```
 
+### Step 1.5: Check Research Vault for Relevant Prior Work
+
+Before decomposing the idea, check if the research vault has relevant prior research:
+
+```
+1. List files in MEMORY/RESEARCH/ (recursive, .md files only)
+2. Match file names and directory names against the idea's domain keywords
+3. If matches found: read the matched file's frontmatter/first 20 lines for a summary
+```
+
+**If relevant prior research exists:**
+- Summarize the key findings from prior research
+- Include this summary as grounding context in Step 3's agent briefs: "Prior research on this domain found: [summary]. Use these findings as factual grounding when testing the idea against your time horizon."
+- This gives world model agents concrete evidence instead of relying solely on training knowledge
+
+**If no relevant research:** Proceed normally — note "no prior research vault data for this domain."
+
 ### Step 2: Extract and Decompose the Idea
 
 Before hitting it with world models, decompose the idea:


### PR DESCRIPTION
## Summary

Closes #1051

- Adds lightweight research vault check to Algorithm OBSERVE phase so prior research informs all downstream work
- Adds pre-spawn vault check to Quick, Standard, Extensive, and DeepInvestigation research workflows to avoid redundant agent work
- Adds vault check to WorldThreatModelHarness TestIdea so world model agents get prior research as grounding context

## What it does

Before spawning research agents or analytical workflows, PAI now scans `MEMORY/RESEARCH/` for relevant prior work by matching file names and frontmatter titles against the current request. If found, prior findings are included in agent briefs. If the vault is empty or nothing matches, the check is skipped gracefully.

This is the *recall* complement to the *capture* mechanism discussed in #844.

## Changes

6 files, 76 insertions:
- `PAI/Algorithm/v3.7.0.md` — new RESEARCH VAULT CHECK step in OBSERVE
- `skills/Research/Workflows/QuickResearch.md` — Step 0.5
- `skills/Research/Workflows/StandardResearch.md` — Step 0.5
- `skills/Research/Workflows/ExtensiveResearch.md` — Step 0
- `skills/Research/Workflows/DeepInvestigation.md` — cross-vault check in Step 0
- `skills/Thinking/WorldThreatModelHarness/Workflows/TestIdea.md` — Step 1.5

## Test plan

- [ ] Run a research workflow with an empty vault — should skip check gracefully
- [ ] Populate vault with a topic, then research a related topic — should detect and include prior work
- [ ] Run Algorithm on a topic with vault coverage — OBSERVE should note relevant research
- [ ] Verify no sensitive data in any changed files