### PR TITLE
fix(telos): correct GenerateTelosSummary parser to match shipped templates (#1113, #1115)

### DIFF
--- a/Releases/v5.0.0/.claude/PAI/TOOLS/GenerateTelosSummary.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/GenerateTelosSummary.ts
@@ -49,8 +49,10 @@ function parseItems(content: string): ParsedItem[] {
   const lines = content.split('\n');
 
   for (const line of lines) {
-    // Match "- **M0**: text" or "- M0: text" or "- **G0**: text" patterns
-    const match = line.match(/^-\s+\*?\*?(\w+)\*?\*?:\s*(.+)/);
+    // Match all four bullet styles: "- **M0**: text", "- **M0:** text",
+    // "- M0: text", and "- M0:** text". Optional ** before AND after the
+    // colon handles the template/parser drift identified in upstream #1113.
+    const match = line.match(/^-\s+\*?\*?(\w+)\*?\*?:\*?\*?\s*(.+)/);
     if (match) {
       items.push({ id: match[1], text: match[2].trim() });
     }
@@ -68,29 +70,80 @@ function parseMissions(): string[] {
 }
 
 /**
- * Parse goals from GOALS.md, separating 2026 goals from older ones
+ * Parse goals from GOALS.md by walking section headers, not by ID heuristic.
+ * Section headers (## Active / ## Deferred / ## Ongoing / ## Completed) drive
+ * classification — fixes upstream #1115 where G2 was misclassified as deferred
+ * because the old code used `num >= 9 || [0,1].includes(num)`.
  */
-function parseGoals(): { active: string[]; deferred: string[] } {
+function parseGoals(): {
+  active: string[];
+  deferredIds: string[];
+  deferredPlain: string[];
+} {
   const content = readTelosFile('GOALS.md');
-  const items = parseItems(content);
-
-  // Goals with IDs G9+ are 2026 goals based on the file structure
   const active: string[] = [];
-  const deferred: string[] = [];
+  const deferredIds: string[] = [];
+  const deferredPlain: string[] = [];
 
-  for (const item of items) {
-    const num = parseInt(item.id.replace(/\D/g, ''), 10);
-    // Split on " — " (em-dash with spaces) or sentence-ending period (not in URLs)
-    const firstSentence = item.text.split(/\s—\s|(?<!\w\.\w)(?<=\w)\.\s/)[0].trim();
+  type Section = 'active' | 'deferred' | 'completed' | 'other';
+  let currentSection: Section = 'other';
 
-    if (num >= 9 || [0, 1].includes(num)) {
-      active.push(`- **${item.id}**: ${truncate(firstSentence, 70)}`);
-    } else {
-      deferred.push(`- **${item.id}**: ${truncate(firstSentence, 50)}`);
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.trimEnd();
+
+    // Only top-level (##) headings switch the section. Sub-headings like
+    // `### Work`, `### Home`, `### Tech / PAI` are children of the parent
+    // section and must inherit it (otherwise G0-G7 under `## Active` →
+    // `### Work` get classified as 'other' and silently dropped).
+    const headerMatch = line.match(/^##\s+(.+?)\s*$/);
+    if (headerMatch) {
+      const h = headerMatch[1].toLowerCase();
+      if (h.startsWith('active')) currentSection = 'active';
+      else if (h.startsWith('deferred') || h.startsWith('ongoing')) currentSection = 'deferred';
+      else if (h.startsWith('completed')) currentSection = 'completed';
+      else currentSection = 'other';
+      continue;
+    }
+
+    if (currentSection === 'other') continue;
+
+    const idMatch = line.match(/^-\s+\*?\*?(\w+)\*?\*?:\*?\*?\s*(.+)/);
+    if (idMatch) {
+      const id = idMatch[1];
+      const text = idMatch[2].trim();
+      const firstSentence = text.split(/\s—\s|(?<!\w\.\w)(?<=\w)\.\s/)[0].trim();
+
+      if (currentSection === 'active') {
+        active.push(`- **${id}**: ${truncate(firstSentence, 70)}`);
+      } else {
+        // deferred or completed → both go to deferredIds (the inline ID-list line)
+        deferredIds.push(id);
+      }
+      continue;
+    }
+
+    // Plain bullet without ID — used by Deferred / Ongoing / Completed items
+    // in the shipped template. These were silently dropped in upstream #1115.
+    const plainMatch = line.match(/^-\s+(.+)/);
+    if (plainMatch) {
+      const text = plainMatch[1].trim();
+      const firstSentence = text.split(/\s—\s|(?<!\w\.\w)(?<=\w)\.\s/)[0].trim();
+
+      // Skip template placeholders like `*(none recorded yet — update as items ship)*`
+      if (/^\*?\(.*(none|tbd|placeholder)/i.test(firstSentence)) continue;
+
+      if (currentSection === 'deferred' || currentSection === 'completed') {
+        // Strip surrounding **bold** so we keep just the name for the inline list.
+        const bare = firstSentence.replace(/^\*\*(.+?)\*\*.*$/, '$1');
+        deferredPlain.push(truncate(bare, 60));
+      } else if (currentSection === 'active') {
+        // Active without ID — uncommon but render directly so it isn't lost.
+        active.push(`- ${truncate(firstSentence, 70)}`);
+      }
     }
   }
 
-  return { active, deferred };
+  return { active, deferredIds, deferredPlain };
 }
 
 /**
@@ -121,20 +174,19 @@ function parseProblems(): string[] {
 }
 
 /**
- * Parse strategies from STRATEGIES.md
+ * Parse strategies from STRATEGIES.md.
+ *
+ * The shipped template stores strategies as bullets (`- **S0:** Kaizen…`)
+ * under `## Active` / `## Anti-Strategies`, not as `## S0:` headers — the
+ * old header-only regex returned an empty list (upstream #1113). Use the
+ * shared bullet parser; it now picks up Sn AND An entries.
  */
 function parseStrategies(): string[] {
   const content = readTelosFile('STRATEGIES.md');
-  const lines: string[] = [];
-
-  // Extract strategy headers: ## S0: name or ### S1: name
-  const headers = [...content.matchAll(/^#{2,3}\s+(S\d+):\s*(.+?)(?:\s*\(.*\))?\s*$/gm)];
-  for (const match of headers) {
-    const short = match[2].length > 60 ? match[2].substring(0, 57) + '...' : match[2];
-    lines.push(`- **${match[1]}**: ${short}`);
-  }
-
-  return lines;
+  const items = parseItems(content);
+  return items
+    .filter(i => /^[SA]\d+$/.test(i.id))
+    .map(i => `- **${i.id}**: ${truncate(i.text, 80)}`);
 }
 
 /**
@@ -231,13 +283,13 @@ function generate(): string {
     ...goals.active,
   ];
 
-  if (goals.deferred.length > 0) {
-    // Compress deferred goals to a single inline line — they're not active and don't need full bullets
-    const deferredIds = goals.deferred
-      .map(line => line.match(/\*\*(\w+)\*\*/)?.[1])
-      .filter(Boolean)
-      .join(', ');
-    lines.push('', `_Deferred (full text in TELOS/GOALS.md): ${deferredIds}_`);
+  if (goals.deferredIds.length > 0) {
+    lines.push('', `_Deferred (full text in TELOS/GOALS.md): ${goals.deferredIds.join(', ')}_`);
+  }
+  if (goals.deferredPlain.length > 0) {
+    // Plain bullets without IDs from Deferred / Ongoing / Completed sections —
+    // render as a single compact inline line so they aren't silently dropped (#1115).
+    lines.push(`_Ongoing: ${goals.deferredPlain.join(', ')}_`);
   }
 
   lines.push(


### PR DESCRIPTION
Bundles two open TELOS-renderer issues — both root-cause in `Releases/v5.0.0/.claude/PAI/TOOLS/GenerateTelosSummary.ts`:

- Fixes #1113 — template/parser mismatch (stray `**` artifacts; empty `## Strategies` section)
- Fixes #1115 — `G2` misclassified as deferred; `## Deferred / Ongoing` and `## Completed This Year` sections silently dropped

## Changes

### `parseItems()` regex (L53)
Accept colon either inside or outside the `**` bold span — covers all four bullet styles:
```
- **M0**: text       (current expectation)
- **M0:** text       (what shipped templates use)
- M0: text
- M0:** text
```
Old: `/^-\s+\*?\*?(\w+)\*?\*?:\s*(.+)/` — captured trailing `**` as part of value, producing the `**M0**: ** ...` artifact.
New: `/^-\s+\*?\*?(\w+)\*?\*?:\*?\*?\s*(.+)/` — consumes the closing `**` before capturing.

### `parseStrategies()` rewrite
Use the shared bullet parser instead of `/^#{2,3}\s+(S\d+):/`. The shipped STRATEGIES.md stores strategies as bullets under `## Active` / `## Anti-Strategies`, not as `## S0:` headers. Filter on `/^[SA]\d+$/` so both Sn and An (anti-strategy) entries land in the rendered output.

### `parseGoals()` rewrite — section-walker classifier
Replaces the ID-number heuristic (`num >= 9 || [0, 1].includes(num)`) — which encoded a personal goal-numbering convention the shipped template doesn't follow — with section-header awareness. The renderer now classifies each bullet by which `## Active` / `## Deferred / Ongoing` / `## Completed This Year` block it appears under. This is the self-documenting choice the issue body's "open question" identified.

Two subtleties:
- **Only `##` switches section.** Sub-headings (`### Work`, `### Home`, `### Tech / PAI`) inherit the parent section. Treating every `##+` as a section boundary silently drops any goals the user organizes by sub-area.
- **No-ID bullets in Deferred/Ongoing/Completed are rendered as a compact `_Ongoing: name1, name2, ..._` inline line** instead of being dropped. Bold name markers are stripped for the inline list.

### Template-placeholder skip
`*(none recorded yet — update as items ship)*` and similar `*(none/tbd/placeholder ...)*` patterns are now silently skipped so a fresh install shows nothing for empty buckets rather than a literal placeholder bullet.

### Render block in `generate()`
Updated to the new `{ active, deferredIds, deferredPlain }` parseGoals return shape.

## Verification

Tested against a populated GOALS.md that exercises every code path:
- 8 active goals (G0–G7) split across 3 sub-sections (`### Work`, `### Home`, `### Tech / PAI`) under `## Active`
- 4 plain-bullet entries under `## Deferred / Ongoing` (no IDs, with `**Bold Name** — explanation` form)
- 1 placeholder bullet under `## Completed This Year`
- Populated STRATEGIES.md with `- **S0:**…` through `- **S5:**…` plus `- **A0:**…`

Before this patch:
- `## Active Goals (2026)` showed only G0/G1, then `_Deferred (full text in TELOS/GOALS.md): G2, G3, G4, G5, G6, G7_`
- `## Strategies` was empty
- `## Deferred / Ongoing` plain bullets were silently dropped
- Every entry had a stray `** ` prefix in the captured value

After:
- All 8 active goals appear under `## Active Goals (2026)`
- Strategies block shows S0–S5 + A0 (7 entries)
- A single `_Ongoing: PAI Infrastructure Maturation, OpenClaw Ecosystem, House Refresh 2026, CashX_` line appears below Active Goals
- Stray-`**` regression check finds 0 buggy entries (legitimate bold-name strategies/challenges preserved)
- `*(none recorded yet…)*` placeholder is silently skipped

## Notes

The render-time decision to compress no-ID Deferred entries to a single inline line (rather than full bullets) preserves the original design intent ("they're not active and don't need full bullets") while fixing the silent-drop bug — boot-context summaries stay compact.