### PR TITLE
feat(pulse): add Linux systemd support to init scripts

### DIFF
--- a/Releases/v5.0.0/.claude/PAI/PULSE/com.pai.pulse.service
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/com.pai.pulse.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=PAI Pulse — unified daemon (cron, voice, observability, hooks)
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=__BUN_PATH__ run pulse.ts
+WorkingDirectory=__HOME__/.claude/PAI/PULSE
+Restart=on-failure
+RestartSec=30
+TimeoutStopSec=5
+Environment=HOME=__HOME__
+Environment=PATH=__HOME__/.bun/bin:/usr/local/bin:/usr/bin:/bin
+StandardOutput=append:__HOME__/.claude/PAI/PULSE/logs/pulse-stdout.log
+StandardError=append:__HOME__/.claude/PAI/PULSE/logs/pulse-stderr.log
+
+[Install]
+WantedBy=default.target

--- a/Releases/v5.0.0/.claude/PAI/PULSE/manage.sh
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/manage.sh
@@ -28,19 +28,34 @@ else
   BUN_PATH="$(command -v bun || echo "$HOME/.bun/bin/bun")"
 fi
 
+# OS detection — Linux uses systemd --user, macOS uses launchctl.
+OS=$(uname -s)
+SERVICE_SRC="$PULSE_DIR/$PLIST_NAME.service"
+SYSTEMD_SERVICE_DIR="$HOME/.config/systemd/user"
+SERVICE_DST="$SYSTEMD_SERVICE_DIR/$PLIST_NAME.service"
+
 case "$1" in
   start)
-    if [ ! -f "$PLIST_DST" ]; then
-      # Substitute __HOME__ + __BUN_PATH__ placeholders (public template);
-      # no-op on plists that already have literal paths.
-      sed -e "s|__HOME__|$HOME|g" -e "s|__BUN_PATH__|$BUN_PATH|g" "$PLIST_SRC" > "$PLIST_DST"
+    if [ "$OS" = "Linux" ]; then
+      systemctl --user start "$PLIST_NAME"
+      echo "PAI Pulse started"
+    else
+      if [ ! -f "$PLIST_DST" ]; then
+        # Substitute __HOME__ + __BUN_PATH__ placeholders (public template);
+        # no-op on plists that already have literal paths.
+        sed -e "s|__HOME__|$HOME|g" -e "s|__BUN_PATH__|$BUN_PATH|g" "$PLIST_SRC" > "$PLIST_DST"
+      fi
+      launchctl load "$PLIST_DST" 2>/dev/null
+      echo "PAI Pulse started"
     fi
-    launchctl load "$PLIST_DST" 2>/dev/null
-    echo "PAI Pulse started"
     ;;
 
   stop)
-    launchctl unload "$PLIST_DST" 2>/dev/null
+    if [ "$OS" = "Linux" ]; then
+      systemctl --user stop "$PLIST_NAME" 2>/dev/null
+    else
+      launchctl unload "$PLIST_DST" 2>/dev/null
+    fi
     if [ -f "$PID_FILE" ]; then
       PID=$(cat "$PID_FILE")
       kill "$PID" 2>/dev/null
@@ -57,16 +72,20 @@ case "$1" in
     ;;
 
   status)
-    if [ -f "$PID_FILE" ]; then
-      PID=$(cat "$PID_FILE")
-      if ps -p "$PID" > /dev/null 2>&1; then
-        UPTIME=$(ps -p "$PID" -o etime= | xargs)
-        echo "PAI Pulse: RUNNING (PID $PID, uptime $UPTIME)"
-      else
-        echo "PAI Pulse: DEAD (stale PID $PID)"
-      fi
+    if [ "$OS" = "Linux" ]; then
+      systemctl --user status "$PLIST_NAME"
     else
-      echo "PAI Pulse: NOT RUNNING (no PID file)"
+      if [ -f "$PID_FILE" ]; then
+        PID=$(cat "$PID_FILE")
+        if ps -p "$PID" > /dev/null 2>&1; then
+          UPTIME=$(ps -p "$PID" -o etime= | xargs)
+          echo "PAI Pulse: RUNNING (PID $PID, uptime $UPTIME)"
+        else
+          echo "PAI Pulse: DEAD (stale PID $PID)"
+        fi
+      else
+        echo "PAI Pulse: NOT RUNNING (no PID file)"
+      fi
     fi
 
     if [ -f "$STATE_FILE" ]; then
@@ -86,19 +105,37 @@ case "$1" in
   install)
     mkdir -p "$PULSE_DIR/state" "$PULSE_DIR/logs"
 
-    # Cleanup any prior pulse before installing fresh — prevents the stale-PID
-    # / unbound-port half-dead state where a previous launchd-managed pulse is
-    # alive with open fds but never bound :31337.
-    if [ -f "$PLIST_DST" ]; then
-      launchctl unload "$PLIST_DST" 2>/dev/null || true
-    fi
-    pkill -9 -f "bun.*pulse.ts" 2>/dev/null || true
-    sleep 1
+    if [ "$OS" = "Linux" ]; then
+      mkdir -p "$SYSTEMD_SERVICE_DIR"
+      # Kill any prior pulse before installing fresh — prevents the stale-PID
+      # / unbound-port half-dead state where a previous service-managed pulse
+      # is alive with open fds but never bound :31337.
+      systemctl --user stop "$PLIST_NAME" 2>/dev/null || true
+      pkill -9 -f "bun.*pulse.ts" 2>/dev/null || true
+      sleep 1
+      # Substitute __HOME__ + __BUN_PATH__ placeholders (public template);
+      # no-op on service files that already have literal paths.
+      sed -e "s|__HOME__|$HOME|g" -e "s|__BUN_PATH__|$BUN_PATH|g" "$SERVICE_SRC" > "$SERVICE_DST"
+      # Ensure user services survive logout/reboot (no-op if already enabled)
+      loginctl enable-linger "$USER" 2>/dev/null || true
+      systemctl --user daemon-reload
+      systemctl --user enable "$PLIST_NAME"
+      systemctl --user start "$PLIST_NAME"
+    else
+      # Cleanup any prior pulse before installing fresh — prevents the stale-PID
+      # / unbound-port half-dead state where a previous launchd-managed pulse is
+      # alive with open fds but never bound :31337.
+      if [ -f "$PLIST_DST" ]; then
+        launchctl unload "$PLIST_DST" 2>/dev/null || true
+      fi
+      pkill -9 -f "bun.*pulse.ts" 2>/dev/null || true
+      sleep 1
 
