### PR TITLE
fix(env): stop claiming ~/.env; read from ~/.config/PAI/.env instead

### DIFF
--- a/Releases/v4.0.3/.claude/PAI-Install/engine/actions.ts
+++ b/Releases/v4.0.3/.claude/PAI-Install/engine/actions.ts
@@ -724,28 +724,29 @@ export async function runConfiguration(
     await emit({ event: "message", content: "API keys saved securely." });
   }
 
-  // Create symlinks so all consumers can find the .env
-  // Voice server reads ~/.env, hooks read ~/.claude/.env
+  // Create a symlink at ~/.claude/.env for PAI hooks that still read from
+  // the claude-scoped path. ~/.claude/ is PAI's own namespace so the symlink
+  // is safe; we do NOT symlink ~/.env anymore because ~/.env belongs to the
+  // user — they may have their own shell environment file there unrelated to
+  // PAI. VoiceServer and other components now read from envPath
+  // (~/.config/PAI/.env) directly, with an optional overlay from ~/.env if
+  // the user chooses to put PAI-relevant keys there.
   if (existsSync(envPath)) {
-    const symlinkPaths = [
-      join(paiDir, ".env"),         // ~/.claude/.env
-      join(homedir(), ".env"),      // ~/.env (voice server reads this)
-    ];
-    for (const symlinkPath of symlinkPaths) {
-      try {
-        // Remove stale symlink or file before creating
-        if (existsSync(symlinkPath)) {
-          const stat = lstatSync(symlinkPath);
-          if (stat.isSymbolicLink()) {
-            unlinkSync(symlinkPath);
-          } else {
-            continue; // Don't overwrite a real file
-          }
+    const claudeEnvSymlink = join(paiDir, ".env");
+    try {
+      if (existsSync(claudeEnvSymlink)) {
+        const stat = lstatSync(claudeEnvSymlink);
+        if (stat.isSymbolicLink()) {
+          unlinkSync(claudeEnvSymlink);
+        } else {
+          // Don't overwrite a real file — skip creating the symlink.
         }
-        symlinkSync(envPath, symlinkPath);
-      } catch {
-        // Permission error or path conflict
       }
+      if (!existsSync(claudeEnvSymlink)) {
+        symlinkSync(envPath, claudeEnvSymlink);
+      }
+    } catch {
+      // Permission error or path conflict — non-fatal.
     }
   }
 

--- a/Releases/v4.0.3/.claude/VoiceServer/server.ts
+++ b/Releases/v4.0.3/.claude/VoiceServer/server.ts
@@ -20,10 +20,13 @@ import { homedir } from "os";
 import { join } from "path";
 import { existsSync, readFileSync } from "fs";
 
-// Load .env from user home directory
-const envPath = join(homedir(), '.env');
-if (existsSync(envPath)) {
-  const envContent = await Bun.file(envPath).text();
+// Load .env files — XDG-compliant location first, then ~/.env as optional
+// user overlay. The user owns ~/.env for their own purposes; PAI-managed
+// secrets live at ~/.config/PAI/.env so they never collide with user's file.
+// Values in ~/.env win in the case of key collisions (explicit user override).
+async function loadEnvFile(path: string): Promise<void> {
+  if (!existsSync(path)) return;
+  const envContent = await Bun.file(path).text();
   envContent.split('\n').forEach(line => {
     const [key, value] = line.split('=');
     if (key && value && !key.startsWith('#')) {
@@ -32,12 +35,20 @@ if (existsSync(envPath)) {
   });
 }
 
+const xdgEnvPath = join(homedir(), '.config', 'PAI', '.env');
+const homeEnvPath = join(homedir(), '.env');
+
+// Load PAI's managed secrets first (canonical location)
+await loadEnvFile(xdgEnvPath);
+// Then user overlay — any key in ~/.env wins over the XDG file
+await loadEnvFile(homeEnvPath);
+
 const PORT = parseInt(process.env.PORT || "8888");
 const ELEVENLABS_API_KEY = process.env.ELEVENLABS_API_KEY;
 
 if (!ELEVENLABS_API_KEY) {
-  console.error('⚠️  ELEVENLABS_API_KEY not found in ~/.env');
-  console.error('Add: ELEVENLABS_API_KEY=your_key_here');
+  console.error('⚠️  ELEVENLABS_API_KEY not found');
+  console.error(`Add it to ${xdgEnvPath} (or ~/.env) as: ELEVENLABS_API_KEY=your_key_here`);
 }
 
 // ==========================================================================


### PR DESCRIPTION
## Summary

PAI currently writes its managed secrets to \`~/.config/PAI/.env\` (the XDG-compliant canonical location — correct choice) but then creates a symlink at \`~/.env\` pointing at it. That symlink is a home-directory namespace grab: \`~/.env\` is a conventional, user-owned file that many shells and tools look for. If a user installs any other tool that expects \`~/.env\`, it either collides with PAI's secrets or silently overwrites PAI on the next install. The user loses control of a file they should own.

The cause is that \`VoiceServer/server.ts\` hardcodes \`join(homedir(), '.env')\` as the only place it looks for \`ELEVENLABS_API_KEY\`. The installer created the \`~/.env\` symlink purely to satisfy that hardcoded read — not as a considered design decision.

This PR removes the \`~/.env\` symlink and teaches VoiceServer to read from the canonical XDG path directly, with \`~/.env\` preserved as an optional user overlay for anyone who wants to put PAI-relevant keys there.

## Changes

### \`VoiceServer/server.ts\`

Refactored the env-loading block:

**Before:**
\`\`\`ts
// Load .env from user home directory
const envPath = join(homedir(), '.env');
if (existsSync(envPath)) {
  const envContent = await Bun.file(envPath).text();
  envContent.split('\n').forEach(line => { /* parse */ });
}
\`\`\`

**After:**
\`\`\`ts
async function loadEnvFile(path: string): Promise<void> { /* parse if exists */ }

const xdgEnvPath = join(homedir(), '.config', 'PAI', '.env');
const homeEnvPath = join(homedir(), '.env');

await loadEnvFile(xdgEnvPath);   // PAI's managed secrets (canonical)
await loadEnvFile(homeEnvPath);  // optional user overlay — wins on collisions
\`\`\`

The error message when \`ELEVENLABS_API_KEY\` is missing now points at the canonical path rather than hardcoding \`~/.env\`.

### \`PAI-Install/engine/actions.ts\`

Removed the creation of the \`~/.env\` symlink. The \`~/.claude/.env\` symlink is preserved — that path is PAI's own namespace, so the symlink is safe and hooks that already read it continue working unchanged.

## Backward compatibility

This is **fully backward-compatible** with existing installs:

1. **Existing installs with the \`~/.env\` symlink already in place:** Both paths resolve to the same real file. \`loadEnvFile()\` calls it twice; the second load overwrites with the same values. No-op, no breakage.
2. **Existing installs where a user previously replaced \`~/.env\` with a real file containing PAI values:** \`loadEnvFile()\` reads both \`~/.config/PAI/.env\` (if it exists) and \`~/.env\`, so any of the three configurations (XDG only, home only, or both) keeps working.
3. **New installs after this lands:** The installer writes secrets to \`~/.config/PAI/.env\` and creates only the \`~/.claude/.env\` symlink. \`~/.env\` is left untouched — the user owns it.
4. **Install re-runs (upgrades):** The installer's existing safeguard at line 742 (\`continue; // Don't overwrite a real file\`) already refuses to clobber a non-symlink \`~/.env\`, so users who reclaimed their \`~/.env\` between installs are already safe. This PR simply extends that safety by not creating the symlink at all.

## Test plan

- [x] **Local reclaim test.** Removed the \`~/.env\` symlink on my WSL2 install, replaced with an empty real file (mode 0600), restarted VoiceServer via systemd. VoiceServer started clean, \`/health\` reports \`api_key_configured: true\`, a live voice notification request succeeds end-to-end. This confirms the XDG-path load works.
- [x] **Overlay test.** Added a throwaway key to \`~/.env\` (e.g. \`FOO=bar\`) and confirmed \`process.env.FOO\` is visible inside VoiceServer's startup logs (via \`--debug\`), without breaking the XDG load.
- [x] **Error message test.** Temporarily renamed \`~/.config/PAI/.env\` to simulate a fresh install with no secrets yet. Confirmed the new error message correctly points at the XDG path.
- [x] **Shell-escape / install.sh re-run test.** Ran the installer path locally against a scratch directory; confirmed the new behavior: only \`~/.claude/.env\` symlink is created, \`~/.env\` is untouched.
- [ ] **macOS sanity check** — would appreciate a maintainer running \`bun run VoiceServer/server.ts\` on a Mac to confirm the XDG path resolves correctly there too. macOS honors \`\$HOME/.config\` the same way Linux does, so I'm confident but don't have a Mac to verify.

## Why this matters

\`~/.env\` is a conventional, user-owned file. A well-behaved application writes to its own scoped location (\`~/.config/PAI/\` ✓) and teaches its dependencies to read from the right place. It should not reach into the home directory and colonize a generic file — especially not as an implicit side effect of one hardcoded line in one component.

PAI's installer already knows the right pattern (the XDG file is already the canonical location). This PR just finishes the job: makes the runtime read from the right place so the symlink shim isn't needed.

## Related

- #1061 — cross-platform audio playback in VoiceServer (same file, same kind of small-but-real correctness fix)
- #1062 — Pushcut notification channel (adjacent: new code in hooks/lib/notifications.ts that reads env vars and also needs them to resolve correctly)
- #1065 — jq dependency check (same theme: defensive coding can't fix a wrong default)