### PR TITLE
fix(hooks): RepeatDetection state save now happens after Claude responds (closes #1155)

### DIFF
--- a/Releases/v5.0.0/.claude/hooks/RepeatDetection.hook.ts
+++ b/Releases/v5.0.0/.claude/hooks/RepeatDetection.hook.ts
@@ -12,9 +12,17 @@
 import { readFileSync, writeFileSync, existsSync } from "fs";
 import { join } from "path";
 
-const STATE_FILE = join(
+// Read from last-prompt.json (the prompt Claude actually responded to).
+// Write current submission to pending-prompt.json (staged; promoted to last-prompt
+// only when the Stop hook runs, i.e., after Claude responds). This way cancelled
+// or blocked prompts never become the comparison baseline.
+const RESPONDED_PROMPT_FILE = join(
   process.env.HOME || "",
   ".claude/PAI/MEMORY/STATE/last-prompt.json",
+);
+const PENDING_PROMPT_FILE = join(
+  process.env.HOME || "",
+  ".claude/PAI/MEMORY/STATE/pending-prompt.json",
 );
 
 interface HookInput {
@@ -69,16 +77,16 @@ function main(): void {
 
   // Skip very short messages (ratings, acknowledgments, greetings)
   if (currentPrompt.length < 20) {
-    saveCurrentPrompt(currentPrompt, input.session_id);
+    stagePendingPrompt(currentPrompt, input.session_id);
     process.exit(0);
   }
 
-  // Load previous prompt
+  // Load the last prompt Claude actually responded to (promoted by Stop hook).
   let previousPrompt = "";
   let previousSessionId = "";
-  if (existsSync(STATE_FILE)) {
+  if (existsSync(RESPONDED_PROMPT_FILE)) {
     try {
-      const state = JSON.parse(readFileSync(STATE_FILE, "utf-8"));
+      const state = JSON.parse(readFileSync(RESPONDED_PROMPT_FILE, "utf-8"));
       previousPrompt = state.prompt || "";
       previousSessionId = state.session_id || "";
     } catch {
@@ -88,11 +96,11 @@ function main(): void {
 
   // Only compare within the same session
   if (previousSessionId !== input.session_id || !previousPrompt) {
-    saveCurrentPrompt(currentPrompt, input.session_id);
+    stagePendingPrompt(currentPrompt, input.session_id);
     process.exit(0);
   }
 
-  // Compare current to previous
+  // Compare current to previous (last responded-to prompt)
   const currentTokens = tokenize(currentPrompt);
   const previousTokens = tokenize(previousPrompt);
 
@@ -101,8 +109,10 @@ function main(): void {
 
   const similarity = jaccardSimilarity(currentGrams, previousGrams);
 
-  // Save current prompt as the new "previous"
-  saveCurrentPrompt(currentPrompt, input.session_id);
+  // Stage current prompt for promotion. Only promoted to last-prompt by the Stop
+  // hook after Claude responds, so cancelled / blocked prompts never poison the
+  // comparison baseline.
+  stagePendingPrompt(currentPrompt, input.session_id);
 
   // Threshold: 0.6 (60%) similarity triggers warning
   if (similarity >= 0.6) {
@@ -120,10 +130,10 @@ function main(): void {
   process.exit(0);
 }
 
-function saveCurrentPrompt(prompt: string, sessionId: string): void {
+function stagePendingPrompt(prompt: string, sessionId: string): void {
   try {
     writeFileSync(
-      STATE_FILE,
+      PENDING_PROMPT_FILE,
       JSON.stringify({
         prompt,
         session_id: sessionId,

--- a/Releases/v5.0.0/.claude/hooks/RepeatDetectionPromote.hook.ts
+++ b/Releases/v5.0.0/.claude/hooks/RepeatDetectionPromote.hook.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env bun
+/**
+ * RepeatDetectionPromote.hook.ts - Stop hook
+ *
+ * Promotes pending-prompt.json -> last-prompt.json after Claude responds.
+ * Pairs with RepeatDetection.hook.ts (UserPromptSubmit), which stages the
+ * submitted prompt as "pending." Only prompts Claude actually responded to
+ * become the comparison baseline for future repeat detection - cancelled
+ * and blocked prompts never poison the state.
+ */
+
+import { readFileSync, writeFileSync, existsSync, unlinkSync } from "fs";
+import { join } from "path";
+
+const RESPONDED_PROMPT_FILE = join(
+  process.env.HOME || "",
+  ".claude/PAI/MEMORY/STATE/last-prompt.json",
+);
+const PENDING_PROMPT_FILE = join(
+  process.env.HOME || "",
+  ".claude/PAI/MEMORY/STATE/pending-prompt.json",
+);
+
+function main(): void {
+  if (!existsSync(PENDING_PROMPT_FILE)) {
+    process.exit(0);
+  }
+
+  try {
+    const pending = readFileSync(PENDING_PROMPT_FILE, "utf-8");
+    writeFileSync(RESPONDED_PROMPT_FILE, pending);
+    unlinkSync(PENDING_PROMPT_FILE);
+  } catch {
+    // Non-critical - silently fail.
+  }
+
+  process.exit(0);
+}
+
+main();

--- a/Releases/v5.0.0/.claude/settings.json
+++ b/Releases/v5.0.0/.claude/settings.json
@@ -353,6 +353,10 @@
           {
             "type": "command",
             "command": "$HOME/.claude/hooks/DocIntegrity.hook.ts"
+          },
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/RepeatDetectionPromote.hook.ts"
           }
         ]
       }


### PR DESCRIPTION
Fixes #1155.

## What

Move `RepeatDetection.hook.ts` comparison-state save out of `UserPromptSubmit` into a new Stop-hook companion (`RepeatDetectionPromote.hook.ts`). Cancelled and blocked prompts never reach `Stop`, so they no longer become the comparison baseline.

## Why

The current implementation saves to `last-prompt.json` on every `UserPromptSubmit`, before the similarity check and before Claude has a chance to respond. That causes two bugs:

1. **Cancelled-then-edited prompts cause false positives.** Submit -> Esc -> edit -> resubmit gets flagged as a "repeat" of the cancelled draft.
2. **Blocked submissions create an unrecoverable retry loop.** When the hook fires `exit 2` it has already saved the blocked attempt as the new baseline. The user's retry is then compared against the blocked attempt (which is necessarily very similar to their actual intent) and re-blocked. State keeps rolling forward to each blocked attempt; the user can't escape without rephrasing substantially or deleting the state file.

The hook docstring states the intended trigger is the user repeating "after the AI missed their intent" - i.e., after Claude responded. The current behavior triggers on the user repeating after their own previous submission attempt, regardless of whether Claude saw or responded to it. See #1155 for full repro and design-intent citations.

## How

Two-file change in `Releases/v5.0.0/.claude/hooks/`:

- **`RepeatDetection.hook.ts`** - read from `last-prompt.json` (the prompt Claude actually responded to) for the comparison; write the current submission to a new `pending-prompt.json` instead of overwriting the comparison baseline. The function `saveCurrentPrompt` was renamed to `stagePendingPrompt` to reflect the new semantics.
- **`RepeatDetectionPromote.hook.ts`** (new, Stop hook) - on Claude's response completion, promote `pending-prompt.json` -> `last-prompt.json` and delete the pending file.
- **`settings.json`** - register the new Stop hook in the `Stop` chain after `DocIntegrity.hook.ts`.

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| Submit -> Claude responds -> similar resubmit | Triggers (correct) | Triggers (correct) |
| Submit -> cancel -> edit -> resubmit | Triggers (false positive) | No trigger |
| Trigger fires -> user retries with similar wording | Re-triggers, baseline rolls to blocked attempt, loop is unrecoverable | Re-triggers against the same baseline (no state poisoning), still escapable by rephrasing or letting Claude respond |

## Test plan

Manual end-to-end with hand-crafted stdin payloads:

1. **Cancel-edit-resend** - submit P1 (no `last-prompt`), cancel (no Stop), submit P1' (similar). Expected: exit 0 from both. Result: exit 0 from both.
2. **Submit -> Stop -> similar resubmit** - submit P1, run promote hook, submit P2 (highly similar). Expected: exit 2 with similarity warning. Result: exit 2 at 71% similarity.
3. **Block-retry without Stop** - immediately submit P3 (similar to P2 from scenario 2). Expected: exit 2, but at the same similarity score against the unchanged baseline. Result: exit 2 at 71% (same score - confirming `last-prompt.json` did not roll forward to the blocked P2).

All three pass against the local copy.

## No backward-compatibility concerns

- `last-prompt.json` schema is unchanged. Existing files keep working.
- `pending-prompt.json` is a new file in the same `MEMORY/STATE/` dir. If absent (fresh install or pre-fix state), the Stop hook is a no-op.
- Skill flow and any tools reading `last-prompt.json` see only "prompts Claude responded to" - which is the documented intent and the more useful semantic.
