### PR TITLE
fix(v4.0.3): hide nested sub-skills from / menu via user-invocable: false

### DIFF
--- a/Releases/v4.0.3/.claude/PAI/SKILLSYSTEM.md
+++ b/Releases/v4.0.3/.claude/PAI/SKILLSYSTEM.md
@@ -40,6 +40,66 @@ If a skill does not follow this structure, it is not properly configured and wil
 
 ---
 
+## Sub-Skill Frontmatter (MANDATORY)
+
+**Every nested sub-skill `SKILL.md` MUST set `user-invocable: false`
+in its YAML frontmatter.**
+
+### Why
+
+Claude Code auto-indexes every `SKILL.md` file in the `skills/` tree
+and advertises each one as an invokable slash-command tip. PAI
+organizes skills hierarchically — a top-level `SKILL.md` is
+user-invokable, but sub-skills nested underneath are routed to by
+the parent's Workflow Routing table and are NOT meant to be invoked
+by the user directly. Without the `user-invocable: false` flag,
+Claude Code advertises broken tips like `/annual-reports` that do
+not work when the user tries them, eroding trust in every tip the
+system emits.
+
+The `user-invocable: false` frontmatter field is the spec-blessed
+mechanism for this. From the Claude Code Skills documentation:
+
+> `user-invocable` — Set to `false` to hide from the `/` menu. Use
+> for background knowledge users shouldn't invoke directly.
+> Default: `true`.
+
+Reference: https://code.claude.com/docs/en/skills (Frontmatter
+reference table).
+
+### Correct frontmatter for a nested sub-skill
+
+```yaml
+---
+name: AnnualReports
+description: [...]. USE WHEN annual reports, security trends, [...].
+user-invocable: false
+---
+```
+
+### Rule
+
+- **Top-level skills** (`skills/<Name>/SKILL.md`): no
+  `user-invocable` field (defaults to `true`, user-invokable).
+- **Nested sub-skills** (`skills/<Parent>/<SubSkill>/SKILL.md` and
+  deeper): MUST include `user-invocable: false`.
+
+Parent skill routing tables continue to reference sub-skill paths
+as before — `user-invocable: false` hides the skill from the `/`
+menu but does not prevent Claude from reading the file when
+directed by the parent.
+
+### Validator check
+
+```bash
+# Every nested SKILL.md must contain `user-invocable: false`
+find ~/.claude/skills -mindepth 3 -name SKILL.md \
+  -exec grep -L '^user-invocable: false$' {} +
+# MUST return empty.
+```
+
+---
+
 ## Personal vs System Skills (CRITICAL)
 
 **Skills are classified into two categories:**

--- a/Releases/v4.0.3/.claude/skills/ContentAnalysis/ExtractWisdom/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/ContentAnalysis/ExtractWisdom/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ExtractWisdom
 description: Content-adaptive wisdom extraction — detects what domains exist in content and builds custom sections (not static IDEAS/QUOTES). Produces tailored insight reports from videos, podcasts, articles. USE WHEN extract wisdom, analyze video, analyze podcast, extract insights, what's interesting, extract from YouTube, what did I miss, key takeaways.
+user-invocable: false
 ---
 
 ## Customization

--- a/Releases/v4.0.3/.claude/skills/Investigation/OSINT/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Investigation/OSINT/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: OSINT
 description: Structured OSINT investigations — people lookup, company intel, investment due diligence, entity/threat intel, domain recon, organization research using public sources with ethical authorization framework. USE WHEN OSINT, due diligence, background check, research person, company intel, investigate, company lookup, domain lookup, entity lookup, organization lookup, threat intel, discover OSINT sources.
+user-invocable: false
 ---
 
 ## Customization

--- a/Releases/v4.0.3/.claude/skills/Investigation/PrivateInvestigator/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Investigation/PrivateInvestigator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: PrivateInvestigator
 description: Ethical people-finding using 15 parallel research agents (45 search threads) across public records, social media, reverse lookups. Public data only, no pretexting. USE WHEN find person, locate, reconnect, people search, skip trace, reverse lookup, social media search, public records search, verify identity.