-    # Substitute __HOME__ + __BUN_PATH__ placeholders (public template);
-    # no-op on plists that already have literal paths.
-    sed -e "s|__HOME__|$HOME|g" -e "s|__BUN_PATH__|$BUN_PATH|g" "$PLIST_SRC" > "$PLIST_DST"
-    launchctl load "$PLIST_DST"
+      # Substitute __HOME__ + __BUN_PATH__ placeholders (public template);
+      # no-op on plists that already have literal paths.
+      sed -e "s|__HOME__|$HOME|g" -e "s|__BUN_PATH__|$BUN_PATH|g" "$PLIST_SRC" > "$PLIST_DST"
+      launchctl load "$PLIST_DST"
+    fi
 
     # Verify pulse actually binds :31337 within 10s. Fail loud if not — prior
     # behavior was silent success even when the daemon never came up.
@@ -112,14 +149,19 @@ case "$1" in
       fi
     done
 
-    echo "ERROR: PAI Pulse plist installed but port 31337 did not bind within 10s." >&2
+    echo "ERROR: PAI Pulse installed but port 31337 did not bind within 10s." >&2
     echo "  Check: tail -50 $PULSE_DIR/logs/pulse-stderr.log" >&2
     exit 1
     ;;
 
   uninstall)
-    launchctl unload "$PLIST_DST" 2>/dev/null
-    rm -f "$PLIST_DST"
+    if [ "$OS" = "Linux" ]; then
+      systemctl --user disable --now "$PLIST_NAME" 2>/dev/null
+      rm -f "$SERVICE_DST"
+    else
+      launchctl unload "$PLIST_DST" 2>/dev/null
+      rm -f "$PLIST_DST"
+    fi
     echo "PAI Pulse uninstalled"
     ;;
 

--- a/Releases/v5.0.0/.claude/PAI/PULSE/package.json
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "pai-pulse",
+  "version": "2.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "bun run pulse.ts",
+    "install-service": "bash manage.sh install",
+    "status": "bash manage.sh status"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.1.0",
+    "grammy": "^1.34.0",
+    "jose": "^5.0.0",
+    "minisearch": "^7.0.0",
+    "smol-toml": "^1.3.0"
+  }
+}

--- a/Releases/v5.0.0/.claude/PAI/PULSE/start-pulse.sh
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/start-pulse.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Unlock keychain for headless access, then start Pulse
-# Each installation should replace the password with their own
-security unlock-keychain -p "${PULSE_KEYCHAIN_PASSWORD:-changeme}" ~/Library/Keychains/login.keychain-db 2>/dev/null
+# Unlock keychain for headless access (macOS only), then start Pulse
+if [ "$(uname -s)" = "Darwin" ]; then
+  security unlock-keychain -p "${PULSE_KEYCHAIN_PASSWORD:-changeme}" ~/Library/Keychains/login.keychain-db 2>/dev/null
+fi
 exec "${HOME}/.bun/bin/bun" run pulse.ts 2>/dev/null || exec /opt/homebrew/bin/bun run pulse.ts


### PR DESCRIPTION
## Problem

  `manage.sh install` fails on Linux with `launchctl: command not found`.
  The PULSE init scripts were written for macOS only — they use `launchctl`,
  launchd plist XML, and `~/Library/LaunchAgents/`. `start-pulse.sh` also
  unconditionally calls `security unlock-keychain`, another macOS-only binary.
  Pulse cannot be installed or auto-started on any Linux machine.

## Changes

**`manage.sh`** — detects OS via `uname -s` and branches per sub-command:
  - `install`: writes a systemd user-scope unit, calls `daemon-reload` /
    `enable` / `start`, then verifies port 31337 binds (same 10s probe as macOS)
  - `start` / `stop` / `status` / `uninstall`: use `systemctl --user` on Linux,
    unchanged launchctl path on macOS
  - Adds `loginctl enable-linger` so the service survives logout and auto-starts
    at boot on Linux
  - All macOS launchctl/plist code is preserved unchanged in `else` branches

**`com.pai.pulse.service`** — new systemd user-scope unit template using the
  same `__HOME__` / `__BUN_PATH__` placeholder pattern as the existing plist.
  Logs to `PULSE/logs/` to match macOS behavior. `TimeoutStopSec=5` prevents
  `systemctl stop` from hanging while waiting for bun to respond to SIGTERM.

**`start-pulse.sh`** — guards the keychain unlock behind a `uname -s` Darwin
  check so it no-ops on Linux.

**`package.json`** — PULSE had no `package.json`, so `smol-toml`, `grammy`,
  `jose`, and `minisearch` were unresolvable at runtime on a fresh install.

## Testing

  - Tested on Pop!_OS 24.04 LTS (systemd 255, bun 1.3.3)
  - `manage.sh install` → service enabled, port 31337 verified, `/healthz` → 200
  - macOS launchctl path verified by code inspection; not exercised on Darwin

