### PR TITLE
feat(deps/bootstraps/installs/updates): Add Nix flake for cross-platform install + dev shell. PLEASE 🙏

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,64 @@
+{
+  description = "Personal AI Infrastructure — Nix bootstrap";
+
+  inputs = {
+    nixpkgs.url     = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        deps = with pkgs; [ bun curl rsync git bash ];
+
+        # README "Manual install (clone + run)":
+        #   cp -R Releases/v5.0.0/.claude ~/
+        #   cd ~/.claude && ./install.sh
+        inner = pkgs.writeShellApplication {
+          name          = "pai-bootstrap";
+          runtimeInputs = deps;
+          text = ''
+            if [ -e "$HOME/.claude" ]; then
+              BACKUP="$HOME/.claude.backup-$(date +%Y%m%d-%H%M%S)"
+              mv "$HOME/.claude" "$BACKUP"
+              echo "Existing \$HOME/.claude moved to $BACKUP"
+            fi
+            cp -R ${self}/Releases/v5.0.0/.claude "$HOME/.claude"
+            chmod -R u+w "$HOME/.claude"
+            cd "$HOME/.claude"
+            exec bash ./install.sh "$@"
+          '';
+        };
+
+        # Linux (incl. WSL): FHS chroot so PAI's bundled Electron GUI installer
+        # finds libglib-2.0 / GTK / NSS / etc.  macOS: native frameworks ship
+        # with Electron, no wrap needed.
+        bootstrap =
+          if pkgs.stdenv.isLinux then
+            pkgs.buildFHSEnv (pkgs.appimageTools.defaultFhsEnvArgs // {
+              name       = "pai-bootstrap";
+              targetPkgs = p: pkgs.appimageTools.defaultFhsEnvArgs.targetPkgs p ++ deps;
+              runScript  = "${inner}/bin/pai-bootstrap";
+            })
+          else
+            inner;
+
+        # `nix develop` — same toolchain + FHS shape as the installer, for
+        # working on PAI's source itself (running Electron, bun, hooks).
+        devShell =
+          if pkgs.stdenv.isLinux then
+            (pkgs.buildFHSEnv (pkgs.appimageTools.defaultFhsEnvArgs // {
+              name       = "pai-dev";
+              targetPkgs = p: pkgs.appimageTools.defaultFhsEnvArgs.targetPkgs p ++ deps;
+              runScript  = "bash";
+            })).env
+          else
+            pkgs.mkShell { packages = deps; };
+      in {
+        packages.default = bootstrap;
+        apps.default     = { type = "app"; program = "${bootstrap}/bin/pai-bootstrap"; };
+        devShells.default = devShell;
+      });
+}


### PR DESCRIPTION
FIXES ISSUES RELATED TO (i.e.):

- Unreliable installs across operating systems:
    #708 — Electron installer fails at libnss3.so   (closed; same class as our libglib2)
    #856 — Installer Silently Fails Due to Missing unzip Dependency   (closed)
    #848 — Installation Error on v4.0.1–v4.0.3 (fresh install)
    #1117 — error during installation from scratch (Ubuntu-24.04 wsl)
    #438 — Unable to install PAI on an Ubuntu WSL instance
    #440 — Failed install with Claude Code on Windows
    #543 — Run on Windows without recoding bits and pieces?
    #954 — Interrupted install creates multiple Bun alias entries
    #977 — Shell alias (pai): Not found — run: source ~/.zshrc
    #1053 — bad instructions after installation with fish shell
    #1088 — First install — says it's upgrading, and doesn't find Claude Code
    #912 — install.sh crashes on headless Linux — hardcodes --mode gui
    #755 — Installer doesn't fall back to CLI mode in headless/SSH   (closed)

- Unreliable updates / idempotency:
    #893 — 4.0.3 upgrade overwrites configured settings.json with template placeholders
    #650 — Local patch tracking and update-safe SYSTEM file management
    #973 — TOOL enhance: diff, backup --user-only, migrate --auto for safer release updates
    #439 — Preserve user preferences across version upgrades   (closed)
    #1080 — PAI upgrade skill points to wrong folder
    #967 — SecurityValidator runs in fail-open mode after v4.0 install: patterns not migrated

- Dependency hell on different OSes:
    #856 — missing unzip   (closed)
    #708 — libnss3   (closed)
    #855 — VoiceServer: afplay (macOS-only) breaks audio on Linux
    #685 — v3.0 VoiceServer has hard macOS dependencies — no Linux support
    #495 — statusline-command.sh uses macOS-only stat syntax   (closed)
    #679 — stat -f %m regression on Linux/WSL   (closed)
    #1065 — statusline-command.sh silently shows empty defaults when jq is missing
    #385 — Windows/MSYS: Bun.stdin.text() doesn't work — hooks fail silently
    #849 — Linux compatibility (headless, shell, statusline)   (closed)

- The need for dependency checks and per-OS install advice at all.
  Today install.sh has to detect whether bun is present, offer to
  install it, fall back when it isn't, then re-detect after — and emit
  "On Debian/Ubuntu run apt-get install …" hints branched per distro
  — all because the runtime is whatever the user happens to have. Nix
  makes the runtime guaranteed; the whole detect/offer/fallback dance
  and the per-OS advice disappear together.

