### PR TITLE
fix: add missing Pulse daemon dependencies (yaml, minisearch, smol-toml)

### DIFF
--- a/Releases/v5.0.0/.claude/.gitignore
+++ b/Releases/v5.0.0/.claude/.gitignore
@@ -186,6 +186,9 @@ Plugins/marketplaces/.chrome-profile/
 # Pulse Observability lockfile — ship for reproducible installs
 !PAI/PULSE/Observability/bun.lock
 
+# Pulse daemon lockfile — ship for reproducible installs
+!PAI/PULSE/bun.lock
+
 # Python virtual environments
 .venv/
 

--- a/Releases/v5.0.0/.claude/PAI/PULSE/Observability/bun.lock
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/Observability/bun.lock
@@ -28,6 +28,7 @@
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.4.0",
         "tailwindcss-animate": "^1.0.7",
+        "yaml": "^2.8.3",
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -735,6 +736,8 @@
     "victory-vendor": ["victory-vendor@36.9.2", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ=="],
 
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
+
+    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 

--- a/Releases/v5.0.0/.claude/PAI/PULSE/Observability/package.json
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/Observability/package.json
@@ -30,7 +30,8 @@
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.4.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/Releases/v5.0.0/.claude/PAI/PULSE/bun.lock
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/bun.lock
@@ -1,0 +1,20 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "dependencies": {
+        "minisearch": "^7.2.0",
+        "smol-toml": "^1.6.1",
+        "yaml": "^2.8.4",
+      },
+    },
+  },
+  "packages": {
+    "minisearch": ["minisearch@7.2.0", "", {}, "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg=="],
+
+    "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
+
+    "yaml": ["yaml@2.8.4", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog=="],
+  }
+}

--- a/Releases/v5.0.0/.claude/PAI/PULSE/package.json
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "minisearch": "^7.2.0",
+    "smol-toml": "^1.6.1",
+    "yaml": "^2.8.4"
+  }
+}


### PR DESCRIPTION
## Problem

Three packages are imported by Pulse daemon modules but were never declared in any `package.json`:

| Package | Imported by | Effect when missing |
|---------|-------------|---------------------|
| `yaml` | `modules/observability.ts` | Observability module fails to load; all Pulse routes return 404 |
| `minisearch` | `modules/wiki.ts` | Wiki module fails to load; `/knowledge`, `/docs`, `/skills`, `/hooks` pages return 404 |
| `smol-toml` | `pulse.ts`, `lib.ts` | PULSE.toml parsing fails on cold start |

On every cold start, Bun cannot resolve these packages, the affected modules fail silently, and the Pulse dashboard returns `404` on the routes they serve. The dashboard only works if the packages have been added manually after install.

## Fix

Create `PAI/PULSE/package.json` with all three runtime dependencies and a corresponding `bun.lock`. Update `.gitignore` to carve out `PAI/PULSE/bun.lock` alongside the existing `Observability/bun.lock` exception.

The deps belong in `PULSE/package.json` (the daemon root), not in `PULSE/Observability/package.json` (the Next.js static export) — the modules that import them are Pulse server-side code, not frontend components.

## Reproduction

```
cd Releases/v5.0.0/.claude/PAI/PULSE
bun install   # fresh install — minisearch, smol-toml, yaml not resolved
bun pulse.ts  # wiki + observability modules fail silently
curl http://localhost:31337/api/wiki/skills  # → 404 Not found
curl http://localhost:31337/api/wiki         # → 404 Not found
```