+user-invocable: false
 ---
 
 ## Customization

--- a/Releases/v4.0.3/.claude/skills/Media/Art/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Media/Art/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: Art
 description: Generate illustrations, technical diagrams, mermaid flowcharts, infographics, header images, thumbnails, comics, and PAI pack icons using multiple rendering backends. USE WHEN art, header images, visualizations, mermaid, flowchart, technical diagram, infographic, PAI icon, pack icon, YouTube thumbnails, ad hoc thumbnails, annotated screenshots, aphorisms, comics, comparisons, D3 dashboards, embossed logo wallpaper, essay illustration, frameworks, maps, recipe cards, remove background, stats, taxonomies, timelines, brand wallpaper, visualize, generate image, Midjourney, compose thumbnail, generate prompt.
+user-invocable: false
 ---
 
 # Art Skill

--- a/Releases/v4.0.3/.claude/skills/Media/Remotion/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Media/Remotion/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: Remotion
 description: Programmatic video creation with React via Remotion — compositions, animations, motion graphics, rendered to MP4. USE WHEN video, animation, motion graphics, video rendering, React video, intro video, YouTube video, TikTok video, video production, render video, content to animation, animate content, video overlay.
+user-invocable: false
 ---
 
 ## 🚨 MANDATORY: Voice Notification (REQUIRED BEFORE ANY ACTION)

--- a/Releases/v4.0.3/.claude/skills/Scraping/Apify/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Scraping/Apify/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: Apify
 description: Social media scraping, business data, e-commerce via Apify actors — with auto-update workflow for actor catalog. USE WHEN Twitter, Instagram, LinkedIn, TikTok, YouTube, Facebook, Google Maps, Amazon scraping, Apify, update Apify actors, social media scraping, lead generation, web scraper.
+user-invocable: false
 ---
 
 ## Customization

--- a/Releases/v4.0.3/.claude/skills/Scraping/BrightData/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Scraping/BrightData/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: BrightData
 description: 4-tier progressive URL scraping and multi-page crawling — WebFetch, then Chrome-header curl, then Playwright browser, then Bright Data proxy. Auto-escalates when lower tiers fail. USE WHEN Bright Data, scrape URL, web scraping, site blocking me, can't access, bot detection, crawl site, crawl pages, spider, CAPTCHA, four tier scrape, progressive scraping, Chrome headers.
+user-invocable: false
 ---
 
 ## Customization

--- a/Releases/v4.0.3/.claude/skills/Security/AnnualReports/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Security/AnnualReports/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: AnnualReports
 description: Aggregate and analyze annual security reports from major vendors — extract trends, compare threat landscapes year-over-year, produce synthesized threat intelligence summaries. Fetch, list, and update report sources. USE WHEN annual reports, security reports, threat reports, industry reports, vendor reports, threat landscape, fetch report, list sources, update sources.
+user-invocable: false
 ---
 
 ## Customization

--- a/Releases/v4.0.3/.claude/skills/Security/PromptInjection/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Security/PromptInjection/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: PromptInjection
 description: Test LLM applications for prompt injection vulnerabilities — jailbreak attempts, system prompt extraction, context manipulation, guardrail bypass techniques, direct injection, indirect injection, multi-stage attacks, and reconnaissance. USE WHEN prompt injection, jailbreak, LLM security, AI security assessment, pentest AI application, test chatbot, guardrail bypass, direct injection, indirect injection, RAG poisoning, multi-stage attack, complete assessment, reconnaissance.
+user-invocable: false
 ---
 
 ## Customization

