### PR TITLE
README: document headless/server install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,23 @@ cp -r .claude ~/ && cd ~/.claude && bash install.sh
 
 **After installation:** Run `source ~/.zshrc && pai` to launch PAI.
 
+### Headless / Server Install (no GUI)
+
+The default `install.sh` launches an Electron GUI, which fails on headless
+Linux servers with errors like `libnss3.so: cannot open shared object file`.
+The installer ships a terminal wizard for exactly this case — skip
+`install.sh` and invoke the CLI mode directly:
+
+```bash
+# Clone and stage the release as usual
+git clone https://github.com/danielmiessler/Personal_AI_Infrastructure.git
+cd Personal_AI_Infrastructure/Releases/v4.0.3
+cp -r .claude ~/
+
+# Run the terminal wizard instead of the Electron GUI
+cd ~/.claude && bun run PAI-Install/main.ts --mode cli
+```
+
 ### Upgrading from a Previous Version
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds a short "Headless / Server Install" section to the README for users installing PAI on a headless Linux server
- Documents the existing CLI-mode path (`bun run PAI-Install/main.ts --mode cli`) as an alternative to `install.sh`, which launches an Electron GUI and fails on headless boxes with `libnss3.so` errors
- No code changes — docs only

## Test plan
- [x] Rendered locally — section sits between the standard install block and the "Upgrading from a Previous Version" heading
- [x] Commands verified against `Releases/v4.0.3/.claude/PAI-Install/main.ts` (the CLI wizard path already ships in v4.0.3)