### PR TITLE
fix(pulse): correct Pulse→PULSE case in observability dashboard path

### DIFF
--- a/Releases/v5.0.0/.claude/PAI/PULSE/Observability/observability.ts
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/Observability/observability.ts
@@ -66,7 +66,7 @@ const SECURITY_LOG_DIR = join(MEMORY_DIR, "SECURITY")
 const SETTINGS_PATH = join(HOME, ".claude", "settings.json")
 const LADDER_DIR = join(HOME, "Projects", "Ladder")
 
-const DEFAULT_DASHBOARD_DIR = join(PAI_DIR, "Pulse", "Observability", "out")
+const DEFAULT_DASHBOARD_DIR = join(PAI_DIR, "PULSE", "Observability", "out")
 
 // ── In-Memory Store (hook-pushed state/events) ──
 
@@ -149,7 +149,7 @@ function getDashboardDir(): string {
   const dir = config.dashboard_dir ?? DEFAULT_DASHBOARD_DIR
   // Resolve relative paths against Pulse directory
   if (!dir.startsWith("/")) {
-    return join(HOME, ".claude", "PAI", "Pulse", dir)
+    return join(HOME, ".claude", "PAI", "PULSE", dir)
   }
   return dir
 }


### PR DESCRIPTION
  ## Problem

  `GET /` returns 404 on Linux. The Observability module hardcodes `"Pulse"`
  in two path constants, but the actual directory is `PULSE`. macOS filesystems
  are case-insensitive so this was silently correct there; Linux is not.

  ## Changes

  Two lines in `Observability/observability.ts`:

  - `DEFAULT_DASHBOARD_DIR` — `PAI/Pulse/Observability/out` → `PAI/PULSE/Observability/out`
  - `getDashboardDir()` relative-path resolver — same fix; this branch is hit
    whenever `PULSE.toml` sets a relative `dashboard_dir` (the default config does)

  ## Testing

  - Verified on Pop!_OS 24.04: `curl http://localhost:31337/` → HTTP 200 after fix
  - No macOS behavior change (path resolves identically on case-insensitive FS)

