### PR TITLE
fix(install): loud dependency failures for jq, audio, and pdftotext

### DIFF
--- a/Releases/v4.0.3/.claude/PAI-Install/install.sh
+++ b/Releases/v4.0.3/.claude/PAI-Install/install.sh
@@ -77,6 +77,22 @@ case "$OS" in
   *)      error "Unsupported platform: $OS"; exit 1 ;;
 esac
 
+# ─── Package Manager Detection ────────────────────────────
+# Probe in preference order: brew (macOS), apt-get, dnf, yum.
+# PKG_MGR is later used by the dependency-install branches and
+# by the runtime dependency check to print actionable hints.
+PKG_MGR="unknown"
+if command -v brew &>/dev/null; then
+  PKG_MGR="brew"
+elif command -v apt-get &>/dev/null; then
+  PKG_MGR="apt-get"
+elif command -v dnf &>/dev/null; then
+  PKG_MGR="dnf"
+elif command -v yum &>/dev/null; then
+  PKG_MGR="yum"
+fi
+info "Package manager: $PKG_MGR"
+
 # ─── Check curl ───────────────────────────────────────────
 if ! command -v curl &>/dev/null; then
   error "curl is required but not found."
@@ -86,6 +102,11 @@ fi
 success "curl found"
 
 # ─── Check/Install Git ───────────────────────────────────
+# Linux branches no longer swallow installer stderr with `2>/dev/null`
+# so real package-manager errors (missing repos, auth failures, locked
+# dpkg, etc.) surface to the user instead of silently leaving git
+# missing. Unknown package managers fail loudly with a manual-install
+# hint. The Darwin branch is preserved byte-identical.
 if command -v git &>/dev/null; then
   success "Git found: $(git --version 2>&1 | head -1)"
 else
@@ -100,26 +121,41 @@ else
       exit 1
     fi
   elif [[ "$OS" == "Linux" ]]; then
-    if command -v apt-get &>/dev/null; then
-      sudo apt-get install -y git 2>/dev/null || warn "Could not install Git"
-    elif command -v yum &>/dev/null; then
-      sudo yum install -y git 2>/dev/null || warn "Could not install Git"
-    fi
+    case "$PKG_MGR" in
+      apt-get)
+        sudo apt-get install -y git || { error "apt-get failed to install git"; exit 1; }
+        ;;
+      dnf)
+        sudo dnf install -y git || { error "dnf failed to install git"; exit 1; }
+        ;;
+      yum)
+        sudo yum install -y git || { error "yum failed to install git"; exit 1; }
+        ;;
+      *)
+        error "Git not found and no supported package manager detected."
+        echo "  Please install git manually (e.g. from https://git-scm.com/downloads) and re-run this script."
+        exit 1
+        ;;
+    esac
   fi
 
   if command -v git &>/dev/null; then
     success "Git installed: $(git --version 2>&1 | head -1)"
   else
-    warn "Git could not be installed automatically. Please install it manually."
+    error "Git could not be installed automatically. Please install it manually."
+    exit 1
   fi
 fi
 
 # ─── Check/Install Bun ───────────────────────────────────
+# The previous `bash 2>/dev/null` swallowed real installer errors
+# (network failures, architecture mismatches, missing unzip on some
+# Linux distros). Drop the redirect so problems are visible.
 if command -v bun &>/dev/null; then
   success "Bun found: v$(bun --version 2>/dev/null || echo 'unknown')"
 else
   info "Installing Bun runtime..."
-  curl -fsSL https://bun.sh/install | bash 2>/dev/null
+  curl -fsSL https://bun.sh/install | bash
 
   # Add to PATH for this session
   export PATH="$HOME/.bun/bin:$PATH"
@@ -138,6 +174,70 @@ if command -v claude &>/dev/null; then
 else
   warn "Claude Code not found — will install during setup"
 fi