--- a/Releases/v4.0.3/.claude/skills/Security/Recon/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Security/Recon/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: Recon
 description: Network reconnaissance — subdomain enumeration, port scanning, DNS/WHOIS/ASN lookups, endpoint discovery from JS, mass scanning, path discovery, CIDR/netblock analysis. Passive and active modes with corporate structure mapping and bounty program tracking. USE WHEN recon, reconnaissance, bug bounty, bounty programs, attack surface, subdomains, subdomain enumeration, port scan, mass scan, DNS, WHOIS, ASN, CIDR, netblock, IP recon, domain recon, passive recon, corporate structure, endpoint discovery, path discovery, scan results, analyze scan, update tools.
+user-invocable: false
 ---
 
 ## Customization

--- a/Releases/v4.0.3/.claude/skills/Security/SECUpdates/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Security/SECUpdates/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: SECUpdates
 description: Security news from tldrsec, no.security, Krebs, Schneier, and other sources. USE WHEN security news, security updates, what's new in security, breaches, security research, sec updates, tldrsec, Krebs, Schneier.
+user-invocable: false
 ---
 
 ## Customization

--- a/Releases/v4.0.3/.claude/skills/Security/WebAssessment/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Security/WebAssessment/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: WebAssessment
 description: Full web app security assessment — app understanding, threat modeling, OWASP testing, ffuf fuzzing, Playwright automation, AI-assisted vuln analysis. Coordinates with Recon and PromptInjection skills. USE WHEN web assessment, pentest, security testing, vulnerability scan, threat model app, understand application, create threat model, vulnerability analysis, Gemini analysis, ffuf, fuzzing, bug bounty, OSINT, browser automation, Playwright.
+user-invocable: false
 ---
 
 ## Customization

--- a/Releases/v4.0.3/.claude/skills/Thinking/BeCreative/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Thinking/BeCreative/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: BeCreative
 description: Divergent ideation via Verbalized Sampling + extended thinking (1.6-2.1x diversity). USE WHEN be creative, deep thinking, brainstorm, divergent ideas, creative solutions, maximum creativity, tree of thoughts, idea generation, domain specific creativity, technical creativity, standard creativity.
+user-invocable: false
 ---
 
 ## Customization

--- a/Releases/v4.0.3/.claude/skills/Thinking/Council/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Thinking/Council/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: Council
 description: Multi-agent debate with visible transcripts where agents respond to each other. USE WHEN council, debate, perspectives, weigh options, deliberate, multiple viewpoints. Unlike RedTeam (adversarial), Council is collaborative-adversarial.
+user-invocable: false
 ---
 
 ## Customization

--- a/Releases/v4.0.3/.claude/skills/Thinking/FirstPrinciples/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Thinking/FirstPrinciples/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: FirstPrinciples
 description: Decompose to axioms, challenge inherited assumptions, reconstruct from verified truths. USE WHEN first principles, fundamental, root cause, decompose, challenge assumptions, rebuild from scratch.
+user-invocable: false
 ---
 
 ## Customization

--- a/Releases/v4.0.3/.claude/skills/Thinking/IterativeDepth/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Thinking/IterativeDepth/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: IterativeDepth
 description: 2-8 scientific lens passes to surface hidden requirements single-pass analysis misses. USE WHEN iterative depth, deep exploration, multi-angle analysis, multiple perspectives, examine from angles, surface hidden requirements.
+user-invocable: false
 ---
 
 ## Customization

--- a/Releases/v4.0.3/.claude/skills/Thinking/RedTeam/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Thinking/RedTeam/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: RedTeam
 description: 32 adversarial agents to destroy weak arguments and find fatal flaws — parallel analysis and adversarial validation. USE WHEN red team, attack idea, counterarguments, critique, stress test, poke holes, devil's advocate, find weaknesses, break this, parallel analysis, adversarial validation.
+user-invocable: false
 ---
 
 ## Customization

--- a/Releases/v4.0.3/.claude/skills/Thinking/Science/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Thinking/Science/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: Science
 description: Hypothesis-test-analyze cycles for systematic problem-solving — the meta-skill governing all others. Includes define goal, generate hypotheses, design experiment, measure results, analyze results, iterate, full cycle, quick diagnosis, and structured investigation. USE WHEN think about, figure out, try approaches, experiment with, iterate on, improve, optimize, define goal, generate hypotheses, design experiment, measure results, analyze results, full cycle, quick diagnosis, structured investigation, science, hypothesis.