- The need for a separate, website-only wrapper script at all. As a
  natural consequence of the previous bullet, today there has to be a
  script at https://ourpai.ai/install.sh whose job is exactly to do
  the prereq-checking, the bun-installing, the ~/.claude → backup mv,
  and the tarball fetch — i.e. all the work that exists ONLY because
  the runtime isn't defined. With Nix, none of that work exists, so
  no separate wrapper is needed: the website can simply say "run
  `nix run github:.../PAI`". And as a side win this also closes the
  gap that the current website wrapper is, for some reason, nowhere
  version-tracked on the PAI repo — the README links to a live URL
  with no git history. With this PR, the install path is `flake.nix`
  in the repo: source-controlled, signed by your own commits,
  reviewable in PRs.

- Agnosticism (longer-term goal). No direct issues — this is the
  larger arc. I look forward to the day we break free from Anthropic.
  This PR is one precondition: a defined, portable runtime environment
  is what lets PAI's runtime be swapped (Claude Code → Pi → another
  agent layer) without distro-by-distro breakage every time.

---

I BEG YOU TO CONSIDER MR MIESSLER!

A big hole in PAI I've noticed whenever trying out your features (and
why I haven't moved from my personal lightweight Pi-Mono DA yet) is
the lack of idempotency. We have workarounds like LLM-driven adaptive
updates — but really, in your own words, determinism is the default
when we can make it so. It makes it easier for consumers and
developers to work on PAI together.

The current `curl … | bash` is presented as a one-line install but it
isn't really one. It leaves the prerequisite story to chance: the
script itself has to detect whether bun is present, offer to install
it, fall back gracefully when it isn't — all because the runtime
environment is whatever the user happens to have. That work shouldn't
live in a shell script. With Nix it disappears: `bun`, `curl`,
`rsync`, `git`, plus the FHS libs Electron needs, are all guaranteed
by the runtime — the installer doesn't have to ask, doesn't have to
offer, doesn't have to fall back. THAT'S a true one-line install.

This is also a forcing function for cleaner architecture. Once Nix is
the install path, `node_modules/` can move into the immutable store
(out of `~/.claude/PAI/PAI-Install/electron/` and out of the user's
home), upgrades become atomic via `nix flake update`, rollback is one
command, and the whole "did the curl piped script run cleanly?"
question goes away — the closure is content-addressed and pinned in
`flake.lock`.

---

## Journey is identical, only the bootstrap shrinks

The user experience from the inner installer onward — banners, DA
identity setup, voice, Pulse — is unchanged. The only differences are
in the outer bootstrap:

- No step 1 (prereq check + "offer to install bun") — Nix guarantees
  bun, curl, rsync, git, bash, plus the FHS libs Electron needs.
- No step 3 (fetch v5.0.0 tarball from GitHub) — the flake's source IS
  the source. Tarball download is redundant.
- Step 2 (backup ~/.claude → ~/.claude.backup-{timestamp}) and step 4
  (place release at ~/.claude/) happen exactly the same way, just
  without the `▸ 2/5` / `▸ 4/5` ceremony around them.
- Step 5 (handoff to ~/.claude/install.sh) — identical. Same wizard,
  same banner, same prompts.

What disappears is exactly the part that was leaving outcome to
chance — what the user happens to have installed, what their distro
ships by default, whether the bun installer succeeds non-interactively.

## What this adds

A single new file (`flake.nix`) exposing:

- `nix run github:danielmiessler/Personal_AI_Infrastructure` — installs
  PAI on any Nix-supporting system (macOS, regular Linux, NixOS, WSL)
  with one command, no prereq install, no `curl | bash`.
- `nix develop github:danielmiessler/Personal_AI_Infrastructure` —
  drops hackers into a shell with bun/curl/rsync/git/bash + (on Linux)
  the FHS libs PAI's bundled Electron GUI needs (libglib2, GTK, NSS,
  etc.).

Existing install paths (`curl | bash`, manual clone) are unchanged.

## Why this PR exists

Non-Nix install paths today:

- `curl -sSL https://ourpai.ai/install.sh | bash` — fails on NixOS at
  step 5/5 with `libglib-2.0.so.0: cannot open shared object file`
  because PAI's bundled Electron expects an FHS userspace.
- README "Manual install" — same failure at the GUI launch.

The Nix flake wraps the install in `pkgs.buildFHSEnv` with
`pkgs.appimageTools.defaultFhsEnvArgs` (nixpkgs-curated, community-
maintained dep list for desktop Electron-shaped apps). No hand-rolled
library list, no per-distro install hints, no "On Debian/Ubuntu run
apt-get install …" branches. The FHS env covers any desktop Linux app
shape Electron might evolve into.

## Forward-looking notes (not part of this PR)

- The bootstrap that runs at https://ourpai.ai/install.sh is not in
  this repo — the README links to the live URL with no git history. If
  it lived in the repo (or was source-controlled somewhere visible),
  the install path would be auditable, the Nix flake could mirror it
  exactly, and the two paths could share code.
- After this lands, a clean follow-up is moving `node_modules/` and
  the bundled Electron into the Nix store at derivation-build time, so
  `~/.claude/PAI/` only contains user-mutable state (skills, agents,
  memory, DA identity, settings).

## Tested

`nix run --refresh github:zitongcharliedeng/PAI/nix-flake` from a
sandbox HOME on NixOS:
- FHS env activates, prereqs all visible at `/nix/store/...` paths
- Backup-then-install steps execute (auto-mv ~/.claude →
  ~/.claude.backup-{timestamp}, then cp Releases/v5.0.0/.claude →
  ~/.claude)
- Inner installer launches and reaches its CLI flow (Electron GUI not
  exercised in headless test, but FHS env is what fixes that case)

macOS not directly tested. Flake evaluates clean across all four
default systems; macOS branch is plain `writeShellApplication` with no
FHS wrap since Electron uses native frameworks there.