+
+# ─── Runtime Dependency Check ─────────────────────────────
+# Loudly verify the runtime tools PAI relies on (tracked in
+# https://github.com/danielmiessler/Personal_AI_Infrastructure/issues/1065).
+# Missing tools print a package-manager-specific install hint and
+# cause the installer to exit non-zero so problems are caught before
+# users hit them at runtime.
+MISSING_DEPS=()
+
+check_dep() {
+  # check_dep <label> <cmd1> [cmd2 ...]
+  # Passes if any of the supplied commands exist on PATH.
+  local label="$1"; shift
+  local cmd
+  for cmd in "$@"; do
+    if command -v "$cmd" &>/dev/null; then
+      success "$label found ($cmd)"
+      return 0
+    fi
+  done
+  error "$label not found (checked: $*)"
+  MISSING_DEPS+=("$label")
+  return 1
+}
+
+info "Checking runtime dependencies..."
+check_dep "jq" jq || true
+check_dep "audio player (mpg123 or ffplay)" mpg123 ffplay || true
+check_dep "pdftotext (poppler-utils)" pdftotext || true
+
+if [ ${#MISSING_DEPS[@]} -gt 0 ]; then
+  echo ""
+  error "Missing runtime dependencies: ${MISSING_DEPS[*]}"
+  echo ""
+  case "$PKG_MGR" in
+    brew)
+      echo "  Install with Homebrew:"
+      echo "    brew install jq mpg123 poppler"
+      ;;
+    apt-get)
+      echo "  Install with apt-get:"
+      echo "    sudo apt-get install -y jq mpg123 poppler-utils"
+      ;;
+    dnf)
+      echo "  Install with dnf:"
+      echo "    sudo dnf install -y jq mpg123 poppler-utils"
+      ;;
+    yum)
+      echo "  Install with yum:"
+      echo "    sudo yum install -y jq mpg123 poppler-utils"
+      ;;
+    *)
+      echo "  No supported package manager detected. Install these manually:"
+      echo "    - jq:         https://stedolan.github.io/jq/"
+      echo "    - mpg123:     https://www.mpg123.de/  (or ffmpeg for ffplay)"
+      echo "    - pdftotext:  part of poppler-utils / https://poppler.freedesktop.org/"
+      ;;
+  esac
+  echo ""
+  echo "  See: https://github.com/danielmiessler/Personal_AI_Infrastructure/issues/1065"
+  echo ""
+  exit 1
+fi
+success "All runtime dependencies found"
 
 # ─── Launch Installer ────────────────────────────────────
 # Resolve PAI-Install directory (may be sibling or child of script location)

--- a/Releases/v4.0.3/.claude/statusline-command.sh
+++ b/Releases/v4.0.3/.claude/statusline-command.sh
@@ -18,6 +18,11 @@
 
 set -o pipefail
 
+if ! command -v jq >/dev/null 2>&1; then
+  echo "PAI statusline: jq not found. Install with: sudo apt-get install -y jq (or brew install jq)"
+  exit 0
+fi
+
 # ─────────────────────────────────────────────────────────────────────────────
 # CONFIGURATION
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`install.sh` previously hid package-manager errors behind
`2>/dev/null` and silently skipped runtime tools PAI actually needs,
so users on Linux/WSL hit cryptic failures well after install claimed
to succeed. This PR makes those failures loud and actionable.

### install.sh (`Releases/v4.0.3/.claude/PAI-Install/install.sh`)

- **Package manager detection prelude** — probes `brew`, `apt-get`,
  `dnf`, `yum` in that order and sets `PKG_MGR` (or `unknown`).
  Shared by the install branches and the dependency hints.
- **Loud git install** — unknown package manager now exits 1 with a
  manual-install pointer instead of silently warning; apt/dnf/yum
  errors propagate. **The Darwin/brew path is preserved
  byte-identical** (no Mac available for testing — please verify on
  review).
- **Loud bun install** — the `curl ... | bash 2>/dev/null` no longer
  swallows installer errors (network failures, missing unzip, arch
  mismatches).
- **Runtime dependency check** — a new `check_dep` helper verifies
  `jq`, `mpg123 OR ffplay`, and `pdftotext` before the installer
  hands off to `main.ts`. Missing deps print a per-package-manager
  install command and link #1065.

### statusline-command.sh (`Releases/v4.0.3/.claude/statusline-command.sh`)

- Early guard after `set -o pipefail`: if `jq` is missing, print an
  install hint and `exit 0`. The statusline is decorative and a
  non-zero exit would block Claude Code sessions — the actionable
  message is what closes the bug for affected users.

## Test plan

- [x] `bash -n` on both files
- [x] Synthetic PATH isolation with `jq` removed: `install.sh` exits
      non-zero, names the missing deps, prints per-PKG_MGR hints
      (unknown branch tested), and links #1065.
- [x] Synthetic happy path with all deps + `apt-get` in PATH:
      dep check passes, success banner prints, installer proceeds.
- [x] `statusline-command.sh` with `jq` masked: prints the install
      hint, exits 0.
- [x] `git diff main...` shows exactly the two files.
- [ ] Darwin reviewer sanity-check: git install branch is unchanged
      from before this PR.

Fixes #1065