+user-invocable: false
 ---
 
 ## Customization

--- a/Releases/v4.0.3/.claude/skills/Thinking/WorldThreatModelHarness/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Thinking/WorldThreatModelHarness/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: WorldThreatModelHarness
 description: Stress-test ideas, strategies, and investments across 11 time horizons (6mo-50yr). Update and view world models. USE WHEN threat model, world model, test idea, test strategy, future analysis, test investment, test against future, stress test idea, time horizon analysis, update models, view models, refresh models, model status.
+user-invocable: false
 ---
 
 # World Threat Model Harness

--- a/Releases/v4.0.3/.claude/skills/Utilities/Aphorisms/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Utilities/Aphorisms/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: Aphorisms
 description: CRUD on {PRINCIPAL.NAME}'s curated aphorism collection — search by theme, add with metadata, research thinkers, match quotes to newsletter content. USE WHEN aphorism, quote, saying, find quote for newsletter, research thinker quotes, add aphorism, search aphorisms, find aphorism.
+user-invocable: false
 ---
 
 ## Customization

--- a/Releases/v4.0.3/.claude/skills/Utilities/AudioEditor/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Utilities/AudioEditor/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: AudioEditor
 description: AI-powered audio/video editing — transcription, intelligent cut detection, automated editing with crossfades, and optional cloud polish. USE WHEN clean audio, edit audio, remove filler words, clean podcast, remove ums, fix audio, cut dead air, polish audio, clean recording, transcribe and edit.
+user-invocable: false
 ---
 
 # AudioEditor

--- a/Releases/v4.0.3/.claude/skills/Utilities/Browser/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Utilities/Browser/SKILL.md
@@ -2,6 +2,7 @@
 name: Browser
 description: Visual verification and browser automation via Playwright. Headless or headed Chrome. USE WHEN browser, screenshot, debug web, verify UI, troubleshoot frontend, automate browser, browse website, review stories, run stories, recipe, web automation.
 version: 3.3.0
+user-invocable: false
 ---
 
 ## Customization

--- a/Releases/v4.0.3/.claude/skills/Utilities/Cloudflare/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Utilities/Cloudflare/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: Cloudflare
 description: Deploy and manage Cloudflare Workers, Pages, and services via Code Mode MCP (API queries) + wrangler (deploys). OAuth auth for wrangler (tokens lack Pages perms). USE WHEN Cloudflare, worker, deploy, Pages, MCP server, wrangler, DNS, KV, R2, D1, Vectorize.
+user-invocable: false
 ---
 
 ## Customization

--- a/Releases/v4.0.3/.claude/skills/Utilities/CreateCLI/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Utilities/CreateCLI/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: CreateCLI
 description: Generate production-ready TypeScript CLIs with 3-tier template system (simple argv, yargs, oclif), type safety, error handling, and documentation. USE WHEN create CLI, build CLI, command-line tool, wrap API, add command, upgrade tier, TypeScript CLI.
+user-invocable: false
 ---
 
 ## Customization

--- a/Releases/v4.0.3/.claude/skills/Utilities/CreateSkill/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Utilities/CreateSkill/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: CreateSkill
 description: Scaffold new PAI skills with proper YAML front matter, TitleCase naming, flat folder structure (SKILL.md + Workflows/ + Tools/), and validation against SkillSystem.md. USE WHEN create skill, new skill, skill structure, canonicalize, validate skill, update skill, fix skill structure, scaffold skill.
+user-invocable: false
 ---
 
 ## Customization

--- a/Releases/v4.0.3/.claude/skills/Utilities/CreateSkill/Workflows/CanonicalizeSkill.md
+++ b/Releases/v4.0.3/.claude/skills/Utilities/CreateSkill/Workflows/CanonicalizeSkill.md
@@ -144,6 +144,36 @@ skills/OSINT/Workflows/CompanyDueDiligence.md
 
 **Rule:** If you need to organize many files, use clear filenames NOT subdirectories.
 
