### PR TITLE
Honor PAI_DIR consistently in three lingering hardcodes

### DIFF
--- a/Releases/v5.0.0/.claude/PAI/PULSE/manage.sh
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/manage.sh
@@ -2,7 +2,7 @@
 # PAI Pulse — Process Management
 # Usage: manage.sh {start|stop|restart|status|install|uninstall}
 
-PULSE_DIR="$HOME/.claude/PAI/PULSE"
+PULSE_DIR="${PAI_DIR:-$HOME/.claude/PAI}/PULSE"
 PLIST_NAME="com.pai.pulse"
 PLIST_SRC="$PULSE_DIR/$PLIST_NAME.plist"
 PLIST_DST="$HOME/Library/LaunchAgents/$PLIST_NAME.plist"

--- a/Releases/v5.0.0/.claude/PAI/PULSE/modules/hooks.ts
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/modules/hooks.ts
@@ -115,7 +115,7 @@ function handleAgentGuard(body: {
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
         permissionDecision: "allow",
-        additionalContext: `WATCHDOG: Background agent "${name}" launching. If not already running, start an agent watchdog Monitor:\nMonitor({ description: "Agent watchdog", persistent: true, timeout_ms: 3600000, command: "bun $HOME/.claude/PAI/TOOLS/AgentWatchdog.ts" })`,
+        additionalContext: `WATCHDOG: Background agent "${name}" launching. If not already running, start an agent watchdog Monitor:\nMonitor({ description: "Agent watchdog", persistent: true, timeout_ms: 3600000, command: "bun ${process.env.PAI_DIR ?? `${process.env.HOME}/.claude/PAI`}/TOOLS/AgentWatchdog.ts" })`,
       },
     })
   }

--- a/Releases/v5.0.0/.claude/skills/Agents/Tools/ComposeAgent.ts
+++ b/Releases/v5.0.0/.claude/skills/Agents/Tools/ComposeAgent.ts
@@ -34,8 +34,9 @@ import Handlebars from "handlebars";
 
 // Paths
 const HOME = process.env.HOME || "~";
+const PAI_DIR = process.env.PAI_DIR || `${HOME}/.claude/PAI`;
 const BASE_TRAITS_PATH = `${HOME}/.claude/skills/Agents/Data/Traits.yaml`;
-const USER_TRAITS_PATH = `${HOME}/.claude/PAI/USER/SKILLCUSTOMIZATIONS/Agents/Traits.yaml`;
+const USER_TRAITS_PATH = `${PAI_DIR}/USER/SKILLCUSTOMIZATIONS/Agents/Traits.yaml`;
 const TEMPLATE_PATH = `${HOME}/.claude/skills/Agents/Templates/DynamicAgent.hbs`;
 const CUSTOM_AGENTS_DIR = `${HOME}/.claude/custom-agents`;
 


### PR DESCRIPTION
## Problem

`PAI_DIR` is honored inconsistently in v5.0.0. `PAI/TOOLS/paths.ts` (`paiPath()`) reads it at runtime as designed, and `PAI/statusline-command.sh` (line 14) does `PAI_DIR="${PAI_DIR:-$HOME/.claude/PAI}"` and uses the variable in the rest of the script. Three other files hardcode `$HOME/.claude/PAI/...` directly, breaking the contract for any caller that sets `PAI_DIR` to a non-default location.

For default upstream installs (where `PAI_DIR=$HOME/.claude/PAI` per `settings.json:4`) the behavior is identical, so this is invisible. The bug only surfaces if a downstream installer or user overrides `PAI_DIR`.

## Fix

Three small changes (~3 lines total) — same fallback pattern that `statusline-command.sh:14` already uses:

1. **`PAI/PULSE/manage.sh:5`** — `PULSE_DIR="$HOME/.claude/PAI/PULSE"` → `PULSE_DIR="${PAI_DIR:-$HOME/.claude/PAI}/PULSE"`. Otherwise `manage.sh` start/stop/restart points at the wrong directory under non-default `PAI_DIR`.

2. **`PAI/PULSE/modules/hooks.ts:118`** — Watchdog Monitor command string interpolated `bun $HOME/.claude/PAI/TOOLS/AgentWatchdog.ts`. Switched to runtime `process.env.PAI_DIR` with `$HOME/.claude/PAI` fallback. Otherwise the watchdog launches the wrong path under non-default `PAI_DIR`.

3. **`skills/Agents/Tools/ComposeAgent.ts:38`** — `USER_TRAITS_PATH` was `${HOME}/.claude/PAI/USER/SKILLCUSTOMIZATIONS/Agents/Traits.yaml`. Now reads `PAI_DIR` from env. The other paths in the same block (`BASE_TRAITS_PATH`, `TEMPLATE_PATH`, `CUSTOM_AGENTS_DIR`) target `~/.claude/skills/` and `~/.claude/custom-agents/` which are install-root paths, NOT inside `PAI_DIR` — those correctly stay as-is.

## What I deliberately did NOT change

- **`PAI/statusline-command.sh:63,77`** — these look like hardcodes but are actually intentional defensive fallbacks. Lines 61-65 try `$PAI_DIR/ALGORITHM/LATEST` first, then literal paths. Comments on lines 57-59 explicitly explain: "Hardened against Claude Code's hook-spawn context where $HOME or $PAI_DIR may not resolve as expected." Not a bug.

- **`settings.json:9` (`GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE`)** and **`settings.json:381`** (statusline command path). I couldn't verify whether Claude Code's settings parser resolves `${PAI_DIR}` from the env block at parse time. Without that verification, refusing to file as a bug.

- **`PAI/TOOLS/gmail.ts:17`** — comment only, not code.

## Scope

3 files, 4 insertions, 3 deletions. No new dependencies. No API changes. Behavior unchanged for default upstream installs (where `PAI_DIR=$HOME/.claude/PAI`).

## Verified

- `rg -n 'HOME/\.claude/PAI' Releases/v5.0.0/.claude/` returns these 3 plus the intentional fallbacks and the gmail.ts comment, no other production code.
- All 3 changes use the same fallback pattern (`${PAI_DIR:-$HOME/.claude/PAI}` for shell, `process.env.PAI_DIR ?? \`${process.env.HOME}/.claude/PAI\`` for TS) that's already established in the codebase.
