### PR TITLE
fix(VoiceServer): cross-platform audio playback in playAudio()

### DIFF
--- a/Releases/v4.0.3/.claude/VoiceServer/server.ts
+++ b/Releases/v4.0.3/.claude/VoiceServer/server.ts
@@ -369,14 +369,47 @@ async function generateSpeech(
   return await response.arrayBuffer();
 }
 
-// Play audio using afplay (macOS)
+// Resolve the audio player command + arg builder for the current platform.
+// macOS uses afplay; Linux tries ffplay (ffmpeg) then falls back to mpg123.
+function getAudioPlayer(volume: number, tempFile: string): { command: string; args: string[] } | null {
+  if (process.platform === 'darwin') {
+    return { command: '/usr/bin/afplay', args: ['-v', volume.toString(), tempFile] };
+  }
+
+  const clamped = Math.max(0, Math.min(1, volume));
+
+  if (existsSync('/usr/bin/ffplay')) {
+    return {
+      command: '/usr/bin/ffplay',
+      args: ['-nodisp', '-autoexit', '-loglevel', 'quiet', '-volume', Math.round(clamped * 100).toString(), tempFile],
+    };
+  }
+
+  if (existsSync('/usr/bin/mpg123')) {
+    // mpg123 -f scales raw PCM by integer 0..32768
+    return {
+      command: '/usr/bin/mpg123',
+      args: ['-q', '-f', Math.round(clamped * 32768).toString(), tempFile],
+    };
+  }
+
+  return null;
+}
+
+// Play audio: macOS uses afplay, Linux uses ffplay or mpg123 (whichever is installed).
 async function playAudio(audioBuffer: ArrayBuffer, volume: number = FALLBACK_VOLUME): Promise<void> {
   const tempFile = `/tmp/voice-${Date.now()}.mp3`;
 
   await Bun.write(tempFile, audioBuffer);
 
+  const player = getAudioPlayer(volume, tempFile);
+  if (!player) {
+    spawn('/bin/rm', [tempFile]);
+    throw new Error('No supported audio player found. Install ffmpeg (ffplay) or mpg123.');
+  }
+
   return new Promise((resolve, reject) => {
-    const proc = spawn('/usr/bin/afplay', ['-v', volume.toString(), tempFile]);
+    const proc = spawn(player.command, player.args);
 
     proc.on('error', (error) => {
       console.error('Error playing audio:', error);
@@ -388,7 +421,7 @@ async function playAudio(audioBuffer: ArrayBuffer, volume: number = FALLBACK_VOL
       if (code === 0) {
         resolve();
       } else {
-        reject(new Error(`afplay exited with code ${code}`));
+        reject(new Error(`${player.command} exited with code ${code}`));
       }
     });
   });


### PR DESCRIPTION
## Summary

`VoiceServer/server.ts:playAudio()` hardcodes `/usr/bin/afplay`, which is macOS-only. On Linux every TTS notification fails with `ENOENT` and the voice server appears to work but produces no audio — the failure is swallowed by the fire-and-forget `curl` pattern at the call sites, so users see ✅ success in their terminal and silent speakers.

This PR makes audio playback cross-platform. It is **complementary** to #1030 (which covers the desktop-notification half via `notify-send`) and addresses the audio-playback half of #855 — neither file region overlaps.

## Change

Extract player resolution into a small `getAudioPlayer()` helper, then call it from `playAudio()`:

| Platform | Player | Notes |
|---|---|---|
| `darwin` | `/usr/bin/afplay` | unchanged behavior |
| linux + ffplay present | `/usr/bin/ffplay` | preferred — `ffmpeg` is widely preinstalled |
| linux + mpg123 present | `/usr/bin/mpg123` | lightweight fallback (~500 KB) |
| neither | throws with install hint | actionable error instead of `ENOENT` |

Volume is preserved across players: `afplay -v` (0..1 float), `ffplay -volume` (0..100 int), `mpg123 -f` (0..32768 PCM scale).

## Why ffplay first, mpg123 second

`ffplay` ships with `ffmpeg` which is already a dependency on most modern dev boxes; `mpg123` is the well-known minimal fallback called out in #855. Trying both gives users a graceful path on minimal containers/distros without forcing a heavy install.

## Test plan

- [x] Verified on Ubuntu 24.04 / WSL2 on Windows 11 — TTS audio plays through WSLg PulseAudio to Windows speakers with **zero additional configuration** (no PulseAudio TCP forwarding, no Docker shenanigans)
- [x] mpg123 fallback path verified directly (`mpg123 -q -f 32768 /tmp/voice-*.mp3` → exit 0, audio plays)
- [x] macOS code path unchanged — same `afplay -v` invocation
- [x] No new dependencies; no changes outside `playAudio()` and the new helper
- [ ] macOS smoke test (would appreciate a maintainer running it before merge — I don't have a Mac handy)

## Scope

- ✅ `playAudio()` only
- ❌ Desktop notifications — already handled by #1030
- ❌ `start.sh` / `stop.sh` / `restart.sh` (`launchctl` → systemd-user) — separate PR, deserves its own discussion

## References

- Addresses the audio-playback half of #855
- Complementary to #1030
- Historical context in #685 (notes that PR #288 once fixed all of this and it was lost in the v3.0 restructuring)