+### Nested Sub-Skill Frontmatter
+
+**Every nested `SKILL.md` (depth ≥ 2) MUST set `user-invocable: false`
+in its YAML frontmatter.**
+
+```bash
+# Every nested SKILL.md must have the flag
+find ~/.claude/skills -mindepth 3 -name SKILL.md \
+  -exec grep -L '^user-invocable: false$' {} +
+# MUST return empty.
+```
+
+Why: Claude Code auto-indexes every `SKILL.md` and advertises each
+as a `/slash-command` tip. Nested sub-skills are routed to by the
+parent, not invoked by the user, so they must be hidden from the `/`
+menu via the `user-invocable: false` frontmatter field.
+
+When canonicalizing a nested sub-skill, add the field to its
+frontmatter if missing:
+
+```yaml
+---
+name: SubSkillName
+description: [...]
+user-invocable: false
+---
+```
+
+See `PAI/SKILLSYSTEM.md § Sub-Skill Frontmatter` for the full rule.
+
 ---
 
 ## Step 6: Convert YAML Frontmatter
@@ -290,6 +320,7 @@ Run checklist:
 - [ ] Workflows contain ONLY work execution procedures
 - [ ] Reference docs live at skill root (not in Workflows/)
 - [ ] No `backups/` directory inside skill
+- [ ] Nested sub-skills set `user-invocable: false` in frontmatter
 
 ---
 

--- a/Releases/v4.0.3/.claude/skills/Utilities/CreateSkill/Workflows/ValidateSkill.md
+++ b/Releases/v4.0.3/.claude/skills/Utilities/CreateSkill/Workflows/ValidateSkill.md
@@ -150,6 +150,22 @@ Verify:
 - No `backups/` directory inside skill
 - Reference docs at skill root (not in Workflows/)
 
+### Sub-Skill Frontmatter
+
+**If this is a nested sub-skill** (lives at depth ≥ 2 under
+`skills/`, e.g., `skills/<Parent>/<SubSkill>/SKILL.md`), its YAML
+frontmatter MUST set `user-invocable: false`:
+
+```bash
+grep -q '^user-invocable: false$' ~/.claude/skills/[Parent]/[SubSkill]/SKILL.md
+```
+
+Why: Claude Code auto-indexes every `SKILL.md` and advertises each
+as a `/slash-command` tip. Sub-skills are routed to by the parent,
+not invoked by the user, so they must be hidden from the `/` menu.
+
+See `PAI/SKILLSYSTEM.md § Sub-Skill Frontmatter` for the full rule.
+
 ---
 
 ## Step 7a: Check CLI-First Integration (for skills with CLI tools)
