### PR TITLE
fix: dashboard 404s on Linux due to Pulse vs PULSE path casing

### DIFF
--- a/Releases/v5.0.0/.claude/PAI/PULSE/Observability/observability.ts
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/Observability/observability.ts
@@ -66,7 +66,7 @@ const SECURITY_LOG_DIR = join(MEMORY_DIR, "SECURITY")
 const SETTINGS_PATH = join(HOME, ".claude", "settings.json")
 const LADDER_DIR = join(HOME, "Projects", "Ladder")
 
-const DEFAULT_DASHBOARD_DIR = join(PAI_DIR, "Pulse", "Observability", "out")
+const DEFAULT_DASHBOARD_DIR = join(PAI_DIR, "PULSE", "Observability", "out")
 
 // ── In-Memory Store (hook-pushed state/events) ──
 
@@ -149,7 +149,7 @@ function getDashboardDir(): string {
   const dir = config.dashboard_dir ?? DEFAULT_DASHBOARD_DIR
   // Resolve relative paths against Pulse directory
   if (!dir.startsWith("/")) {
-    return join(HOME, ".claude", "PAI", "Pulse", dir)
+    return join(HOME, ".claude", "PAI", "PULSE", dir)
   }
   return dir
 }
@@ -1647,7 +1647,7 @@ function readDirMdFiles(dir: string): { name: string, content: string, sections:
 function handleUserIndexApi(filter: string | null): Response {
   try {
     const PAI_DIR = process.env.PAI_DIR || join(process.env.HOME || "", ".claude", "PAI")
-    const indexPath = join(PAI_DIR, "Pulse", "state", "user-index.json")
+    const indexPath = join(PAI_DIR, "PULSE", "state", "user-index.json")
     const raw = Bun.file(indexPath)
     if (!raw.size) {
       return Response.json(


### PR DESCRIPTION
## Summary

`Releases/v5.0.0/.claude/PAI/PULSE/Observability/observability.ts` hardcodes three filesystem paths using `"Pulse"` (TitleCase). The canonical install directory in v5.0.0 is `"PULSE"` (uppercase) — confirmed by the `install.sh` template and the `Releases/v5.0.0/.claude/PAI/PULSE/` directory in this repo.

On macOS HFS+/APFS (case-insensitive default), `Pulse` and `PULSE` resolve to the same directory — bug is invisible. On Linux ext4/btrfs (case-sensitive), the dashboard directory is never found, every static-file lookup returns 404, and `localhost:31337/` appears completely broken even though the HTTP server is bound and serving fine.

This is a Linux-portability regression — the daemon starts cleanly, the cron loop runs, voice notifications work — but the Life Dashboard is dark.

## Reproduction (Linux ext4 / btrfs)

```bash
# Fresh PAI 5.0.0 install on Linux
cd ~/.claude/PAI/PULSE && bun run pulse.ts &

# Pulse starts and binds to port:
#   {"level":"info","msg":"HTTP server listening","port":31337}

curl -s -o /dev/null -w "HTTP %{http_code}\n" http://localhost:31337/
# HTTP 404
curl -s -o /dev/null -w "HTTP %{http_code}\n" http://localhost:31337/agents
# HTTP 404
curl -s -o /dev/null -w "HTTP %{http_code}\n" http://localhost:31337/index.html
# HTTP 404
```

Voice notify (`POST /notify`) works fine — only the dashboard's static-file serving is dead.

Root cause: `serveStaticFile()` calls `getDashboardDir()` which returns `~/.claude/PAI/Pulse/Observability/out` (lowercase 'P'). That path doesn't exist on case-sensitive filesystems — the actual directory is `~/.claude/PAI/PULSE/Observability/out`. So `existsSafe()` returns false and every page returns 404.

## Fix

Three string changes — `"Pulse"` → `"PULSE"` — in `observability.ts`:

| Line | Context |
|---|---|
| 69 | `DEFAULT_DASHBOARD_DIR` constant |
| 152 | `getDashboardDir()` relative-path resolver |
| 1650 | `handleUserIndexApi()` user-index.json lookup |

These are the only path-construction sites using `"Pulse"`. The other `"Pulse"` references in the file (around lines 851/853/859/861) are string literals describing the daemon by name in tooling descriptions — those are correct and remain unchanged.

## Test (Linux)

After patch:

```bash
$ curl -s -o /dev/null -w "HTTP %{http_code}\n" http://localhost:31337/
HTTP 200

$ curl -s http://localhost:31337/ | grep -oE '<title>[^<]*</title>'
<title>PAI Observatory</title>

$ for p in /agents /telos /health /work /security; do
    printf "%-15s " "$p"
    curl -s -o /dev/null -w "HTTP %{http_code}\n" "http://localhost:31337${p}"
  done
/agents          HTTP 200
/telos           HTTP 200
/health          HTTP 200
/work            HTTP 200
/security        HTTP 200
```

## Risk

Very low.

- **Linux:** previously broken → now works (intended fix).
- **macOS:** behavior unchanged — case-insensitive HFS+/APFS already resolved `"Pulse"` to the canonical `"PULSE"` directory, so the same paths resolved fine before and after the change.
- **No semantic changes** — only path string casing. No public API touched. No config schema changes.
