### PR TITLE
fix: wire Pulse TELOS dashboard to real user data

### DIFF
--- a/Releases/v5.0.0/.claude/PAI/PULSE/Observability/observability.ts
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/Observability/observability.ts
@@ -1553,10 +1553,13 @@ function parseCurrencyCell(cell: string): number {
 
 function parseGoals(content: string): { id: string, text: string }[] {
   return content.split("\n")
-    .filter(l => /^[-*]\s*\*{0,2}G\d+\*{0,2}:/.test(l))
+    .filter(l => /^[-*]\s*\*{0,2}G\d+\*{0,2}:/.test(l) || /^[-*]\s*Goal\s+\d+:/.test(l))
     .map(l => {
-      const m = l.match(/\*{0,2}(G\d+)\*{0,2}:\s*(.+)/)
-      return m ? { id: m[1], text: m[2].trim() } : null
+      const m1 = l.match(/\*{0,2}(G\d+)\*{0,2}:\s*(.+)/)
+      if (m1) return { id: m1[1], text: m1[2].trim() }
+      const m2 = l.match(/Goal\s+(\d+):\s*(.+)/)
+      if (m2) return { id: `G${m2[1]}`, text: m2[2].trim() }
+      return null
     })
     .filter(Boolean) as { id: string, text: string }[]
 }
@@ -1566,6 +1569,13 @@ function parseSections(content: string): { heading: string, body: string }[] {
   const sections: { heading: string, body: string }[] = []
 
   const parts = content.split(/^## /m)
+  // Also scan preamble (parts[0]) for ID-bullet items (e.g. "- **P2:** description")
+  const preamble = parts[0] ?? ""
+  for (const line of preamble.split("\n")) {
+    const mb = (line.match(/^-\s+\*{0,2}([A-Z]{1,3}\d+[a-z]?):\*{0,2}\s*(.+)/) ??
+                line.match(/^-\s+\*{0,2}([A-Z]{1,3}\d+[a-z]?)\*{0,2}:\s*(.+)$/))
+    if (mb) sections.push({ heading: `${mb[1]}: ${mb[2].slice(0, 70).trim()}`, body: mb[2].trim() })
+  }
   for (const part of parts.slice(1)) {
     const newline = part.indexOf("\n")
     if (newline === -1) continue
@@ -1594,7 +1604,7 @@ function parseSections(content: string): { heading: string, body: string }[] {
   }
 
   for (const line of lines) {
-    const idBullet = line.match(/^-\s+\*{0,2}([A-Z]{1,3}\d+[a-z]?)\*{0,2}:\s*(.+)$/)
+    const idBullet = line.match(/^-\s+\*{0,2}([A-Z]{1,3}\d+[a-z]?):\*{0,2}\s*(.+)/) ?? line.match(/^-\s+\*{0,2}([A-Z]{1,3}\d+[a-z]?)\*{0,2}:\s*(.+)$/)
     const plainBullet = line.match(/^-\s+(.+)$/)
     const indented = line.match(/^\s+(\S.*)$/)
     const isBlank = line.trim() === ""
@@ -1603,7 +1613,7 @@ function parseSections(content: string): { heading: string, body: string }[] {
     if (idBullet) {
       commitPara()
       commitBullet()
-      currentBullet = { heading: idBullet[1], body: idBullet[2].trim() }
+      currentBullet = { heading: `${idBullet[1]}: ${idBullet[2].slice(0, 70).trim()}`, body: idBullet[2].trim() }
     } else if (plainBullet) {
       commitPara()
       commitBullet()
@@ -2227,8 +2237,11 @@ function firstParagraph(value: string): string {
 
 function parseHeadingText(heading: string, prefix: string, body: string): ParsedHeading | null {
   const match = heading.match(new RegExp(`^(${prefix}\\d+[a-z]?)\\s*:\\s*(.+)$`, "i"))
-  if (!match) return null
-  return { id: match[1], title: cleanInlineMarkdown(match[2]), body }
+  if (match) return { id: match[1], title: cleanInlineMarkdown(match[2]), body }
+  // Fallback: "Word N: title" where Word starts with prefix letter (e.g. "Challenge 1: title" for prefix "C")
+  const wordMatch = heading.match(new RegExp(`^${prefix}\\w+\\s+(\\d+[a-z]?):\\s*(.+)$`, "i"))
+  if (wordMatch) return { id: `${prefix.toUpperCase()}${wordMatch[1]}`, title: cleanInlineMarkdown(wordMatch[2]), body }
+  return null
 }
 
 function parseNestedHeadings(body: string, prefix: string): ParsedHeading[] {
@@ -2244,9 +2257,15 @@ function parseNestedHeadings(body: string, prefix: string): ParsedHeading[] {
 
   for (const line of body.split("\n")) {
     const match = line.match(new RegExp(`^#{2,4}\\s+(${prefix}\\d+[a-z]?)\\s*:\\s*(.+)$`, "i"))
+    // Fallback: match "## Word N: title" where Word starts with prefix letter (e.g. "Challenge 1:" → C1)
+    const wordMatch = !match ? line.match(new RegExp(`^#{2,4}\\s+${prefix}\\w+\\s+(\\d+[a-z]?):\\s*(.+)$`, "i")) : null
     if (match) {
       commit()
       current = { id: match[1], title: cleanInlineMarkdown(match[2]), body: "" }
+      currentBody = []
+    } else if (wordMatch) {
+      commit()
+      current = { id: `${prefix.toUpperCase()}${wordMatch[1]}`, title: cleanInlineMarkdown(wordMatch[2]), body: "" }
       currentBody = []
     } else if (current) {
       currentBody.push(line)
@@ -2325,10 +2344,22 @@ async function handleTelosOverview(): Promise<Response> {
       return Response.json({ error: `life goals returned ${lifeResponse.status}` }, { status: 500 })
     }
     const life = await lifeResponse.json() as LifeGoalsPayload
-    const missions = parseSourceHeadings(asLifeSections(life.mission), "M").map((m) => ({
+    let missions = parseSourceHeadings(asLifeSections(life.mission), "M").map((m) => ({
       id: m.id,
       title: m.title,
     }))
+    // Fallback: parse MISSION.md prose using bold-labeled sections (e.g. **Current Mission Statement:**)
+    if (missions.length === 0) {
+      const missionRaw = readMd(join(TELOS_DIR, "MISSION.md"))
+      const boldSections = missionRaw.match(/\*\*([^*]+):\*\*\s*\n+([^\n*]+(?:\n(?!\n\*\*)[^\n]+)*)/g) || []
+      missions = boldSections.slice(0, 4).map((block, i) => {
+        const headerMatch = block.match(/\*\*([^*]+):\*\*\s*\n+(.+)/s)
+        return {
+          id: `M${i}`,
+          title: headerMatch ? cleanInlineMarkdown(headerMatch[2]).slice(0, 100).replace(/\s+/g, " ").trim() : `Mission ${i + 1}`,
+        }
+      }).filter((m) => m.title.length > 5)
+    }
     const goals = asLifeGoals(life.goals).map((g) => ({
       id: g.id,
       title: cleanInlineMarkdown(g.title ?? g.text ?? g.id),
@@ -2349,11 +2380,14 @@ async function handleTelosOverview(): Promise<Response> {
     const strategies = parseSourceHeadings(asLifeSections(life.strategies), "S").map((s) => ({
       id: s.id,
       title: s.title,
+      overcomes: [],
       implements: [],
     }))
     const challenges = parseSourceHeadings(asLifeSections(life.challenges), "C").map((c) => ({
       id: c.id,
       title: c.title,
+      note: firstParagraph(c.body),
+      blocks: [],
     }))
 
     return Response.json({

--- a/Releases/v5.0.0/.claude/PAI/PULSE/Observability/src/app/telos/_v7/use-telos-data.ts
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/Observability/src/app/telos/_v7/use-telos-data.ts
@@ -1,15 +1,96 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { TELOS as FALLBACK, type Telos } from "./data";
 
+function mergeTelosData(fallback: Telos, api: Partial<Record<string, unknown>>): Telos {
+  const merged: Telos = { ...fallback };
+
+  if (api.owner && typeof api.owner === "object") {
+    merged.owner = api.owner as Telos["owner"];
+  }
+  if (api.idealState && typeof api.idealState === "object") {
+    merged.idealState = api.idealState as Telos["idealState"];
+  }
+  if (Array.isArray(api.dimensions) && api.dimensions.length > 0) {
+    merged.dimensions = api.dimensions as Telos["dimensions"];
+  }
+  if (Array.isArray(api.problems) && api.problems.length > 0) {
+    merged.problems = (api.problems as Array<Record<string, unknown>>).map((p) => ({
+      id: String(p.id ?? ""),
+      title: String(p.title ?? ""),
+      note: String(p.note ?? ""),
+      severity: (["high", "med", "low"].includes(String(p.severity)) ? p.severity : "med") as "high" | "med" | "low",
+      affects: Array.isArray(p.affects) ? (p.affects as string[]) : [],
+    }));
+  }
+  if (Array.isArray(api.missions) && api.missions.length > 0) {
+    merged.missions = (api.missions as Array<Record<string, unknown>>).map((m) => ({
+      id: String(m.id ?? ""),
+      title: String(m.title ?? ""),
+      horizon: String(m.horizon ?? ""),
+      active: Boolean(m.active),
+      addresses: Array.isArray(m.addresses) ? (m.addresses as string[]) : [],
+    }));
+  }
+  if (Array.isArray(api.goals) && api.goals.length > 0) {
+    merged.goals = (api.goals as Array<Record<string, unknown>>).map((g) => ({
+      id: String(g.id ?? ""),
+      title: String(g.title ?? g.text ?? ""),
+      kpi: String(g.kpi ?? ""),
+      target: String(g.target ?? ""),
+      pct: typeof g.pct === "number" ? g.pct : 0,
+      delta: typeof g.delta === "number" ? g.delta : 0,
+      dims: Array.isArray(g.dims) ? (g.dims as string[]) : [],
+      metrics: Array.isArray(g.metrics) ? (g.metrics as string[]) : [],
+    }));
+  }
+  if (Array.isArray(api.metrics) && api.metrics.length > 0) {
+    merged.metrics = api.metrics as Telos["metrics"];
+  }
+  if (Array.isArray(api.challenges) && api.challenges.length > 0) {
+    merged.challenges = (api.challenges as Array<Record<string, unknown>>).map((c) => ({
+      id: String(c.id ?? ""),
+      title: String(c.title ?? ""),
+      note: String(c.note ?? ""),
+      blocks: Array.isArray(c.blocks) ? (c.blocks as string[]) : [],
+    }));
+  }
+  if (Array.isArray(api.strategies) && api.strategies.length > 0) {
+    merged.strategies = (api.strategies as Array<Record<string, unknown>>).map((s) => ({
+      id: String(s.id ?? ""),
+      title: String(s.title ?? ""),
+      overcomes: Array.isArray(s.overcomes) ? (s.overcomes as string[]) : [],
+      implements: Array.isArray(s.implements) ? (s.implements as string[]) : [],
+      active: Boolean(s.active),
+    }));
+  }
+
+  return merged;
+}
+
 export function useTelosData(): { telos: Telos | null; refetch: () => void; error: string | null } {
-  const [version, setVersion] = useState<number>(0);
+  const [telos, setTelos] = useState<Telos>(FALLBACK);
+  const [error, setError] = useState<string | null>(null);
+  const [version, setVersion] = useState(0);
 
-  const refetch = useCallback(() => {
-    setVersion((value) => value + 1);
-  }, []);
+  const refetch = useCallback(() => setVersion((v) => v + 1), []);
 
-  void version;
-  return { telos: FALLBACK, refetch, error: null };
+  useEffect(() => {
+    fetch("/api/telos/overview")
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json() as Promise<Partial<Record<string, unknown>>>;
+      })
+      .then((data) => {
+        setTelos(mergeTelosData(FALLBACK, data));
+        setError(null);
+      })
+      .catch((err: unknown) => {
+        console.warn("[useTelosData] API fetch failed, using fallback:", err);
+        setError(err instanceof Error ? err.message : String(err));
+      });
+  }, [version]);
+
+  return { telos, refetch, error };
 }

--- a/Releases/v5.0.0/.claude/PAI/PULSE/Observability/src/app/telos/_v7/use-telos-data.ts
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/Observability/src/app/telos/_v7/use-telos-data.ts
@@ -3,67 +3,244 @@
 import { useCallback, useEffect, useState } from "react";
 import { TELOS as FALLBACK, type Telos } from "./data";
 
-function mergeTelosData(fallback: Telos, api: Partial<Record<string, unknown>>): Telos {
+type Dict = Record<string, unknown>;
+
+const asString = (v: unknown): string => String(v ?? "");
+const asNumber = (v: unknown): number => (typeof v === "number" ? v : 0);
+const asStringArray = (v: unknown): string[] => (Array.isArray(v) ? (v as string[]) : []);
+const asNumberArray = (v: unknown): number[] => (Array.isArray(v) ? (v as number[]) : []);
+
+const oneOf = <T extends string>(v: unknown, allowed: readonly T[], fallback: T): T =>
+  (allowed as readonly string[]).includes(String(v)) ? (v as T) : fallback;
+
+function mergeTelosData(fallback: Telos, api: Partial<Dict>): Telos {
   const merged: Telos = { ...fallback };
 
   if (api.owner && typeof api.owner === "object") {
-    merged.owner = api.owner as Telos["owner"];
+    const o = api.owner as Dict;
+    merged.owner = {
+      name: asString(o.name),
+      day: asString(o.day),
+      streak: asNumber(o.streak),
+    };
   }
+
   if (api.idealState && typeof api.idealState === "object") {
-    merged.idealState = api.idealState as Telos["idealState"];
+    const i = api.idealState as Dict;
+    merged.idealState = {
+      horizon: asString(i.horizon),
+      note: asString(i.note),
+    };
   }
+
   if (Array.isArray(api.dimensions) && api.dimensions.length > 0) {
-    merged.dimensions = api.dimensions as Telos["dimensions"];
+    merged.dimensions = (api.dimensions as Dict[]).map((d) => ({
+      id: asString(d.id),
+      label: asString(d.label),
+      cur: asNumber(d.cur),
+      ideal: asNumber(d.ideal),
+      velo: asNumber(d.velo),
+      color: asString(d.color),
+    }));
   }
+
+  if (Array.isArray(api.snapshot) && api.snapshot.length > 0) {
+    merged.snapshot = (api.snapshot as Dict[]).map((s) => ({
+      id: asString(s.id),
+      label: asString(s.label),
+      v: asNumber(s.v),
+      of: asNumber(s.of),
+    }));
+  }
+
   if (Array.isArray(api.problems) && api.problems.length > 0) {
-    merged.problems = (api.problems as Array<Record<string, unknown>>).map((p) => ({
-      id: String(p.id ?? ""),
-      title: String(p.title ?? ""),
-      note: String(p.note ?? ""),
-      severity: (["high", "med", "low"].includes(String(p.severity)) ? p.severity : "med") as "high" | "med" | "low",
-      affects: Array.isArray(p.affects) ? (p.affects as string[]) : [],
+    merged.problems = (api.problems as Dict[]).map((p) => ({
+      id: asString(p.id),
+      title: asString(p.title),
+      note: asString(p.note),
+      severity: oneOf(p.severity, ["high", "med", "low"] as const, "med"),
+      affects: asStringArray(p.affects),
     }));
   }
+
   if (Array.isArray(api.missions) && api.missions.length > 0) {
-    merged.missions = (api.missions as Array<Record<string, unknown>>).map((m) => ({
-      id: String(m.id ?? ""),
-      title: String(m.title ?? ""),
-      horizon: String(m.horizon ?? ""),
+    merged.missions = (api.missions as Dict[]).map((m) => ({
+      id: asString(m.id),
+      title: asString(m.title),
+      horizon: asString(m.horizon),
       active: Boolean(m.active),
-      addresses: Array.isArray(m.addresses) ? (m.addresses as string[]) : [],
+      addresses: asStringArray(m.addresses),
     }));
   }
+
   if (Array.isArray(api.goals) && api.goals.length > 0) {
-    merged.goals = (api.goals as Array<Record<string, unknown>>).map((g) => ({
-      id: String(g.id ?? ""),
-      title: String(g.title ?? g.text ?? ""),
-      kpi: String(g.kpi ?? ""),
-      target: String(g.target ?? ""),
-      pct: typeof g.pct === "number" ? g.pct : 0,
-      delta: typeof g.delta === "number" ? g.delta : 0,
-      dims: Array.isArray(g.dims) ? (g.dims as string[]) : [],
-      metrics: Array.isArray(g.metrics) ? (g.metrics as string[]) : [],
+    merged.goals = (api.goals as Dict[]).map((g) => ({
+      id: asString(g.id),
+      title: asString(g.title),
+      kpi: asString(g.kpi),
+      target: asString(g.target),
+      pct: asNumber(g.pct),
+      delta: asNumber(g.delta),
+      dims: asStringArray(g.dims),
+      metrics: asStringArray(g.metrics),
     }));
   }
+
   if (Array.isArray(api.metrics) && api.metrics.length > 0) {
-    merged.metrics = api.metrics as Telos["metrics"];
-  }
-  if (Array.isArray(api.challenges) && api.challenges.length > 0) {
-    merged.challenges = (api.challenges as Array<Record<string, unknown>>).map((c) => ({
-      id: String(c.id ?? ""),
-      title: String(c.title ?? ""),
-      note: String(c.note ?? ""),
-      blocks: Array.isArray(c.blocks) ? (c.blocks as string[]) : [],
+    merged.metrics = (api.metrics as Dict[]).map((m) => ({
+      id: asString(m.id),
+      label: asString(m.label),
+      value: asString(m.value),
+      unit: asString(m.unit),
+      trend: asNumber(m.trend),
+      spark: asNumberArray(m.spark),
+      feeds: asStringArray(m.feeds),
+      color: asString(m.color),
     }));
   }
+
+  if (Array.isArray(api.challenges) && api.challenges.length > 0) {
+    merged.challenges = (api.challenges as Dict[]).map((c) => ({
+      id: asString(c.id),
+      title: asString(c.title),
+      note: asString(c.note),
+      blocks: asStringArray(c.blocks),
+    }));
+  }
+
   if (Array.isArray(api.strategies) && api.strategies.length > 0) {
-    merged.strategies = (api.strategies as Array<Record<string, unknown>>).map((s) => ({
-      id: String(s.id ?? ""),
-      title: String(s.title ?? ""),
-      overcomes: Array.isArray(s.overcomes) ? (s.overcomes as string[]) : [],
-      implements: Array.isArray(s.implements) ? (s.implements as string[]) : [],
+    merged.strategies = (api.strategies as Dict[]).map((s) => ({
+      id: asString(s.id),
+      title: asString(s.title),
+      overcomes: asStringArray(s.overcomes),
+      implements: asStringArray(s.implements),
       active: Boolean(s.active),
     }));
+  }
+
+  if (Array.isArray(api.projects) && api.projects.length > 0) {
+    merged.projects = (api.projects as Dict[]).map((p) => ({
+      id: asString(p.id),
+      title: asString(p.title),
+      strategy: asString(p.strategy),
+      dims: asStringArray(p.dims),
+      status: oneOf(p.status, ["green", "amber", "red"] as const, "green"),
+      work: Array.isArray(p.work)
+        ? (p.work as Dict[]).map((w) => ({
+            id: asString(w.id),
+            title: asString(w.title),
+            strategy: asString(w.strategy),
+            eta: asString(w.eta),
+            status: oneOf(w.status, ["green", "amber", "red"] as const, "green"),
+            owner: asString(w.owner),
+          }))
+        : [],
+      team: Array.isArray(p.team) ? (p.team as string[]) : undefined,
+    }));
+  }
+
+  if (Array.isArray(api.team) && api.team.length > 0) {
+    merged.team = (api.team as Dict[]).map((t) => ({
+      id: asString(t.id),
+      name: asString(t.name),
+      role: asString(t.role),
+      kind: oneOf(t.kind, ["human", "agent"] as const, "human"),
+      owns: asStringArray(t.owns),
+      avatar: asString(t.avatar),
+      note: asString(t.note),
+    }));
+  }
+
+  if (Array.isArray(api.budget) && api.budget.length > 0) {
+    merged.budget = (api.budget as Dict[]).map((b) => ({
+      id: asString(b.id),
+      kind: oneOf(b.kind, ["money", "time", "attention"] as const, "money"),
+      label: asString(b.label),
+      value: asString(b.value),
+      of: asString(b.of),
+      pct: asNumber(b.pct),
+      funds: asStringArray(b.funds),
+      note: asString(b.note),
+      warn: typeof b.warn === "boolean" ? b.warn : undefined,
+    }));
+  }
+
+  if (Array.isArray(api.recommendations) && api.recommendations.length > 0) {
+    merged.recommendations = (api.recommendations as Dict[]).map((r) => ({
+      id: asString(r.id),
+      action: asString(r.action),
+      because: asString(r.because),
+      upstream: asStringArray(r.upstream),
+      effort: asString(r.effort),
+      impact: oneOf(r.impact, ["high", "med", "low"] as const, "med"),
+    }));
+  }
+
+  if (api.stranded && typeof api.stranded === "object") {
+    const s = api.stranded as Dict;
+    merged.stranded = {
+      work_no_goal: Array.isArray(s.work_no_goal)
+        ? (s.work_no_goal as Dict[]).map((w) => ({
+            id: asString(w.id),
+            title: asString(w.title),
+            owner: asString(w.owner),
+            age: asString(w.age),
+          }))
+        : [],
+      goals_no_strategy: Array.isArray(s.goals_no_strategy)
+        ? (s.goals_no_strategy as Dict[]).map((g) => ({
+            id: asString(g.id),
+            title: asString(g.title),
+            reason: asString(g.reason),
+          }))
+        : [],
+      strategies_idle: Array.isArray(s.strategies_idle)
+        ? (s.strategies_idle as Dict[]).map((st) => ({
+            id: asString(st.id),
+            title: asString(st.title),
+            reason: asString(st.reason),
+          }))
+        : [],
+    };
+  }
+
+  if (Array.isArray(api.subtabs) && api.subtabs.length > 0) {
+    merged.subtabs = (api.subtabs as Dict[]).map((s) => ({
+      id: asString(s.id),
+      label: asString(s.label),
+      dim: asString(s.dim),
+      cur: asNumber(s.cur),
+      ideal: asNumber(s.ideal),
+      velo: asNumber(s.velo),
+      target: asString(s.target),
+      top: asString(s.top),
+    }));
+  }
+
+  if (api.preferences && typeof api.preferences === "object") {
+    const p = api.preferences as Dict;
+    merged.preferences = {
+      books: asStringArray(p.books),
+      films: asStringArray(p.films),
+      anime: asStringArray(p.anime),
+      characters: asStringArray(p.characters),
+      aphorisms: asStringArray(p.aphorisms),
+      hobbies: asStringArray(p.hobbies),
+      literature: asStringArray(p.literature),
+    };
+  }
+
+  if (api.narrativeSeed && typeof api.narrativeSeed === "object") {
+    const n = api.narrativeSeed as Dict;
+    merged.narrativeSeed = {
+      days_into: asNumber(n.days_into),
+      push_name: asString(n.push_name),
+      current_work: asString(n.current_work),
+      via_strategy: asString(n.via_strategy),
+      addresses: asString(n.addresses),
+      moves_goal: asString(n.moves_goal),
+      serves_mission: asString(n.serves_mission),
+    };
   }
 
   return merged;
@@ -80,7 +257,7 @@ export function useTelosData(): { telos: Telos | null; refetch: () => void; erro
     fetch("/api/telos/overview")
       .then((r) => {
         if (!r.ok) throw new Error(`HTTP ${r.status}`);
-        return r.json() as Promise<Partial<Record<string, unknown>>>;
+        return r.json() as Promise<Partial<Dict>>;
       })
       .then((data) => {
         setTelos(mergeTelosData(FALLBACK, data));


### PR DESCRIPTION
## Overview
This PR wires the Pulse TELOS dashboard to live user data by fetching from the `/api/telos/overview` endpoint and implements a series of parser improvements to handle real-world Markdown variations in the TELOS primitive files (Missions, Goals, Challenges, Strategies, and Problems).

## Key Changes

### 🔌 Exhaustive Data Hydration (`use-telos-data.ts`)
- **Runtime Fetching:** Transitioned the dashboard from static fallbacks to live API fetching with hydration via `useEffect`.
- **Robust Merging Logic:** Implemented an exhaustive `mergeTelosData` function that performs field-by-field validation and type-safe merging for the entire TELOS schema. This ensures the UI stays resilient by falling back to baseline data only when specific API fields are missing or malformed.
- **Coverage:** Added merging support for Dimensions, Snapshots, Problems, Missions, Goals, Metrics, Challenges, Strategies, Projects, Team, Budget, Recommendations, and Narrative Seeds.

### 🔍 Robust Markdown Parsing (`observability.ts`)
- **Preamble Support:** `parseSections` now scans file preambles for ID-bullets (e.g., `- **P2:**`) that appear before the first `##` heading, ensuring no data is lost in files like `PROBLEMS.md`.
- **Format Flexibility:** 
  - Added support for `Goal N: text` and `Challenge N: text` formats alongside standard ID-prefixes.
  - Updated regex to handle bold colons (e.g., `**P2:**`) frequently used in manual edits.
- **Prose Extraction:** Added a fallback for `MISSION.md` that extracts bold-labeled sections as missions when explicit ID headings are absent.
- **Heading Normalization:** Improved heading parsing to normalize word-prefixes into standard IDs (e.g., "Challenge 1" -> `C1`).

### 🛠️ Schema & Type Cleanup
- Enriched the API response with missing fields for `strategies` (`overcomes`) and `challenges` (`note`, `blocks`).
- Cleaned up internal types and introduced `Dict` helpers for cleaner data transformation.

## Verification
- Dashboard successfully hydrates with real data from local TELOS files.
- Verified parser handles both "Goal 1:" and "G1:" formats.
- Confirmed preamble items in `PROBLEMS.md` are correctly captured.
