### PR TITLE
fix(pulse): sweep remaining "Pulse" → "PULSE" path casing across all …

### DIFF
--- a/Releases/v5.0.0/.claude/PAI/PULSE/Observability/observability.ts
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/Observability/observability.ts
@@ -1647,7 +1647,7 @@ function readDirMdFiles(dir: string): { name: string, content: string, sections:
 function handleUserIndexApi(filter: string | null): Response {
   try {
     const PAI_DIR = process.env.PAI_DIR || join(process.env.HOME || "", ".claude", "PAI")
-    const indexPath = join(PAI_DIR, "Pulse", "state", "user-index.json")
+    const indexPath = join(PAI_DIR, "PULSE", "state", "user-index.json")
     const raw = Bun.file(indexPath)
     if (!raw.size) {
       return Response.json(

--- a/Releases/v5.0.0/.claude/PAI/PULSE/checks/github-work.ts
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/checks/github-work.ts
@@ -14,7 +14,7 @@ import { parse } from "smol-toml"
 import { SignJWT, importPKCS8 } from "jose"
 
 const HOME = process.env.HOME ?? ""
-const PULSE_DIR = join(HOME, ".claude", "PAI", "Pulse")
+const PULSE_DIR = join(HOME, ".claude", "PAI", "PULSE")
 const STATE_FILE = join(PULSE_DIR, "state", "work-token.json")
 
 // ── Worker Config (from PULSE.toml [worker] section) ──

--- a/Releases/v5.0.0/.claude/PAI/PULSE/checks/notification-governor.ts
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/checks/notification-governor.ts
@@ -34,7 +34,7 @@ import { createHash } from "crypto";
 
 const HOME = process.env.HOME || "";
 const PAI_DIR = process.env.PAI_DIR || join(HOME, ".claude", "PAI");
-const STATE_FILE = join(PAI_DIR, "Pulse", "state", "notification-governor.json");
+const STATE_FILE = join(PAI_DIR, "PULSE", "state", "notification-governor.json");
 const LOG_FILE = join(PAI_DIR, "MEMORY", "OBSERVABILITY", "notification-governor.jsonl");
 const NOTIFY_URL = "http://localhost:31337/notify";
 const VOICE_ID = "fTtv3eikoepIosk8dTZ5";

--- a/Releases/v5.0.0/.claude/PAI/PULSE/checks/poller-meta-monitor.ts
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/checks/poller-meta-monitor.ts
@@ -20,8 +20,8 @@ import { join } from "path";
 
 const HOME = process.env.HOME || "";
 const PAI_DIR = process.env.PAI_DIR || join(HOME, ".claude", "PAI");
-const PULSE_STATE = join(PAI_DIR, "Pulse", "state", "state.json");
-const PULSE_TOML = join(PAI_DIR, "Pulse", "PULSE.toml");
+const PULSE_STATE = join(PAI_DIR, "PULSE", "state", "state.json");
+const PULSE_TOML = join(PAI_DIR, "PULSE", "PULSE.toml");
 
 // Jobs we specifically monitor — the Current→Ideal pipeline ones.
 const WATCHED_JOBS = [

--- a/Releases/v5.0.0/.claude/PAI/PULSE/lib.ts
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/lib.ts
@@ -246,7 +246,7 @@ export async function spawnScript(command: string, timeoutMs = 60_000): Promise<
   const proc = Bun.spawn(["bash", "-c", command], {
     stdout: "pipe",
     stderr: "pipe",
-    cwd: join(process.env.HOME ?? "~", ".claude", "PAI", "Pulse"),
+    cwd: join(process.env.HOME ?? "~", ".claude", "PAI", "PULSE"),
     env: { ...process.env },
   })
 

--- a/Releases/v5.0.0/.claude/PAI/PULSE/modules/imessage.ts
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/modules/imessage.ts
@@ -60,8 +60,8 @@ export interface IMessageHealth {
 
 const HOME = process.env.HOME ?? ""
 const CWD = join(HOME, ".claude")
-const STATE_DIR = join(HOME, ".claude", "PAI", "Pulse", "state", "imessage")
-const LOGS_DIR = join(HOME, ".claude", "PAI", "Pulse", "logs", "imessage")
+const STATE_DIR = join(HOME, ".claude", "PAI", "PULSE", "state", "imessage")
+const LOGS_DIR = join(HOME, ".claude", "PAI", "PULSE", "logs", "imessage")
 
 let pollTimer: ReturnType<typeof setInterval> | null = null
 let running = false

--- a/Releases/v5.0.0/.claude/PAI/PULSE/modules/user-index.ts
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/modules/user-index.ts
@@ -25,7 +25,7 @@ import { join, relative, basename, dirname } from "path"
 const HOME = process.env.HOME ?? ""
 const PAI_DIR = process.env.PAI_DIR || join(HOME, ".claude", "PAI")
 const USER_DIR = join(PAI_DIR, "USER")
-const STATE_DIR = join(PAI_DIR, "Pulse", "state")
+const STATE_DIR = join(PAI_DIR, "PULSE", "state")
 const INDEX_PATH = join(STATE_DIR, "user-index.json")
 const MODULE_NAME = "user-index"
 

--- a/Releases/v5.0.0/.claude/PAI/PULSE/pulse-old.ts
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/pulse-old.ts
@@ -46,7 +46,7 @@ import {
 
 // ── Constants ──
 
-const PULSE_DIR = join(process.env.HOME ?? "~", ".claude", "PAI", "Pulse")
+const PULSE_DIR = join(process.env.HOME ?? "~", ".claude", "PAI", "PULSE")
 const STATE_PATH = join(PULSE_DIR, "state", "state.json")
 const PID_PATH = join(PULSE_DIR, "state", "pulse.pid")
 const HOOK_PORT = parseInt(process.env.HOOK_SERVER_PORT || "8686", 10)

--- a/Releases/v5.0.0/.claude/PAI/PULSE/pulse-unified.ts
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/pulse-unified.ts
@@ -22,7 +22,7 @@ import { parse } from "smol-toml"
 
 const HOME = process.env.HOME ?? "~"
 const PAI_DIR = join(HOME, ".claude", "PAI")
-const PULSE_DIR = join(PAI_DIR, "Pulse")
+const PULSE_DIR = join(PAI_DIR, "PULSE")
 
 const envPath = join(HOME, ".claude", ".env")
 try {

--- a/Releases/v5.0.0/.claude/PAI/PULSE/run-job.ts
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/run-job.ts
@@ -31,7 +31,7 @@ if (!jobName) {
   process.exit(1)
 }
 
-const PULSE_DIR = join(process.env.HOME ?? "~", ".claude", "PAI", "Pulse")
+const PULSE_DIR = join(process.env.HOME ?? "~", ".claude", "PAI", "PULSE")
 const config = await loadConfig(PULSE_DIR)
 const job = config.jobs.find((j) => j.name === jobName)
 if (!job) {

--- a/Releases/v5.0.0/.claude/PAI/PULSE/setup.ts
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/setup.ts
@@ -15,7 +15,7 @@ import { existsSync, mkdirSync } from "fs"
 
 const HOME = process.env.HOME ?? "~"
 const PAI_DIR = join(HOME, ".claude", "PAI")
-const PULSE_DIR = join(PAI_DIR, "Pulse")
+const PULSE_DIR = join(PAI_DIR, "PULSE")
 
 // ── Helpers ──
 


### PR DESCRIPTION
…modules

macOS filesystem is case-insensitive so "Pulse" and "PULSE" silently resolved to the same directory. On Linux (case-sensitive FS) these paths point to non-existent locations, causing silent failures at runtime.

Files corrected:
- Observability/observability.ts: handleUserIndexApi user-index.json path (third occurrence missed by the earlier two-line fix)
- lib.ts: spawnScript cwd
- checks/github-work.ts: PULSE_DIR constant
- checks/notification-governor.ts: STATE_FILE path
- checks/poller-meta-monitor.ts: PULSE_STATE + PULSE_TOML paths
- modules/imessage.ts: STATE_DIR + LOGS_DIR paths
- modules/user-index.ts: STATE_DIR path
- pulse-unified.ts, run-job.ts, setup.ts, pulse-old.ts: PULSE_DIR constant

See also: PR #1126 (linux systemd support), PR #1116 (headless ubuntu compat)

This set of PRs attempts to capture the fixes for linux in those and add into simpler PRs for easier review/test/merge.