### PR TITLE
fix(telos): align v5 templates and parsers on bullet format

### DIFF
--- a/Releases/v5.0.0/.claude/PAI/TOOLS/GenerateTelosSummary.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/GenerateTelosSummary.ts
@@ -98,26 +98,13 @@ function parseGoals(): { active: string[]; deferred: string[] } {
  */
 function parseProblems(): string[] {
   const content = readTelosFile('PROBLEMS.md');
-  const lines: string[] = [];
-
-  // Format: ## P0: Title (optional parenthetical)
-  const headers = [...content.matchAll(/^##\s+(P\d+):\s*(.+?)(?:\s*\(.*\))?\s*$/gm)];
-  for (const match of headers) {
-    const title = match[2].trim();
-    const short = title.length > 60 ? title.substring(0, 57) + '...' : title;
-    lines.push(`- **${match[1]}**: ${short}`);
-  }
-
-  // Fallback: try list items
-  if (lines.length === 0) {
-    const items = parseItems(content);
-    for (const item of items) {
-      const title = item.text.split(/[—-]/)[0].trim().replace(/\*\*/g, '');
-      lines.push(`- **${item.id}**: ${title}`);
-    }
-  }
-
-  return lines;
+  return parseItems(content)
+    .filter(i => /^P\d+$/.test(i.id))
+    .map(i => {
+      const title = i.text.split(/[—-]/)[0].trim().replace(/\*\*/g, '');
+      const short = title.length > 60 ? title.substring(0, 57) + '...' : title;
+      return `- **${i.id}**: ${short}`;
+    });
 }
 
 /**
@@ -125,16 +112,9 @@ function parseProblems(): string[] {
  */
 function parseStrategies(): string[] {
   const content = readTelosFile('STRATEGIES.md');
-  const lines: string[] = [];
-
-  // Extract strategy headers: ## S0: name or ### S1: name
-  const headers = [...content.matchAll(/^#{2,3}\s+(S\d+):\s*(.+?)(?:\s*\(.*\))?\s*$/gm)];
-  for (const match of headers) {
-    const short = match[2].length > 60 ? match[2].substring(0, 57) + '...' : match[2];
-    lines.push(`- **${match[1]}**: ${short}`);
-  }
-
-  return lines;
+  return parseItems(content)
+    .filter(i => /^S\d+$/.test(i.id))
+    .map(i => `- **${i.id}**: ${truncate(i.text, 60)}`);
 }
 
 /**

--- a/Releases/v5.0.0/.claude/PAI/USER/TELOS/CHALLENGES.md
+++ b/Releases/v5.0.0/.claude/PAI/USER/TELOS/CHALLENGES.md
@@ -4,9 +4,9 @@
 
 > Personal patterns, friction points, and persistent failure modes you're aware of.
 
-- **C0:** (sample) I tend to start more projects than I finish — when something gets hard or boring, a new idea looks more attractive than completing the current one.
-- **C1:** (sample) I avoid hard conversations until they become harder than they needed to be.
-- **C2:** (sample) I optimize small surface-area tasks (inbox, tweaks) when I'm avoiding the one big thing that actually matters this week.
+- **C0**: (sample) I tend to start more projects than I finish — when something gets hard or boring, a new idea looks more attractive than completing the current one.
+- **C1**: (sample) I avoid hard conversations until they become harder than they needed to be.
+- **C2**: (sample) I optimize small surface-area tasks (inbox, tweaks) when I'm avoiding the one big thing that actually matters this week.
 
 ## Notes
 

--- a/Releases/v5.0.0/.claude/PAI/USER/TELOS/GOALS.md
+++ b/Releases/v5.0.0/.claude/PAI/USER/TELOS/GOALS.md
@@ -6,9 +6,9 @@
 
 ## Active
 
-- **G0:** (sample) Ship MVP of Project X by 2026-Q2 — measurable: 100 daily active users.
-- **G1:** (sample) Publish 24 newsletter issues this year — measurable: one every other Sunday, no skipped weeks.
-- **G2:** (sample) Reach a sustainable monthly revenue target — measurable: $X MRR by end of year.
+- **G0**: (sample) Ship MVP of Project X by 2026-Q2 — measurable: 100 daily active users.
+- **G1**: (sample) Publish 24 newsletter issues this year — measurable: one every other Sunday, no skipped weeks.
+- **G2**: (sample) Reach a sustainable monthly revenue target — measurable: $X MRR by end of year.
 
 ## Deferred / Ongoing
 

--- a/Releases/v5.0.0/.claude/PAI/USER/TELOS/MISSION.md
+++ b/Releases/v5.0.0/.claude/PAI/USER/TELOS/MISSION.md
@@ -4,9 +4,9 @@
 
 > What you're here to do — the most durable north star.
 
-- **M0:** (sample) Help one million people make better decisions through accessible AI tools.
-- **M1:** (sample) Build infrastructure that lets individuals own their data and AI.
-- **M2:** (sample — aspirational, optional) Leave behind work that's still useful 50 years after I'm gone.
+- **M0**: (sample) Help one million people make better decisions through accessible AI tools.
+- **M1**: (sample) Build infrastructure that lets individuals own their data and AI.
+- **M2**: (sample — aspirational, optional) Leave behind work that's still useful 50 years after I'm gone.
 
 ## Notes
 

--- a/Releases/v5.0.0/.claude/PAI/USER/TELOS/NARRATIVES.md
+++ b/Releases/v5.0.0/.claude/PAI/USER/TELOS/NARRATIVES.md
@@ -4,9 +4,9 @@
 
 > The stories you tell yourself (and others) about the world — the frames your work operates within.
 
-- **N0:** (sample) I build tools that move power from institutions to individuals.
-- **N1:** (sample) The next decade rewards people who can ship working software end-to-end without waiting for a team.
-- **N2:** (sample — conference one-liner) I'm a [your craft] who helps [your audience] do [your outcome].
+- **N0**: (sample) I build tools that move power from institutions to individuals.
+- **N1**: (sample) The next decade rewards people who can ship working software end-to-end without waiting for a team.
+- **N2**: (sample — conference one-liner) I'm a [your craft] who helps [your audience] do [your outcome].
 
 ## Notes
 

--- a/Releases/v5.0.0/.claude/PAI/USER/TELOS/PROBLEMS.md
+++ b/Releases/v5.0.0/.claude/PAI/USER/TELOS/PROBLEMS.md
@@ -4,9 +4,9 @@
 
 > External problems in the world you're working to address.
 
-- **P0:** (sample) Most knowledge workers spend more time fighting their tools than doing the work the tools are supposed to enable.
-- **P1:** (sample) High-quality information is unevenly distributed — people without insider networks pay a real cost in worse decisions.
-- **P2:** (sample) Personal data is held by platforms that don't share the user's incentives.
+- **P0**: (sample) Most knowledge workers spend more time fighting their tools than doing the work the tools are supposed to enable.
+- **P1**: (sample) High-quality information is unevenly distributed — people without insider networks pay a real cost in worse decisions.
+- **P2**: (sample) Personal data is held by platforms that don't share the user's incentives.
 
 ## Notes
 

--- a/Releases/v5.0.0/.claude/PAI/USER/TELOS/STRATEGIES.md
+++ b/Releases/v5.0.0/.claude/PAI/USER/TELOS/STRATEGIES.md
@@ -4,9 +4,9 @@
 
 > How you approach your missions, goals, and problems — the playbook.
 
-- **S0:** (sample) Ship the crappy version, then iterate in public — speed of feedback beats polish in the first 80%.
-- **S1:** (sample) Write before building — if I can't explain it in plain prose, the design isn't ready.
-- **S2:** (sample) Default to open — open-source the tools, share the work, let distribution come from usefulness.
+- **S0**: (sample) Ship the crappy version, then iterate in public — speed of feedback beats polish in the first 80%.
+- **S1**: (sample) Write before building — if I can't explain it in plain prose, the design isn't ready.
+- **S2**: (sample) Default to open — open-source the tools, share the work, let distribution come from usefulness.
 
 ## Notes
 


### PR DESCRIPTION
Closes #1113.

## What

Aligns v5 TELOS templates and the `GenerateTelosSummary.ts` parsers on a single bullet-based convention `- **ID**: text` for all six ID-bearing files (MISSION, GOALS, PROBLEMS, STRATEGIES, CHALLENGES, NARRATIVES).

Two coordinated changes:

1. **Templates (18 lines, 6 files):** `- **ID:**` → `- **ID**:` (colon outside the bold span). Required so `parseItems` regex captures the value cleanly. Full rationale in #1113.

2. **Parsers (`Releases/v5.0.0/.claude/PAI/TOOLS/GenerateTelosSummary.ts`):**
   - **`parseStrategies`** — was header-only (`## S0:` / `### S0:`), now reads bullets via `parseItems` with an `S\d+` ID filter. Without this change, the shipped STRATEGIES template never renders into `PRINCIPAL_TELOS.md` because the template is bullet-based and the parser only matched headers.
   - **`parseProblems`** — was header-first with bullet fallback. Drops the header path, becomes bullet-only with a `P\d+` ID filter. Same rationale: shipped template is bullets; the dual-format complexity wasn't earning its keep.

After this PR, every ID-bearing TELOS file uses the same shape (bullets with `**ID**:`) and every parser reads the same shape via `parseItems`.

## Why

Without the parser change, the template fix alone is incomplete. Anyone running the bootstrap renderer would get:

- `PRINCIPAL_TELOS.md` `## Strategies` → empty (parser ignores template bullets entirely)
- `PRINCIPAL_TELOS.md` `## Problems Being Solved` → renders, but via a fallback path that only existed to paper over the template/parser mismatch

Fixing both at once gives the maintainer one clean "templates and parsers are now consistent" merge, instead of a follow-up PR to make the first one actually work.

## Files changed

**Templates:**
- `Releases/v5.0.0/.claude/PAI/USER/TELOS/MISSION.md`
- `Releases/v5.0.0/.claude/PAI/USER/TELOS/GOALS.md`
- `Releases/v5.0.0/.claude/PAI/USER/TELOS/PROBLEMS.md`
- `Releases/v5.0.0/.claude/PAI/USER/TELOS/STRATEGIES.md`
- `Releases/v5.0.0/.claude/PAI/USER/TELOS/CHALLENGES.md`
- `Releases/v5.0.0/.claude/PAI/USER/TELOS/NARRATIVES.md`

**Parser:**
- `Releases/v5.0.0/.claude/PAI/TOOLS/GenerateTelosSummary.ts` — `parseStrategies`, `parseProblems`

## Breaking change — migration note

Users whose existing `STRATEGIES.md` or `PROBLEMS.md` files use H2/H3 headers (`## S0: title` or `### P0: title`) will stop rendering after this merge. Migrate to bullet format `- **S0**: title` to match the unified convention.

The shipped v5.0.0 templates already use bullets, so users who never customized their files are not affected.

## Out of scope

- `parseGoals` ID-classification heuristic (`G9+` and `[0, 1]` → active) — that's a separate concern tracked in #1115.
- `parseNarratives` similar `[0, 1, 7]` → primary heuristic — same shape of issue as #1115, not part of this PR.

## Verification

After merge, running the renderer against the as-shipped v5.0.0 templates produces clean, complete output:

```
$ bun PAI/TOOLS/GenerateTelosSummary.ts
$ cat PAI/USER/TELOS/PRINCIPAL_TELOS.md

## Missions
- **M0**: (sample) Help one million people make better decisions...
- **M1**: (sample) Build infrastructure that lets individuals own...
- **M2**: (sample — aspirational, optional) Leave behind work...

## Active Goals (2026)
- **G0**: (sample) Ship MVP of Project X by 2026-Q2...
- **G1**: (sample) Publish 24 newsletter issues this year...

## Problems Being Solved
- **P0**: (sample) Most knowledge workers spend more time fighting...
- **P1**: (sample) High-quality information is unevenly distributed...
- **P2**: (sample) Personal data is held by platforms...

## Strategies
- **S0**: (sample) Ship the crappy version, then iterate in public...
- **S1**: (sample) Write before building...
- **S2**: (sample) Default to open...
```

All six sections render with no `**` artifact, no silent drops.
