### PR TITLE
fix(installer): cross-platform service check and multi-shell alias scan

### DIFF
--- a/Releases/v5.0.0/.claude/PAI/PAI-Install/engine/actions.ts
+++ b/Releases/v5.0.0/.claude/PAI/PAI-Install/engine/actions.ts
@@ -1634,8 +1634,11 @@ async function installPulse(paiDir: string, emit: EngineEventHandler): Promise<b
 async function reloadPulse(paiDir: string, emit: EngineEventHandler): Promise<void> {
   const manageScript = join(paiDir, "PAI", "PULSE", "manage.sh");
   if (!existsSync(manageScript)) return;
-  const homeLaunchAgent = join(homedir(), "Library", "LaunchAgents", "com.pai.pulse.plist");
-  if (!existsSync(homeLaunchAgent)) return;
+  // Check that Pulse is installed for the current platform before reloading.
+  const serviceInstalled = process.platform === "darwin"
+    ? existsSync(join(homedir(), "Library", "LaunchAgents", "com.pai.pulse.plist"))
+    : existsSync(join(homedir(), ".config", "systemd", "user", "com.pai.pulse.service"));
+  if (!serviceInstalled) return;
   await emit({ event: "message", content: "Reloading Pulse to pick up new voice configuration..." });
   await new Promise<void>((resolve) => {
     const child = spawn("bash", [manageScript, "restart"], {

--- a/Releases/v5.0.0/.claude/PAI/PAI-Install/engine/validate.ts
+++ b/Releases/v5.0.0/.claude/PAI/PAI-Install/engine/validate.ts
@@ -234,32 +234,51 @@ export async function runValidation(state: InstallState, emit?: EngineEventHandl
     critical: false,
   });
 
-  // 7b. Pulse launchd plist present (auto-start on login)
-  const pulsePlist = join(homedir(), "Library", "LaunchAgents", "com.pai.pulse.plist");
-  const pulsePlistInstalled = existsSync(pulsePlist);
-  checks.push({
-    name: "Pulse launchd agent",
-    passed: pulsePlistInstalled,
-    detail: pulsePlistInstalled
+  // 7b. Pulse auto-start service present (launchd on macOS, systemd on Linux)
+  let pulseServiceInstalled = false;
+  let pulseServiceDetail = "";
+  if (process.platform === "darwin") {
+    const pulsePlist = join(homedir(), "Library", "LaunchAgents", "com.pai.pulse.plist");
+    pulseServiceInstalled = existsSync(pulsePlist);
+    pulseServiceDetail = pulseServiceInstalled
       ? "Installed at ~/Library/LaunchAgents/com.pai.pulse.plist"
-      : "Not installed — Pulse will not auto-start on login",
+      : "Not installed — Pulse will not auto-start on login";
+  } else {
+    const pulseUnit = join(homedir(), ".config", "systemd", "user", "com.pai.pulse.service");
+    pulseServiceInstalled = existsSync(pulseUnit);
+    pulseServiceDetail = pulseServiceInstalled
+      ? "Installed at ~/.config/systemd/user/com.pai.pulse.service"
+      : "Not installed — Pulse will not auto-start on login";
+  }
+  checks.push({
+    name: "Pulse auto-start service",
+    passed: pulseServiceInstalled,
+    detail: pulseServiceDetail,
     critical: false,
   });
 
-  // 8. Zsh alias configured
-  const zshrcPath = join(homedir(), ".zshrc");
+  // 8. Shell alias configured (.zshrc, .bashrc, or .profile)
+  const shellRcFiles = [".zshrc", ".bashrc", ".profile"];
   let aliasConfigured = false;
-  if (existsSync(zshrcPath)) {
-    try {
-      const zshContent = readFileSync(zshrcPath, "utf-8");
-      aliasConfigured = zshContent.includes("# PAI alias") && zshContent.includes("alias pai=");
-    } catch {}
+  let aliasFoundIn = "";
+  for (const rc of shellRcFiles) {
+    const rcPath = join(homedir(), rc);
+    if (existsSync(rcPath)) {
+      try {
+        const rcContent = readFileSync(rcPath, "utf-8");
+        if (rcContent.includes("# PAI alias") && rcContent.includes("alias pai=")) {
+          aliasConfigured = true;
+          aliasFoundIn = rc;
+          break;
+        }
+      } catch {}
+    }
   }
 
   checks.push({
     name: "Shell alias (pai)",
     passed: aliasConfigured,
-    detail: aliasConfigured ? "Configured in .zshrc" : "Not found — run: source ~/.zshrc",
+    detail: aliasConfigured ? `Configured in ~/${aliasFoundIn}` : "Not found — run: source ~/.<shell>rc",
     critical: true,
   });
 


### PR DESCRIPTION
validate.ts: replace macOS-only launchd plist check with platform-branched check (launchd plist on Darwin, systemd user unit on Linux). Replace zsh-only .zshrc alias scan with a loop over .zshrc/.bashrc/.profile so the check passes regardless of the user's default shell.

actions.ts: reloadPulse() now checks the correct platform service file before attempting manage.sh restart — previously the macOS-only plist guard caused the reload to silently no-op on Linux.

References: https://github.com/danielmiessler/Personal_AI_Infrastructure/pull/1116

This set of PRs attempts to capture the fixes for linux in those and add into simpler PRs for easier review/test/merge.