### PR TITLE
fix: InterviewScan now correctly flags unmodified bootstrap templates

### DIFF
--- a/Releases/v5.0.0/.claude/PAI/TOOLS/InterviewScan.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/InterviewScan.ts
@@ -197,6 +197,13 @@ const PLACEHOLDER_PATTERNS = [
   /^\s*-\s*TBD\s*$/gim,
 ];
 
+// Sample-template detection. Bootstrap-installed TELOS files carry a banner
+// and "(sample)" prefixed entries. Both indicate the user has not yet
+// personalized the file — without these checks the scanner scored such files
+// 100% because they're length-substantive and TBD-free, masking real gaps.
+const SAMPLE_TEMPLATE_BANNER = /🎯 SAMPLE TEMPLATE/;
+const SAMPLE_LINE = /^\s*[-*]\s+(?:\*\*[^*]+\*\*[\s:—–-]*)?\(sample\)\b/gim;
+
 // Phase boost ensures foundational TELOS files always beat Phase 2+ files in
 // priority order, regardless of incompleteness. Phase 1 at 100% complete still
 // outranks Phase 2 at 0% complete — {{PRINCIPAL_NAME}}'s rule: review foundational first.
@@ -249,6 +256,19 @@ function scoreFile(target: (typeof REGISTRY)[number]): Target {
   const placeholderPenalty = result.tbd_count * 40 + result.seed_markers * 20 + result.empty_sections * 30;
   const contentBonus = Math.min(content.length / 10, 500);
   result.completeness_score = Math.max(0, Math.min(100, 100 - placeholderPenalty / 10 + contentBonus / 50));
+
+  // Sample-template kill-switch. Banner = unmodified bootstrap → cap at 15%.
+  // ≥2 "(sample)" entries = mostly-template → cap at 25%. A single "(sample)"
+  // could be incidental user wording, so we only act on multiples.
+  const hasBanner = SAMPLE_TEMPLATE_BANNER.test(content);
+  const sampleEntries = (content.match(SAMPLE_LINE) || []).length;
+  if (hasBanner) {
+    result.completeness_score = Math.min(result.completeness_score, 15);
+    result.why_incomplete.push("SAMPLE TEMPLATE banner present — content is bootstrap default");
+  } else if (sampleEntries >= 2) {
+    result.completeness_score = Math.min(result.completeness_score, 25);
+    result.why_incomplete.push(`${sampleEntries} "(sample)" entries — content not personalized`);
+  }
 
   // Priority: phase (dominant) + leverage + incompleteness. Phase 1 always beats Phase 2.
   const incompleteness = 100 - result.completeness_score;


### PR DESCRIPTION
## Summary

`InterviewScan.ts` scored bootstrap-installed TELOS files as 100% complete because:

- The `🎯 SAMPLE TEMPLATE` banner is regular markdown that didn't trigger any TBD / seed-marker pattern.
- `(sample)` prefixed entries (e.g. `**G0:** (sample) Ship MVP of Project X by 2026-Q2`) are length-substantive content that boosted the score.

Result: `/interview` skipped sample-only files, marking them `review_mode: true` even though they were literally still the bootstrap template. The DA would say "GOALS is 100% complete — let's review" while reading sample placeholders.

This affected every Phase 1 file we hit during a fresh-install `/interview` run: GOALS, PROBLEMS, STRATEGIES, CHALLENGES, NARRATIVES, BELIEFS, WISDOM, BOOKS — all scored 100% on what was still bootstrap text.

## Reproduction

```bash
# Fresh PAI 5.0.0 install
bun ~/.claude/PAI/TOOLS/InterviewScan.ts --file GOALS
```

Expected: low completeness because file is unmodified template.
Actual (pre-fix): `completeness_score: 100, review_mode: true, why_incomplete: ["already substantive — review for updates/refinements"]`.

The file content at that point is still:
```
- **G0:** (sample) Ship MVP of Project X by 2026-Q2 — measurable: 100 daily active users.
- **G1:** (sample) Publish 24 newsletter issues this year ...
```

## Fix

Two new patterns added to `scoreFile()`:

- `SAMPLE_TEMPLATE_BANNER` (`/🎯 SAMPLE TEMPLATE/`) — caps score at 15% and records the reason. The banner is unique to bootstrap files; presence is a strong signal that nothing has been personalized.
- `SAMPLE_LINE` (`/^\s*[-*]\s+(?:\*\*[^*]+\*\*[\s:—–-]*)?\(sample\)\b/gim`) — caps score at 25% when **2 or more** matches are found. A single `(sample)` could be incidental user wording (e.g. "sample size of 100"); multiples strongly indicate template.

Both add their reason to `why_incomplete`, so users see *why* the score is low.

## Test

After patch:

```bash
bun ~/.claude/PAI/TOOLS/InterviewScan.ts --file NARRATIVES
```

```diff
-  "completeness_score": 100,
-  "review_mode": true,
-  "why_incomplete": ["already substantive — review for updates/refinements"]
+  "completeness_score": 15,
+  "review_mode": false,
+  "why_incomplete": ["SAMPLE TEMPLATE banner present — content is bootstrap default"]
```

The scanner now correctly drives `/interview` into fill-mode for unmodified templates instead of pretending they're done.

## Risk

Low. Change is purely additive — never raises a score, only lowers it for files matching the new patterns. Single-`(sample)` files (incidental wording) are not flagged. Personalized files are unchanged.
