### PR TITLE
Wire SmartApprover as PermissionRequest hook in v5.0.0 settings

### DIFF
--- a/Releases/v5.0.0/.claude/settings.json
+++ b/Releases/v5.0.0/.claude/settings.json
@@ -82,6 +82,17 @@
     "defaultMode": "default"
   },
   "hooks": {
+    "PermissionRequest": [
+      {
+        "matcher": "Write|Edit|MultiEdit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/SmartApprover.hook.ts"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",


### PR DESCRIPTION
## Problem

`SmartApprover.hook.ts` ships in v5.0.0 at `Releases/v5.0.0/.claude/hooks/SmartApprover.hook.ts` and is documented in `Releases/v5.0.0/.claude/PAI/DOCUMENTATION/Hooks/HookSystem.md` as the PermissionRequest handler:

> SmartApprover (PermissionRequest) — trusted workspace auto-approval + read/write classification.

But the `settings.json` shipped in v5.0.0 has no `PermissionRequest` entry, so the hook never fires. Every Write/Edit/MultiEdit/Bash to a path outside the static `permissions.allow` rules falls through to a user prompt — exactly the case SmartApprover was designed to auto-handle.

The hook file's own header says:

```ts
* TRIGGER: PermissionRequest (matcher: Write|Edit|MultiEdit|Bash)
```

So this is purely unfinished wiring — the hook is shipped, designed, and documented; it just isn't registered.

## Fix

Add the PermissionRequest hook entry to `Releases/v5.0.0/.claude/settings.json` with matcher `Write|Edit|MultiEdit|Bash` (matches SmartApprover's own declared scope per its file header).

## Scope

- 11 lines added to one file (`Releases/v5.0.0/.claude/settings.json`).
- No source code changes.
- No new files.
- No new dependencies.
- Behavior change: Write/Edit/MultiEdit/Bash to trusted-workspace paths (`~/.claude/`, `~/Projects/`, `~/LocalProjects/`, `~/Downloads/`, `/tmp/`) now auto-approve instead of prompting. Read operations to non-trusted paths now auto-approve instead of prompting. Write operations to non-trusted paths still prompt (unchanged).

## Verified

- HookSystem.md (`grep -n PermissionRequest Releases/v5.0.0/.claude/PAI/DOCUMENTATION/Hooks/HookSystem.md`) lists 'PermissionRequest' among supported HookEventName values and documents SmartApprover's intended role.
- v5.0.0 settings.json had no PermissionRequest hook before this change.
- SmartApprover's emitted `hookSpecificOutput.hookEventName` is 'PermissionRequest' (line 180 of the hook source), confirming intended event type.
