### PR TITLE
fix(service): resolve bash absolutely in spawnScript for Linux service envs

### DIFF
--- a/Releases/v5.0.0/.claude/PAI/PULSE/lib.ts
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/lib.ts
@@ -242,8 +242,14 @@ export function isSentinel(output: string): boolean {
 
 // ── Process Spawning ──
 
+// Resolve bash absolutely so cron-spawned children don't hit ENOENT when the
+// inherited PATH is sparse (observed on Linux when Pulse runs under a
+// minimal-env service manager). /bin/bash is the POSIX fallback — present on
+// macOS natively and on every mainstream Linux distro.
+const BASH_PATH = Bun.which("bash") ?? "/bin/bash"
+
 export async function spawnScript(command: string, timeoutMs = 60_000): Promise<string> {
-  const proc = Bun.spawn(["bash", "-c", command], {
+  const proc = Bun.spawn([BASH_PATH, "-c", command], {
     stdout: "pipe",
     stderr: "pipe",
     cwd: join(process.env.HOME ?? "~", ".claude", "PAI", "Pulse"),


### PR DESCRIPTION

When Pulse runs under systemd, the inherited PATH is minimal and "bash" is not resolvable by name — Bun.spawn(["bash", ...]) throws ENOENT, silently killing every cron job.

Use Bun.which("bash") with a /bin/bash fallback so the absolute path is resolved at module load time against whatever PATH is available, then cached for all subsequent spawnScript calls.

Ref: PR #1126 (fix/linux-support by dmcgoldrd)

This set of PRs attempts to capture the fixes for linux in those and add into simpler PRs for easier review/test/merge.