@@ -216,6 +232,7 @@ grep -l "Intent-to-Flag" ~/.claude/skills/[SkillName]/Workflows/*.md
 ### Structure
 - [ ] `tools/` directory exists
 - [ ] No `backups/` inside skill
+- [ ] Nested sub-skills set `user-invocable: false` in frontmatter
 
 ### CLI-First Integration (for skills with CLI tools)
 - [ ] CLI tools expose configuration via flags (not hardcoded)

--- a/Releases/v4.0.3/.claude/skills/Utilities/Delegation/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Utilities/Delegation/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: Delegation
 description: Parallelize work via background/foreground agents, built-in types, custom agents, or agent teams/swarms. USE WHEN 3+ independent workstreams, parallel execution, agent specialization, Extended+ effort, agent team, swarm, create an agent team.
+user-invocable: false
 ---
 
 # Delegation — Agent Orchestration & Parallelization

--- a/Releases/v4.0.3/.claude/skills/Utilities/Documents/Docx/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Utilities/Documents/Docx/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: Docx
 description: Create, edit, and analyze Word documents — tracked changes, tables, images, complex formatting, and format conversion. USE WHEN docx, Word document, create document, tracked changes, redlining.
+user-invocable: false
 ---
 
 # DOCX creation, editing, and analysis

--- a/Releases/v4.0.3/.claude/skills/Utilities/Documents/Pdf/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Utilities/Documents/Pdf/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: Pdf
 description: Create, merge, split, extract text/tables from PDFs, fill forms, add watermarks, and convert to/from other formats. USE WHEN pdf, PDF file, merge PDF, extract tables, fill form, split PDF.
+user-invocable: false
 ---
 
 # PDF Processing Guide

--- a/Releases/v4.0.3/.claude/skills/Utilities/Documents/Pptx/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Utilities/Documents/Pptx/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: Pptx
 description: Create, edit, and analyze PowerPoint presentations — slide layouts, speaker notes, design elements, and format conversion. USE WHEN pptx, PowerPoint, slides, presentation, create slides, speaker notes.
+user-invocable: false
 ---
 
 # PPTX creation, editing, and analysis

--- a/Releases/v4.0.3/.claude/skills/Utilities/Documents/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Utilities/Documents/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: Documents
 description: Read, write, convert, and analyze documents — routes to PDF, DOCX, XLSX, PPTX sub-skills for creation, editing, extraction, and format conversion. USE WHEN document, process file, create document, convert format, extract text, PDF, DOCX, XLSX, PPTX, Word, Excel, spreadsheet, PowerPoint, presentation, slides, consulting report, large PDF, merge PDF, fill form, tracked changes, redlining.
+user-invocable: false
 ---
 
 ## Customization

--- a/Releases/v4.0.3/.claude/skills/Utilities/Documents/Xlsx/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Utilities/Documents/Xlsx/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: Xlsx
 description: Create, read, analyze Excel workbooks — formulas, financial models, data analysis, recalculation, and CSV/TSV conversion. USE WHEN xlsx, Excel, spreadsheet, formulas, financial model, data analysis.
+user-invocable: false
 ---
 
 # Requirements for Outputs

--- a/Releases/v4.0.3/.claude/skills/Utilities/Evals/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Utilities/Evals/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: Evals
 description: Objective eval metrics via code/model/human graders with pass@k/pass^k scoring. USE WHEN eval, evaluate, test agent, benchmark, verify behavior, regression test, capability test, run eval, compare models, compare prompts, create judge, create use case, view results, failure to task, suite manager, transcript capture, trial runner.
+user-invocable: false
 ---
 
 ## Customization

--- a/Releases/v4.0.3/.claude/skills/Utilities/Fabric/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Utilities/Fabric/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: Fabric
 description: 240+ specialized prompt patterns for content analysis, extraction, and transformation — run patterns, sync from repo, create threat models, summarize. USE WHEN fabric, fabric pattern, run fabric, update patterns, sync fabric, summarize with fabric, create threat model, analyze with fabric.
+user-invocable: false
 ---
 
 ## Customization

--- a/Releases/v4.0.3/.claude/skills/Utilities/PAIUpgrade/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Utilities/PAIUpgrade/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: PAIUpgrade
 description: Extract system improvements from content AND monitor external sources (Anthropic ecosystem, YouTube). USE WHEN upgrade, improve system, system upgrade, analyze for improvements, check Anthropic, Anthropic changes, new Claude features, check YouTube, new videos, algorithm upgrade, mine reflections, find sources, research upgrade, PAI upgrade.
+user-invocable: false
 ---
 
 ## Customization

--- a/Releases/v4.0.3/.claude/skills/Utilities/Parser/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Utilities/Parser/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: Parser
 description: Extract structured JSON from URLs, files, videos, PDFs with entity extraction and batch support. USE WHEN parse, extract, URL, transcript, entities, JSON, batch, content, YouTube, PDF, article, newsletter, Twitter, browser extension, collision detection, detect content type, extract article, extract newsletter, extract YouTube, extract PDF, parse content.
+user-invocable: false
 ---
 
 ## Customization

--- a/Releases/v4.0.3/.claude/skills/Utilities/Prompting/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Utilities/Prompting/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: Prompting
 description: Meta-prompting system that generates optimized prompts using templates, standards, and patterns. Produces structured prompts with role, context, and output format. USE WHEN meta-prompting, template generation, prompt optimization, programmatic prompt composition, render template, validate template, prompt engineering.
+user-invocable: false
 ---
 
 ## Customization


### PR DESCRIPTION
## Summary

Claude Code auto-indexes every `SKILL.md` in the `skills/` tree and advertises each as an invokable slash-command tip. PAI organizes skills hierarchically: top-level `SKILL.md` files are user-invokable, but **36 nested sub-skills at depth >= 2** are routed to by the parent's Workflow Routing table and are not meant to be invoked by the user directly. Without any marker distinguishing them, Claude Code advertises broken tips like `/annual-reports`, `/council`, `/osint` — they appear in the `/` menu and tip system, but nothing meaningful happens when a user tries them. ~78% false-positive rate on the primary tip affordance.

## Fix

Set `user-invocable: false` on every nested sub-skill `SKILL.md`. This is the spec-blessed frontmatter field from the [Claude Code Skills documentation](https://code.claude.com/docs/en/skills) (Frontmatter reference):

> `user-invocable` — Set to `false` to hide from the `/` menu. Use for background knowledge users shouldn't invoke directly. Default: `true`.

The flag hides the skill from the `/` menu and tip system. Claude can still route to the sub-skill via the parent's file-path reference (parent's routing table uses `Read`, not the Skill tool invocation). **No renames, no file moves, no routing changes.**

## Changes

- Add `user-invocable: false` to 36 nested sub-skill `SKILL.md` files across `ContentAnalysis`, `Investigation`, `Media`, `Scraping`, `Security`, `Thinking`, and `Utilities` parents.
- Add section **Sub-Skill Frontmatter (MANDATORY)** to `PAI/SKILLSYSTEM.md` documenting the rule, rationale, correct frontmatter shape, and validator check.
- Update `CreateSkill` `CanonicalizeSkill` and `ValidateSkill` workflows to enforce the flag on nested sub-skills as part of structural validation.

**Diff:** 39 files changed, 144 insertions(+), 0 deletions(-). Purely additive — no deletions, no renames.

## Scope

All 36 nested sub-skills in `Releases/v4.0.3/`. Older release snapshots (`v4.0.0`, `v4.0.1`, `v4.0.2`) are frozen artifacts and intentionally not touched.

## Relationship to #1082

#1082 (open) removes 16 hardcoded spinner tips that reference skill names which **never existed as files** (e.g., `/broadcast`, `/inbox`). This PR addresses a different failure mode: tips for sub-skills that **do exist** as files but should not be user-invokable. `user-invocable: false` cannot apply to non-existent files, so #1082 remains independently valid. The two PRs are complementary.

## Test plan

- [x] `find Releases/v4.0.3/.claude/skills -mindepth 3 -name SKILL.md -exec grep -L '^user-invocable: false$' {} +` returns empty (every nested SKILL.md has the flag).
- [x] `find Releases/v4.0.3/.claude/skills -mindepth 2 -maxdepth 2 -name SKILL.md -exec grep -l '^user-invocable' {} +` returns empty (no top-level skills were changed).
- [x] Parent routing tables unchanged — sub-skills still reachable via `<SubSkill>/SKILL.md` paths as before.
- [ ] Fresh Claude Code session should no longer emit tips like `/annual-reports`, `/council`, etc. for nested sub-skills (requires reviewer to test locally).

## Why this framing

This is submitted as both a convention fix (SKILLSYSTEM.md) and the full migration (all 36 files) in one PR because the per-file change is a single frontmatter line — splitting the convention and the application into separate PRs would add review overhead without meaningful isolation. If reviewer prefers the convention doc merged first, happy to split.

Generated with [Claude Code](https://claude.com/claude-code)