### PR TITLE
fix(installer): make PAI-Install headless-safe on Linux

### DIFF
--- a/Releases/v4.0.3/.claude/PAI-Install/install.sh
+++ b/Releases/v4.0.3/.claude/PAI-Install/install.sh
@@ -154,8 +154,11 @@ fi
 info "Launching installer..."
 echo ""
 
-# Auto-detect headless/SSH environments and fall back to CLI mode
-if [ -z "$DISPLAY" ] && [ -z "$WAYLAND_DISPLAY" ] && [ "$(uname)" != "Darwin" ]; then
+# Auto-detect headless/SSH environments and fall back to CLI mode.
+# Use ${VAR:-} to tolerate `set -u` (nounset, enabled on line 8) — on SSH/headless
+# Linux hosts DISPLAY and WAYLAND_DISPLAY are typically unset, which would abort
+# the script before the detection runs.
+if [ -z "${DISPLAY:-}" ] && [ -z "${WAYLAND_DISPLAY:-}" ] && [ "$(uname)" != "Darwin" ]; then
     INSTALL_MODE="cli"
     info "Headless environment detected — using CLI installer."
 else

--- a/Releases/v4.0.3/.claude/PAI-Install/main.ts
+++ b/Releases/v4.0.3/.claude/PAI-Install/main.ts
@@ -15,7 +15,18 @@ import { existsSync } from "fs";
 
 const args = process.argv.slice(2);
 const modeIdx = args.indexOf("--mode");
-const mode = modeIdx >= 0 ? args[modeIdx + 1] : "gui";
+
+// Auto-detect headless (no DISPLAY/WAYLAND_DISPLAY on non-Darwin) when --mode
+// is omitted. install.sh already does this when invoked via bash, but running
+// main.ts directly (e.g. `bun PAI-Install/main.ts`) bypassed that check and
+// unconditionally launched the Electron GUI, which fails on headless Linux.
+function defaultMode(): "gui" | "cli" {
+  if (process.platform === "darwin") return "gui";
+  if (!process.env.DISPLAY && !process.env.WAYLAND_DISPLAY) return "cli";
+  return "gui";
+}
+
+const mode = modeIdx >= 0 ? args[modeIdx + 1] : defaultMode();
 
 const ROOT = import.meta.dir;
 


### PR DESCRIPTION
Two regressions prevented the installer from running on headless / SSH Linux hosts (no X11/Wayland):

1. install.sh:158 — referenced bare $DISPLAY / $WAYLAND_DISPLAY under `set -euo pipefail`. nounset aborted the script before the headless fallback could run. Fixed by using ${DISPLAY:-} / ${WAYLAND_DISPLAY:-}. Observed error: `install.sh: line 158: DISPLAY: unbound variable`.

2. main.ts:18 — mode defaulted to "gui" when --mode was omitted, so running `bun PAI-Install/main.ts` directly bypassed install.sh's headless detection and spawned Electron. Added a defaultMode() helper that returns "cli" on non-Darwin hosts without DISPLAY/WAYLAND_DISPLAY.

Also fixes: `bun PAI-Install/main.ts` no longer tries to `npm install` electron on hosts that can never run it.