### PR TITLE
fix(VoiceServer): cross-platform desktop notifications, log path, and port check

### DIFF
--- a/Releases/v4.0.3/.claude/VoiceServer/install.sh
+++ b/Releases/v4.0.3/.claude/VoiceServer/install.sh
@@ -14,9 +14,11 @@ NC='\033[0m' # No Color
 
 # Configuration
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# shellcheck source=lib/platform.sh
+. "$SCRIPT_DIR/lib/platform.sh"
 SERVICE_NAME="com.pai.voice-server"
 PLIST_PATH="$HOME/Library/LaunchAgents/${SERVICE_NAME}.plist"
-LOG_PATH="$HOME/Library/Logs/pai-voice-server.log"
+LOG_PATH="$(pai_log_path)"
 ENV_FILE="$HOME/.env"
 
 echo -e "${BLUE}=====================================================${NC}"

--- a/Releases/v4.0.3/.claude/VoiceServer/lib/platform.sh
+++ b/Releases/v4.0.3/.claude/VoiceServer/lib/platform.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# PAI VoiceServer — shared platform detection and path helpers.
+#
+# Designed to be sourced by sibling scripts (install.sh, start.sh, stop.sh,
+# status.sh, uninstall.sh, menubar/pai-voice.5s.sh). POSIX-leaning bash: no
+# associative arrays, no process substitution in function bodies, works under
+# `bash` on macOS and Linux/WSL2.
+#
+# Exports three helpers:
+#   pai_is_wsl           — returns 0 iff running inside WSL (any version)
+#   pai_log_path         — prints the platform-appropriate log file path
+#   pai_port_pids PORT   — prints PIDs listening on PORT (lsof > ss > netstat)
+#
+# Platform matrix:
+#   macOS (darwin): log path = $HOME/Library/Logs/pai-voice-server.log
+#                    (byte-identical to pre-refactor literal)
+#   Linux + WSL2:   log path = ${XDG_DATA_HOME:-$HOME/.local/share}/pai/logs/pai-voice-server.log
+#
+# This file is intentionally side-effect free on source — no echo, no exit,
+# no directory creation. Callers decide when to mkdir the log directory.
+
+# --------------------------------------------------------------------------
+# OS detection
+# --------------------------------------------------------------------------
+
+pai_uname_s() {
+    uname -s 2>/dev/null || echo "Unknown"
+}
+
+pai_is_darwin() {
+    [ "$(pai_uname_s)" = "Darwin" ]
+}
+
+pai_is_linux() {
+    [ "$(pai_uname_s)" = "Linux" ]
+}
+
+# pai_is_wsl — true iff /proc/version mentions Microsoft (WSL1 or WSL2).
+# Case-insensitive match catches both "Microsoft" (WSL1) and "microsoft" (WSL2).
+pai_is_wsl() {
+    if ! pai_is_linux; then
+        return 1
+    fi
+    if [ ! -r /proc/version ]; then
+        return 1
+    fi
+    if grep -qi 'microsoft' /proc/version; then
+        return 0
+    fi
+    return 1
+}
+
+# --------------------------------------------------------------------------
+# Paths
+# --------------------------------------------------------------------------
+
+# pai_log_path — prints the absolute log file path for pai-voice-server.
+# On macOS preserves the historical ~/Library/Logs location (byte-identical
+# to the pre-refactor literal) so the Darwin flow stays untouched.
+# On Linux/WSL uses XDG_DATA_HOME with a sane fallback.
+pai_log_path() {
+    if pai_is_darwin; then
+        printf '%s\n' "$HOME/Library/Logs/pai-voice-server.log"
+        return 0
+    fi
+    # Linux or WSL — XDG Base Directory spec.
+    local base="${XDG_DATA_HOME:-$HOME/.local/share}"
+    printf '%s\n' "$base/pai/logs/pai-voice-server.log"
+}
+
+# --------------------------------------------------------------------------
+# Port helpers
+# --------------------------------------------------------------------------
+
+# pai_port_pids PORT — prints one PID per line that is listening on PORT.
+# Tries lsof first (historic behavior on macOS), then ss (iproute2, ubiquitous
+# on modern Linux/WSL), then netstat as a last resort. Prints nothing and
+# returns 1 if none are available or nothing is listening.
+pai_port_pids() {
+    local port="$1"
+    if [ -z "$port" ]; then
+        return 2
+    fi
+
+    if command -v lsof >/dev/null 2>&1; then
+        local pids
+        pids=$(lsof -ti ":${port}" 2>/dev/null)
+        if [ -n "$pids" ]; then
+            printf '%s\n' "$pids"
+            return 0
+        fi
+    fi
+
+    if command -v ss >/dev/null 2>&1; then
+        # ss -H -ltnp sport = :PORT — machine-readable, one line per socket.
+        # Extract pid=NNN from users:(("name",pid=NNN,fd=N)).
+        local out
+        out=$(ss -H -ltnp "sport = :${port}" 2>/dev/null \
+              | grep -oE 'pid=[0-9]+' \
+              | cut -d= -f2 \
+              | sort -u)
+        if [ -n "$out" ]; then
+            printf '%s\n' "$out"
+            return 0
+        fi
+    fi
+
+    if command -v netstat >/dev/null 2>&1; then
+        # netstat -ltnp, extract "PID/program" from the last column.
+        local out
+        out=$(netstat -ltnp 2>/dev/null \
+              | awk -v p=":${port}" '$4 ~ p"$" {print $7}' \
+              | cut -d/ -f1 \
+              | grep -E '^[0-9]+$' \
+              | sort -u)
+        if [ -n "$out" ]; then
+            printf '%s\n' "$out"
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
+# pai_port_in_use PORT — 0 iff something is listening on PORT.
+pai_port_in_use() {
+    local pids
+    pids=$(pai_port_pids "$1") || return 1
+    [ -n "$pids" ]
+}

--- a/Releases/v4.0.3/.claude/VoiceServer/menubar/pai-voice.5s.sh
+++ b/Releases/v4.0.3/.claude/VoiceServer/menubar/pai-voice.5s.sh
@@ -7,6 +7,25 @@
 PAI_DIR="${PAI_DIR:-$HOME/.claude}"
 VOICE_SERVER_DIR="$PAI_DIR/VoiceServer"
 
+# Source the shared platform helpers if available. BitBar/SwiftBar runs this
+# from an arbitrary cwd so we resolve the library relative to the script.
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+if [ -r "$SCRIPT_DIR/../lib/platform.sh" ]; then
+    # shellcheck source=../lib/platform.sh
+    . "$SCRIPT_DIR/../lib/platform.sh"
+elif [ -r "$VOICE_SERVER_DIR/lib/platform.sh" ]; then
+    # shellcheck source=/dev/null
+    . "$VOICE_SERVER_DIR/lib/platform.sh"
+fi
+
+# Resolve log path once. Fall back to the historical macOS literal if the
+# helper isn't available (e.g., running from an older checkout).
+if command -v pai_log_path >/dev/null 2>&1; then
+    LOG_PATH="$(pai_log_path)"
+else
+    LOG_PATH="$HOME/Library/Logs/pai-voice-server.log"
+fi
+
 # Check if server is running
 if curl -s -f http://localhost:8888/health > /dev/null 2>&1; then
     # Server is running - show green indicator with size
@@ -41,7 +60,7 @@ fi
 
 echo "---"
 echo "Check Status | bash='$VOICE_SERVER_DIR/status.sh' terminal=true"
-echo "View Logs | bash='tail -f ~/Library/Logs/pai-voice-server.log' terminal=true"
+echo "View Logs | bash='tail -f $LOG_PATH' terminal=true"
 echo "---"
 echo "Test Voice | bash='curl -X POST http://localhost:8888/notify -H \"Content-Type: application/json\" -d \"{\\\"message\\\":\\\"Testing voice server\\\"}\"' terminal=false"
 echo "---"

--- a/Releases/v4.0.3/.claude/VoiceServer/server.ts
+++ b/Releases/v4.0.3/.claude/VoiceServer/server.ts
@@ -369,14 +369,47 @@ async function generateSpeech(
   return await response.arrayBuffer();
 }
 
-// Play audio using afplay (macOS)
+// Resolve the audio player command + arg builder for the current platform.
+// macOS uses afplay; Linux tries ffplay (ffmpeg) then falls back to mpg123.
+function getAudioPlayer(volume: number, tempFile: string): { command: string; args: string[] } | null {
+  if (process.platform === 'darwin') {
+    return { command: '/usr/bin/afplay', args: ['-v', volume.toString(), tempFile] };
+  }
+
+  const clamped = Math.max(0, Math.min(1, volume));
+
+  if (existsSync('/usr/bin/ffplay')) {
+    return {
+      command: '/usr/bin/ffplay',
+      args: ['-nodisp', '-autoexit', '-loglevel', 'quiet', '-volume', Math.round(clamped * 100).toString(), tempFile],
+    };
+  }
+
+  if (existsSync('/usr/bin/mpg123')) {
+    // mpg123 -f scales raw PCM by integer 0..32768
+    return {
+      command: '/usr/bin/mpg123',
+      args: ['-q', '-f', Math.round(clamped * 32768).toString(), tempFile],
+    };
+  }
+
+  return null;
+}
+
+// Play audio: macOS uses afplay, Linux uses ffplay or mpg123 (whichever is installed).
 async function playAudio(audioBuffer: ArrayBuffer, volume: number = FALLBACK_VOLUME): Promise<void> {
   const tempFile = `/tmp/voice-${Date.now()}.mp3`;
 
   await Bun.write(tempFile, audioBuffer);
 
+  const player = getAudioPlayer(volume, tempFile);
+  if (!player) {
+    spawn('/bin/rm', [tempFile]);
+    throw new Error('No supported audio player found. Install ffmpeg (ffplay) or mpg123.');
+  }
+
   return new Promise((resolve, reject) => {
-    const proc = spawn('/usr/bin/afplay', ['-v', volume.toString(), tempFile]);
+    const proc = spawn(player.command, player.args);
 
     proc.on('error', (error) => {
       console.error('Error playing audio:', error);
@@ -388,7 +421,7 @@ async function playAudio(audioBuffer: ArrayBuffer, volume: number = FALLBACK_VOL
       if (code === 0) {
         resolve();
       } else {
-        reject(new Error(`afplay exited with code ${code}`));
+        reject(new Error(`${player.command} exited with code ${code}`));
       }
     });
   });

--- a/Releases/v4.0.3/.claude/VoiceServer/server.ts
+++ b/Releases/v4.0.3/.claude/VoiceServer/server.ts
@@ -448,6 +448,103 @@ function spawnSafe(command: string, args: string[]): Promise<void> {
 }
 
 // ==========================================================================
+// Cross-platform helpers
+// ==========================================================================
+
+// isWSL — single source of truth for WSL1/WSL2 detection. Shell scripts use
+// the matching `pai_is_wsl` helper in lib/platform.sh. Do NOT duplicate this
+// /proc/version read elsewhere in the TS codebase.
+function isWSL(): boolean {
+  if (process.platform !== 'linux') return false;
+  try {
+    if (!existsSync('/proc/version')) return false;
+    const content = readFileSync('/proc/version', 'utf-8');
+    return /microsoft/i.test(content);
+  } catch {
+    return false;
+  }
+}
+
+// getLogPath — absolute path to the pai-voice-server log file, respecting
+// the platform's conventional location. On macOS this is byte-identical to
+// the historical ~/Library/Logs literal so the Darwin flow is untouched.
+// server.ts currently only emits console.log; this helper exists for
+// symmetry with the shell-side pai_log_path and for future consumers
+// (status endpoint, metrics, etc.) that may need to report the log location.
+function getLogPath(): string {
+  if (process.platform === 'darwin') {
+    return join(homedir(), 'Library', 'Logs', 'pai-voice-server.log');
+  }
+  const xdgData = process.env.XDG_DATA_HOME || join(homedir(), '.local', 'share');
+  return join(xdgData, 'pai', 'logs', 'pai-voice-server.log');
+}
+
+// Resolve the desktop-notification command + arg builder for the current
+// platform. Mirrors the getAudioPlayer() shape introduced for playAudio().
+//
+// Darwin: osascript `display notification "MSG" with title "TITLE" sound
+//         name ""` — byte-identical to the pre-refactor literal at the call
+//         site so macOS behavior is preserved.
+// WSL2:   prefer wsl-notify-send when on PATH; else invoke powershell.exe
+//         with BurntToast (New-BurntToastNotification) if the module is
+//         importable; else fall back to a bare
+//         [Windows.UI.Notifications.ToastNotificationManager] one-liner that
+//         needs no module.
+// Linux:  notify-send "title" "message".
+function getNotificationCmd(
+  title: string,
+  message: string,
+): { command: string; args: string[] } {
+  if (process.platform === 'darwin') {
+    // escapeForAppleScript is applied by the caller before reaching here.
+    const script = `display notification "${message}" with title "${title}" sound name ""`;
+    return { command: '/usr/bin/osascript', args: ['-e', script] };
+  }
+
+  if (isWSL()) {
+    // Prefer the zero-friction native-ish path: wsl-notify-send if installed.
+    if (existsSync('/usr/bin/wsl-notify-send') || existsSync('/usr/local/bin/wsl-notify-send')) {
+      const bin = existsSync('/usr/bin/wsl-notify-send')
+        ? '/usr/bin/wsl-notify-send'
+        : '/usr/local/bin/wsl-notify-send';
+      return { command: bin, args: [`--category=${title}`, message] };
+    }
+
+    // Fall back to powershell.exe via WSL interop. Escape embedded single
+    // quotes for PowerShell by doubling them.
+    const psEscape = (s: string) => s.replace(/'/g, "''");
+    const pTitle = psEscape(title);
+    const pMessage = psEscape(message);
+
+    // Prefer BurntToast when available (widely installed), otherwise fall
+    // back to the bare WinRT ToastNotificationManager one-liner. The `try`
+    // block exits 0 on either path; stderr from Import-Module is swallowed.
+    const script =
+      `$ErrorActionPreference='SilentlyContinue';` +
+      `if (Get-Module -ListAvailable -Name BurntToast) {` +
+      `  Import-Module BurntToast;` +
+      `  New-BurntToastNotification -Text '${pTitle}','${pMessage}'` +
+      `} else {` +
+      `  [Windows.UI.Notifications.ToastNotificationManager,Windows.UI.Notifications,ContentType=WindowsRuntime] | Out-Null;` +
+      `  $template = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02);` +
+      `  $texts = $template.GetElementsByTagName('text');` +
+      `  $texts.Item(0).AppendChild($template.CreateTextNode('${pTitle}')) | Out-Null;` +
+      `  $texts.Item(1).AppendChild($template.CreateTextNode('${pMessage}')) | Out-Null;` +
+      `  $toast = [Windows.UI.Notifications.ToastNotification]::new($template);` +
+      `  [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('PAI').Show($toast)` +
+      `}`;
+
+    return {
+      command: '/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe',
+      args: ['-NoProfile', '-NonInteractive', '-Command', script],
+    };
+  }
+
+  // Plain Linux desktop.
+  return { command: '/usr/bin/notify-send', args: [title, message] };
+}
+
+// ==========================================================================
 // Core: Send notification with 3-tier voice settings resolution
 // ==========================================================================
 
@@ -545,13 +642,20 @@ async function sendNotification(
     }
   }
 
-  // Display macOS notification (can be disabled via settings.json: notifications.desktop.enabled: false)
+  // Display desktop notification (can be disabled via settings.json: notifications.desktop.enabled: false)
+  // Darwin: osascript display notification (byte-identical to pre-refactor path).
+  // Linux:  notify-send.
+  // WSL2:   wsl-notify-send or powershell.exe BurntToast / ToastNotificationManager.
   if (voiceConfig.desktopNotifications) {
     try {
+      // escapeForAppleScript double-escapes backslashes and quotes — safe for
+      // the Darwin osascript branch. On non-Darwin branches the escaped form
+      // is harmless since notify-send/PowerShell receive the strings as
+      // separate argv entries.
       const escapedTitle = escapeForAppleScript(safeTitle);
       const escapedMessage = escapeForAppleScript(safeMessage);
-      const script = `display notification "${escapedMessage}" with title "${escapedTitle}" sound name ""`;
-      await spawnSafe('/usr/bin/osascript', ['-e', script]);
+      const notifyCmd = getNotificationCmd(escapedTitle, escapedMessage);
+      await spawnSafe(notifyCmd.command, notifyCmd.args);
     } catch (error) {
       console.error("Notification display error:", error);
     }

--- a/Releases/v4.0.3/.claude/VoiceServer/start.sh
+++ b/Releases/v4.0.3/.claude/VoiceServer/start.sh
@@ -2,9 +2,12 @@
 
 # Start the Voice Server
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# shellcheck source=lib/platform.sh
+. "$SCRIPT_DIR/lib/platform.sh"
+
 SERVICE_NAME="com.pai.voice-server"
 PLIST_PATH="$HOME/Library/LaunchAgents/${SERVICE_NAME}.plist"
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Colors
 RED='\033[0;31m'
@@ -42,7 +45,7 @@ if [ $? -eq 0 ]; then
         echo "  Test: curl -X POST http://localhost:8888/notify -H 'Content-Type: application/json' -d '{\"message\":\"Test\"}'"
     else
         echo -e "${YELLOW}! Server started but not responding yet${NC}"
-        echo "  Check logs: tail -f ~/Library/Logs/pai-voice-server.log"
+        echo "  Check logs: tail -f $(pai_log_path)"
     fi
 else
     echo -e "${RED}X Failed to start voice server${NC}"

--- a/Releases/v4.0.3/.claude/VoiceServer/status.sh
+++ b/Releases/v4.0.3/.claude/VoiceServer/status.sh
@@ -2,9 +2,13 @@
 
 # Check status of Voice Server
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# shellcheck source=lib/platform.sh
+. "$SCRIPT_DIR/lib/platform.sh"
+
 SERVICE_NAME="com.pai.voice-server"
 PLIST_PATH="$HOME/Library/LaunchAgents/${SERVICE_NAME}.plist"
-LOG_PATH="$HOME/Library/Logs/pai-voice-server.log"
+LOG_PATH="$(pai_log_path)"
 ENV_FILE="$HOME/.env"
 
 # Colors
@@ -45,13 +49,21 @@ else
     echo -e "  ${RED}X Server is not responding${NC}"
 fi
 
-# Check port binding
+# Check port binding — pai_port_pids cascades lsof > ss > netstat.
 echo
 echo -e "${BLUE}Port Status:${NC}"
-if lsof -i :8888 > /dev/null 2>&1; then
-    PROCESS=$(lsof -i :8888 | grep LISTEN | head -1)
+PORT_PIDS=$(pai_port_pids 8888 || true)
+if [ -n "$PORT_PIDS" ]; then
     echo -e "  ${GREEN}OK Port 8888 is in use${NC}"
-    echo "$PROCESS" | awk '{print "  Process: " $1 " (PID: " $2 ")"}'
+    for pid in $PORT_PIDS; do
+        PNAME=""
+        if [ -r "/proc/$pid/comm" ]; then
+            PNAME=$(cat "/proc/$pid/comm" 2>/dev/null || true)
+        elif command -v ps >/dev/null 2>&1; then
+            PNAME=$(ps -p "$pid" -o comm= 2>/dev/null || true)
+        fi
+        echo "  Process: ${PNAME:-unknown} (PID: $pid)"
+    done
 else
     echo -e "  ${YELLOW}! Port 8888 is not in use${NC}"
 fi

--- a/Releases/v4.0.3/.claude/VoiceServer/stop.sh
+++ b/Releases/v4.0.3/.claude/VoiceServer/stop.sh
@@ -2,6 +2,10 @@
 
 # Stop the Voice Server
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# shellcheck source=lib/platform.sh
+. "$SCRIPT_DIR/lib/platform.sh"
+
 SERVICE_NAME="com.pai.voice-server"
 PLIST_PATH="$HOME/Library/LaunchAgents/${SERVICE_NAME}.plist"
 
@@ -28,9 +32,12 @@ else
     echo -e "${YELLOW}! Voice server is not running${NC}"
 fi
 
-# Kill any remaining processes on port 8888
-if lsof -i :8888 > /dev/null 2>&1; then
+# Kill any remaining processes on port 8888 — uses pai_port_pids which
+# cascades lsof > ss > netstat for cross-platform coverage.
+PORT_PIDS=$(pai_port_pids 8888 || true)
+if [ -n "$PORT_PIDS" ]; then
     echo -e "${YELLOW}> Cleaning up port 8888...${NC}"
-    lsof -ti :8888 | xargs kill -9 2>/dev/null
+    # shellcheck disable=SC2086
+    kill -9 $PORT_PIDS 2>/dev/null || true
     echo -e "${GREEN}OK Port 8888 cleared${NC}"
 fi

--- a/Releases/v4.0.3/.claude/VoiceServer/uninstall.sh
+++ b/Releases/v4.0.3/.claude/VoiceServer/uninstall.sh
@@ -2,9 +2,13 @@
 
 # Uninstall Voice Server
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# shellcheck source=lib/platform.sh
+. "$SCRIPT_DIR/lib/platform.sh"
+
 SERVICE_NAME="com.pai.voice-server"
 PLIST_PATH="$HOME/Library/LaunchAgents/${SERVICE_NAME}.plist"
-LOG_PATH="$HOME/Library/Logs/pai-voice-server.log"
+LOG_PATH="$(pai_log_path)"
 
 # Colors
 RED='\033[0;31m'
@@ -51,10 +55,13 @@ else
     echo -e "${YELLOW}  LaunchAgent file not found${NC}"
 fi
 
-# Kill any remaining processes
-if lsof -i :8888 > /dev/null 2>&1; then
+# Kill any remaining processes on port 8888 — pai_port_pids cascades
+# lsof > ss > netstat for cross-platform coverage.
+PORT_PIDS=$(pai_port_pids 8888 || true)
+if [ -n "$PORT_PIDS" ]; then
     echo -e "${YELLOW}> Cleaning up port 8888...${NC}"
-    lsof -ti :8888 | xargs kill -9 2>/dev/null
+    # shellcheck disable=SC2086
+    kill -9 $PORT_PIDS 2>/dev/null || true
     echo -e "${GREEN}OK Port 8888 cleared${NC}"
 fi
 


### PR DESCRIPTION
Extends the getAudioPlayer() pattern from #1061 to cover three more
macOS-only assumptions that fail on Linux and WSL2:

1. sendNotification() hardcoded /usr/bin/osascript — ENOENT on Linux/WSL.
2. Six scripts hardcode ~/Library/Logs/pai-voice-server.log — writes to
   a non-standard location on Linux/WSL.
3. status.sh/stop.sh/uninstall.sh gate port checks on lsof — silently
   report "port not in use" when lsof is absent (common on Linux images).

Adds three TS helpers in server.ts (isWSL, getLogPath, getNotificationCmd)
that mirror the getAudioPlayer() shape, plus a shared lib/platform.sh
with pai_is_wsl / pai_log_path / pai_port_pids for the shell side.

getNotificationCmd routing:
  darwin -> /usr/bin/osascript (literal AppleScript preserved byte-identical)
  wsl2   -> wsl-notify-send if on PATH, else powershell.exe with
            BurntToast (if module importable) or bare
            [Windows.UI.Notifications.ToastNotificationManager] one-liner
  linux  -> /usr/bin/notify-send

pai_port_pids cascades lsof -> ss -> netstat.
pai_log_path uses ${XDG_DATA_HOME:-$HOME/.local/share}/pai/logs on Linux/WSL.

Verified on Ubuntu 24.04 / WSL2:
- bun bundles server.ts cleanly.
- All three port-check branches (lsof, ss-only, netstat-only) correctly
  report pai-voice's live PID against a running pai-voice.service.
- isWSL() = true, getLogPath() = ~/.local/share/pai/logs/pai-voice-server.log,
  getNotificationCmd() emits the powershell.exe BurntToast/WinRT one-liner
  which returns exit 0 and delivers a toast into the Windows notification
  queue (visually confirmed).

Darwin paths are preserved byte-identically and were NOT exercised on
hardware (author has no Mac). Please review the darwin branches
carefully — they are intentionally line-for-line equal to the
pre-refactor literals.

### Stacking on #1061

This branch is stacked on top of #1061 (cross-platform audio playback).
Because that base branch only exists on the fork, this PR targets
`main` directly; GitHub will show the combined diff until #1061 merges,
at which point the diff will collapse to only the changes introduced
here. If #1061 is merged first, no rebase is required — the merge is
already clean against main.