### PR TITLE
feat(notifications): add Pushcut as a notification channel

### DIFF
--- a/Releases/v4.0.3/.claude/hooks/lib/notifications.ts
+++ b/Releases/v4.0.3/.claude/hooks/lib/notifications.ts
@@ -90,3 +90,49 @@ export async function sendPush(
     return false;
   }
 }
+
+// ============================================================================
+// Pushcut Push (fire-and-forget) — iOS rich notifications + Shortcuts bridge
+// ============================================================================
+
+function loadPushcutConfig(): { enabled: boolean; webhookUrl: string } {
+  try {
+    const paiDir = process.env.PAI_DIR || join(homedir(), '.claude');
+    const settingsPath = join(paiDir, 'settings.json');
+    if (!existsSync(settingsPath)) return { enabled: false, webhookUrl: '' };
+
+    const raw = readFileSync(settingsPath, 'utf-8')
+      .replace(/\$\{(\w+)\}/g, (_, key) => process.env[key] || '');
+    const settings = JSON.parse(raw);
+    const pushcut = settings.notifications?.pushcut;
+    return {
+      enabled: pushcut?.enabled ?? false,
+      webhookUrl: pushcut?.webhookUrl ?? '',
+    };
+  } catch {
+    return { enabled: false, webhookUrl: '' };
+  }
+}
+
+export async function sendPushcut(
+  message: string,
+  options: NotificationOptions = {}
+): Promise<boolean> {
+  const config = loadPushcutConfig();
+  if (!config.enabled || !config.webhookUrl) return false;
+
+  try {
+    const body: Record<string, unknown> = { text: message };
+    if (options.title) body.title = options.title;
+
+    const response = await fetch(config.webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(5000),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}

--- a/Releases/v4.0.3/.claude/settings.json
+++ b/Releases/v4.0.3/.claude/settings.json
@@ -1021,6 +1021,10 @@
       "enabled": true,
       "toNumber": "${TWILIO_TO_NUMBER}"
     },
+    "pushcut": {
+      "enabled": false,
+      "webhookUrl": "${PUSHCUT_WEBHOOK_URL}"
+    },
     "thresholds": {
       "longTaskMinutes": 5
     },


### PR DESCRIPTION
## Summary

Adds [Pushcut](https://www.pushcut.io) as an iOS-native notification channel alongside ntfy, following the existing \`sendPush()\` pattern in \`hooks/lib/notifications.ts\`.

Pushcut delivers rich push notifications to iPhone with first-class iOS Shortcuts integration, action buttons, and an Automation Server for unattended Shortcut execution. It's purpose-built for the \"webhook → iPhone notification → optional Shortcuts automation\" use case.

## Why Pushcut

The Apple-native alternative is a custom Apple Push Notification (APNs) integration, which requires:
- Apple Developer account (\$99/yr)
- Registered iOS app + provisioning
- APNs certificate management
- Ongoing maintenance every iOS major

Pushcut already runs that infrastructure and exposes it via a single webhook URL. Strictly less complexity for the same delivery guarantees, plus the Shortcuts integration a DIY APNs solution would not provide. The free tier covers most personal notification volumes; Pro is ~\$5/mo.

## Changes

| File | Change |
|---|---|
| \`hooks/lib/notifications.ts\` | Add \`loadPushcutConfig()\` + \`sendPushcut()\` mirroring the existing ntfy pattern. ~40 lines, no new dependencies. |
| \`settings.json\` | Add \`notifications.pushcut\` block. \`enabled: false\` by default — opt-in. Reads \`PUSHCUT_WEBHOOK_URL\` from env via the existing \`\${VAR}\` substitution. |

\`sendPushcut(message, options)\` matches the \`sendPush()\` signature exactly:
- Fire-and-forget POST
- 5-second timeout via \`AbortSignal.timeout\`
- Returns \`boolean\` (true on HTTP 2xx, false on misconfig/error)
- **Never throws** — failures are silent the same way ntfy failures are

## Usage

\`\`\`ts
import { sendPushcut } from '~/.claude/hooks/lib/notifications';
await sendPushcut('Long task complete', { title: 'Athena' });
\`\`\`

## User setup (will need a docs entry — happy to add to a follow-up doc PR if useful)

1. Install Pushcut from the App Store
2. Create a named notification template in the Notifications tab (the name becomes the URL suffix)
3. Copy the secret webhook URL from the notification's detail view
4. Set \`PUSHCUT_WEBHOOK_URL\` in \`~/.env\`
5. Set \`notifications.pushcut.enabled = true\` in \`settings.json\`

## Test plan

- [x] \`sendPushcut()\` returns \`true\` on HTTP 200 from Pushcut API (verified end-to-end — notification arrived on iPhone)
- [x] Returns \`false\` (no throw) when env var missing or \`enabled: false\`
- [x] Returns \`false\` (no throw) on network error or 5s timeout
- [x] Pre-existing \`sendPush()\` (ntfy) behavior unchanged — same code, same loader pattern
- [x] No new dependencies
- [x] Defaults to \`enabled: false\` — zero impact on existing installs that don't opt in

## Out of scope (intentional, possible follow-ups)

- **Multi-channel dispatcher** that consults \`notifications.routing\` — the routing block exists in \`settings.json\` but no code reads it yet (only individual sender functions are exported). Adding a dispatcher would be a separate, larger PR.
- **Pushcut action buttons / defaultAction** support — needs a concrete use case to design the API surface. Easy to extend the body shape later without breaking the current signature.
- **discord/twilio sender implementations** — still settings-only stubs. Independent work.

## Related

This is a feature add, not a bug fix. Happy to scope it down further or split if maintainers prefer a smaller initial surface.