### PR TITLE
feat(pulse): add Telegram callback_query bridge for inline-keyboard buttons

### DIFF
--- a/Packs/Confirm/INSTALL.md
+++ b/Packs/Confirm/INSTALL.md
@@ -1,0 +1,97 @@
+# Confirm — Installation Guide
+
+**For AI agents installing this pack into a user's PAI infrastructure.**
+
+---
+
+## AI Agent Instructions
+
+Use Claude Code's native tools (`AskUserQuestion`, `TodoWrite`, `Bash`, `Read`, `Write`) to walk the user through this wizard.
+
+### Welcome Message
+
+```
+"I'm installing the Confirm skill from the PAI v5.0.0 release.
+
+Confirm asks the user a yes/no via inline-keyboard buttons on @<DA>_bot and returns their tap. Built on the Pulse Telegram callback bridge. Useful as an approval gate before any irreversible step.
+
+Let me check your system and install."
+```
+
+---
+
+## Phase 1: System Analysis
+
+```bash
+CLAUDE_DIR="$HOME/.claude"
+SKILL_DIR="$CLAUDE_DIR/skills/Confirm"
+HELPER="$CLAUDE_DIR/PAI/TOOLS/TelegramCallbacks.ts"
+PULSE_TG="$CLAUDE_DIR/PAI/PULSE/modules/telegram.ts"
+
+if [ -d "$SKILL_DIR" ]; then
+  echo "EXISTING Confirm skill found at $SKILL_DIR — will back up before install"
+else
+  echo "Clean install — no existing Confirm skill"
+fi
+
+# Prerequisite checks — bridge + helper must already be present
+[ -f "$HELPER" ] || echo "MISSING $HELPER (install PAI v5.0.0+ first)"
+grep -q 'callback_query:data' "$PULSE_TG" 2>/dev/null \
+  || echo "MISSING bridge handler in $PULSE_TG (Pulse needs callback bridge — PAI v5.0.0+)"
+```
+
+If either prerequisite is missing, stop and tell the user to update PAI first.
+
+---
+
+## Phase 2: Confirm with User
+
+Ask the user (use `AskUserQuestion`):
+
+- **Question:** "Install the Confirm skill?"
+- **Options:**
+  - "Install" — proceed
+  - "Skip" — abort
+
+If the user picks Skip, stop and exit cleanly.
+
+---
+
+## Phase 3: Backup
+
+```bash
+if [ -d "$SKILL_DIR" ]; then
+  TS="$(date +%Y%m%d-%H%M%S)"
+  cp -R "$SKILL_DIR" "$SKILL_DIR.backup-$TS"
+  echo "Backup at $SKILL_DIR.backup-$TS"
+fi
+```
+
+---
+
+## Phase 4: Install
+
+Copy the contents of `src/` into `$SKILL_DIR/`:
+
+```bash
+mkdir -p "$SKILL_DIR/Workflows" "$SKILL_DIR/Tools"
+cp -R src/SKILL.md "$SKILL_DIR/SKILL.md"
+cp -R src/Workflows/* "$SKILL_DIR/Workflows/"
+cp -R src/Tools/* "$SKILL_DIR/Tools/"
+```
+
+---
+
+## Phase 5: Verify
+
+Run the steps in `VERIFY.md` and report the results. Restart Pulse if it isn't already running with the bridge handler.
+
+---
+
+## After installation
+
+Tell the user:
+
+- The skill is invoked via `/confirm "<question>"` or `bun run ~/.claude/skills/Confirm/Tools/Ask.ts "<question>"`.
+- Test bot recommended for first-time verification (don't paste production token into anything experimental).
+- Skill returns `approve` / `reject` / `defer` (or whatever choices were configured) plus the raw `callback_data` for downstream logic.

--- a/Packs/Confirm/README.md
+++ b/Packs/Confirm/README.md
@@ -1,0 +1,46 @@
+---
+name: Confirm
+pack-id: pai-confirm-v1.0.0
+version: 1.0.0
+author: danielmiessler
+description: Ask the user a yes/no via inline-keyboard buttons on @<DA>_bot, return their tap. Generic approval gate any worker can call.
+type: skill
+platform: claude-code
+source: PAI v5.0.0
+---
+
+# Confirm
+
+Ask the user a yes/no (or any small set of choices) via inline-keyboard buttons on `@<DA>_bot`. Returns the user's tap.
+
+Built on the Pulse Telegram callback bridge (`PULSE/modules/telegram.ts` → `TOOLS/TelegramCallbacks.ts`). Useful as an approval gate before any irreversible step: "deploy now? approve / reject / defer". Works from anywhere — cron jobs, batch scripts, slash commands, long-running agents.
+
+## Installation
+
+This pack is designed for AI-assisted installation. Point your AI at this directory and ask it to install using `INSTALL.md`.
+
+```
+"Install the Confirm pack from PAI/Packs/Confirm/"
+```
+
+Your AI walks through a 5-phase wizard: system analysis, user questions, backup, installation, verification.
+
+## What's Included
+
+```
+  SKILL.md
+  Workflows/
+    Ask.md
+  Tools/
+    Ask.ts
+```
+
+## Prerequisites
+
+- Pulse Telegram daemon running with the callback bridge (PAI v5.0.0+).
+- `TELEGRAM_BOT_TOKEN` and `TELEGRAM_ALLOWED_USERS` set in `~/.claude/.env`.
+- `PAI/TOOLS/TelegramCallbacks.ts` available (ships with PAI v5.0.0+).
+
+## What it solves
+
+Any automation that needs human approval before an irreversible step. Without a primitive like this, every worker reinvents Telegram send/receive plumbing.

--- a/Packs/Confirm/VERIFY.md
+++ b/Packs/Confirm/VERIFY.md
@@ -1,0 +1,42 @@
+# Confirm — Verification
+
+> **For AI agents:** Complete this checklist after installation. All file checks must pass before declaring the pack installed.
+
+---
+
+## File Verification
+
+```bash
+CLAUDE_DIR="$HOME/.claude"
+SKILL_DIR="$CLAUDE_DIR/skills/Confirm"
+
+[ -d "$SKILL_DIR" ]                       && echo "OK directory exists"     || echo "MISSING directory"
+[ -f "$SKILL_DIR/SKILL.md" ]              && echo "OK SKILL.md present"     || echo "MISSING SKILL.md"
+[ -f "$SKILL_DIR/Workflows/Ask.md" ]      && echo "OK workflow Ask.md"      || echo "MISSING Ask workflow"
+[ -f "$SKILL_DIR/Tools/Ask.ts" ]          && echo "OK Tools/Ask.ts"         || echo "MISSING Ask tool"
+```
+
+## Bridge Verification
+
+```bash
+HELPER="$CLAUDE_DIR/PAI/TOOLS/TelegramCallbacks.ts"
+PULSE_TG="$CLAUDE_DIR/PAI/PULSE/modules/telegram.ts"
+
+[ -f "$HELPER" ]                          && echo "OK helper present"       || echo "MISSING helper"
+grep -q 'callback_query:data' "$PULSE_TG" && echo "OK bridge handler"       || echo "MISSING bridge handler"
+[ -f "$CLAUDE_DIR/PAI/PULSE/state/telegram/callbacks.jsonl" ] \
+                                          && echo "OK JSONL exists"         || echo "INFO no callbacks yet"
+```
+
+## Round-trip Verification (manual)
+
+1. Ensure `TELEGRAM_BOT_TOKEN` + `TELEGRAM_ALLOWED_USERS` are set in `~/.claude/.env`.
+2. Run a 30-second confirm against your bot:
+   ```bash
+   bun run "$SKILL_DIR/Tools/Ask.ts" "Bridge round-trip OK?" --timeout-ms 30000
+   ```
+3. On your phone: tap one of the buttons.
+4. The CLI should print the chosen action (e.g. `approve`) and exit 0.
+
+If step 4 times out without you tapping, the bridge is fine but the test was — try again.
+If step 4 times out *after* you tapped, check that Pulse is running and that `callbacks.jsonl` got a new entry.

--- a/Packs/Confirm/src/SKILL.md
+++ b/Packs/Confirm/src/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: Confirm
+description: "Ask the user a yes/no (or small choice set) via inline-keyboard buttons on @<DA>_bot. USE WHEN you need approval before an irreversible step (deploy, drop, send, commit, merge), need triage from the user's phone for an alert, or want a yes/no gate in a long-running automation. Returns the user's tap."
+disable-model-invocation: false
+effort: low
+---
+
+# /confirm — Approval gate via Telegram inline keyboards
+
+Send a question to the user with two or three buttons, return their tap. Built on the Pulse Telegram callback bridge (`PULSE/modules/telegram.ts` → `TOOLS/TelegramCallbacks.ts`).
+
+## Invocation
+
+```
+/confirm "Continue with deploy?"
+/confirm "Drop table users_old?" --buttons "Drop,Keep,Defer"
+/confirm "Approve PR #482?" --timeout-ms 1800000
+```
+
+Or call directly:
+
+```bash
+bun run ~/.claude/skills/Confirm/Tools/Ask.ts "<question>" \
+  [--buttons "Approve,Reject"] \
+  [--timeout-ms 900000]
+```
+
+## What happens
+
+1. Tool reads `TELEGRAM_BOT_TOKEN` and `TELEGRAM_ALLOWED_USERS` from `~/.claude/.env`.
+2. Generates a UUID-namespaced `callback_data` for each button (`<action>:<uuid>`) so the predicate can't collide with other workflows.
+3. Sends the message via Telegram Bot API with an inline keyboard.
+4. Tails `~/.claude/PAI/PULSE/state/telegram/callbacks.jsonl` via `waitForCallback` until a press matches the UUID.
+5. Edits the message to remove the keyboard (defends against double-tap).
+6. Edits the text to show the chosen action.
+7. Prints JSON to stdout: `{ "action": "approve", "data": "approve:abc-123", "fromId": ... }`.
+8. Exits 0 on a tap, exit 2 on timeout.
+
+## Returns
+
+- `action` — the leading prefix of the chosen `callback_data` (`approve`, `reject`, etc.). Use this for your switch statement.
+- `data` — the full `callback_data` string. Use this only if you need the UUID for audit trail.
+- `fromId` — Telegram user id who tapped. Already passed Pulse's `allowedUsers` gate.
+
+## Rules
+
+- **Validate the action.** Use a switch with explicit cases — never pass `data` to a shell or eval. See `DOCUMENTATION/Notifications/TelegramCallbacks.md` security model.
+- **Keep questions short.** Telegram clips long messages; the buttons are what matters.
+- **Don't reuse buttons across calls.** UUIDs are per-invocation; each `/confirm` is independent.
+
+See `Workflows/Ask.md` for the full request flow.

--- a/Packs/Confirm/src/Tools/Ask.ts
+++ b/Packs/Confirm/src/Tools/Ask.ts
@@ -1,0 +1,155 @@
+#!/usr/bin/env bun
+/**
+ * Ask.ts — yes/no approval gate via @<DA>_bot inline keyboard.
+ *
+ * Sends a Telegram message with buttons, waits for a tap, edits the message
+ * to remove the keyboard + reflect the choice, prints the result as JSON.
+ *
+ * Usage:
+ *   bun run Ask.ts "<question>" [--buttons "A,B,C"] [--timeout-ms N]
+ *
+ * Exit:
+ *   0 = user tapped, JSON on stdout
+ *   2 = timeout
+ *   1 = error
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+// The helper is resolved at runtime so this tool works whether it lives in
+// the source repo (Packs/Confirm/src/Tools/) or installed at
+// ~/.claude/skills/Confirm/Tools/. The helper itself is at
+// ~/.claude/PAI/TOOLS/TelegramCallbacks.ts after install.
+const helperPath = join(process.env.HOME ?? "", ".claude", "PAI", "TOOLS", "TelegramCallbacks.ts");
+if (!existsSync(helperPath)) {
+  process.stderr.write(`Missing helper at ${helperPath}. Install PAI v5.0.0+.\n`);
+  process.exit(1);
+}
+const { waitForCallback } = (await import(helperPath)) as typeof import("../../../../Releases/v5.0.0/.claude/PAI/TOOLS/TelegramCallbacks");
+
+interface Args {
+  question: string;
+  buttons: string[];
+  timeoutMs: number;
+  callbacksPath?: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args = argv.slice(2);
+  if (args.length === 0 || args[0].startsWith("--")) {
+    process.stderr.write(`usage: Ask.ts "<question>" [--buttons "A,B,C"] [--timeout-ms N]\n`);
+    process.exit(1);
+  }
+  const out: Args = { question: args[0], buttons: ["Approve", "Reject", "Defer"], timeoutMs: 15 * 60 * 1000 };
+  for (let i = 1; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--buttons" && args[i + 1]) {
+      out.buttons = args[++i].split(",").map((s) => s.trim()).filter(Boolean);
+    } else if (a === "--timeout-ms" && args[i + 1]) {
+      out.timeoutMs = Number(args[++i]);
+      if (!Number.isFinite(out.timeoutMs) || out.timeoutMs < 1000) {
+        process.stderr.write(`bad --timeout-ms\n`);
+        process.exit(1);
+      }
+    } else if (a === "--callbacks-path" && args[i + 1]) {
+      out.callbacksPath = args[++i];
+    }
+  }
+  if (out.buttons.length < 2 || out.buttons.length > 4) {
+    process.stderr.write(`--buttons must be 2-4 labels\n`);
+    process.exit(1);
+  }
+  return out;
+}
+
+function loadEnv(): { token: string; chatId: string } {
+  // process.env takes precedence over .env file (lets callers override per-call
+  // without mutating ~/.claude/.env, useful for tests and isolation).
+  let token = process.env.TELEGRAM_BOT_TOKEN ?? "";
+  let chatId = (process.env.TELEGRAM_ALLOWED_USERS ?? "").split(",")[0]?.trim() ?? "";
+
+  if (!token || !chatId) {
+    const envPath = join(process.env.HOME ?? "", ".claude", ".env");
+    if (existsSync(envPath)) {
+      const fileEnv: Record<string, string> = {};
+      for (const line of readFileSync(envPath, "utf8").split("\n")) {
+        const m = line.match(/^([A-Z0-9_]+)\s*=\s*(.*)$/);
+        if (m) fileEnv[m[1]] = m[2].trim();
+      }
+      if (!token) token = fileEnv.TELEGRAM_BOT_TOKEN ?? "";
+      if (!chatId) chatId = (fileEnv.TELEGRAM_ALLOWED_USERS ?? "").split(",")[0]?.trim() ?? "";
+    }
+  }
+
+  if (!token) throw new Error("TELEGRAM_BOT_TOKEN missing (set env var or ~/.claude/.env)");
+  if (!chatId) throw new Error("TELEGRAM_ALLOWED_USERS missing (set env var or ~/.claude/.env)");
+  return { token, chatId };
+}
+
+async function tg<T = any>(token: string, method: string, body: object): Promise<T> {
+  const r = await fetch(`https://api.telegram.org/bot${token}/${method}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const j = (await r.json()) as { ok: boolean; description?: string; result?: T };
+  if (!j.ok) throw new Error(`tg ${method} failed: ${j.description ?? r.status}`);
+  return j.result as T;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const { token, chatId } = loadEnv();
+  const uuid = randomUUID();
+
+  const inline_keyboard = [args.buttons.map((label) => ({
+    text: label,
+    callback_data: `${label.toLowerCase()}:${uuid}`,
+  }))];
+
+  const sent = await tg<{ message_id: number }>(token, "sendMessage", {
+    chat_id: chatId,
+    text: args.question,
+    reply_markup: { inline_keyboard },
+  });
+
+  const cb = await waitForCallback({
+    timeoutMs: args.timeoutMs,
+    predicate: (e) => e.data.endsWith(`:${uuid}`),
+    path: args.callbacksPath,
+  });
+
+  if (!cb) {
+    await tg(token, "editMessageText", {
+      chat_id: chatId,
+      message_id: sent.message_id,
+      text: `${args.question}\n\n⏱ Timeout — no response.`,
+      reply_markup: { inline_keyboard: [] },
+    }).catch(() => undefined);
+    process.exit(2);
+  }
+
+  const action = cb.data.split(":")[0];
+  const labelMatch = args.buttons.find((b) => b.toLowerCase() === action) ?? action;
+
+  await tg(token, "editMessageText", {
+    chat_id: chatId,
+    message_id: sent.message_id,
+    text: `${args.question}\n\n→ ${labelMatch}`,
+    reply_markup: { inline_keyboard: [] },
+  }).catch(() => undefined);
+
+  process.stdout.write(JSON.stringify({
+    action,
+    data: cb.data,
+    fromId: cb.fromId,
+    timestamp: cb.timestamp,
+  }) + "\n");
+}
+
+main().catch((e: unknown) => {
+  process.stderr.write(`error: ${e instanceof Error ? e.message : String(e)}\n`);
+  process.exit(1);
+});

--- a/Packs/Confirm/src/Workflows/Ask.md
+++ b/Packs/Confirm/src/Workflows/Ask.md
@@ -1,0 +1,66 @@
+# Ask — round-trip a yes/no via @<DA>_bot
+
+The single workflow this skill exposes.
+
+## Inputs
+
+- `question` (required, string) — what to ask. Keep it short.
+- `buttons` (optional, comma-list) — choice labels. Default: `Approve,Reject,Defer`.
+- `timeoutMs` (optional, number) — how long to wait for a tap. Default: 15 minutes (`900000`).
+
+## Output
+
+JSON to stdout:
+
+```json
+{
+  "action": "approve",
+  "data": "approve:c1f2e3a4-...",
+  "fromId": 85664591,
+  "timestamp": 1730819400123
+}
+```
+
+Exit codes:
+- `0` — user tapped a button.
+- `2` — timeout (no tap within `timeoutMs`).
+- `1` — error (missing env, network failure, etc).
+
+## How it works
+
+1. Read `TELEGRAM_BOT_TOKEN` and `TELEGRAM_ALLOWED_USERS` from `~/.claude/.env`. First user id is the destination chat.
+2. Generate a UUID. Build `callback_data` per button as `<labelLower>:<uuid>`. (e.g. `approve:c1f2-3a4b`).
+3. POST `sendMessage` with `reply_markup.inline_keyboard`.
+4. Save returned `message_id`.
+5. `waitForCallback` with a predicate that matches `endsWith(":" + uuid)`. Returns either the matched entry or null on timeout.
+6. On match: POST `editMessageText` to update the message body to `"<question>\n\n→ <action> tapped"`, with `reply_markup: { inline_keyboard: [] }` to remove the buttons.
+7. On timeout: POST `editMessageText` to `"<question>\n\n⏱ Timeout — no response."` and exit 2.
+
+## Caller-side patterns
+
+```bash
+# Deploy gate
+RESULT=$(bun run ~/.claude/skills/Confirm/Tools/Ask.ts "Promote staging→prod?")
+ACTION=$(echo "$RESULT" | jq -r .action)
+case "$ACTION" in
+  approve) ./bin/deploy prod ;;
+  reject)  echo "Rejected." ;;
+  defer)   echo "Defer — will re-ask in 1h." ;;
+esac
+```
+
+```ts
+// TypeScript caller
+import { spawn } from "child_process";
+const { stdout } = await Bun.spawn([
+  "bun", "run", "~/.claude/skills/Confirm/Tools/Ask.ts",
+  "Drop migrations 0001_init?", "--buttons", "Drop,Keep",
+]).then((p) => p.exited.then(() => p));
+const { action } = JSON.parse(stdout.toString());
+```
+
+## When NOT to use
+
+- For high-frequency events (every CI run, every alert). Telegram rate-limits and you'll burn the user's attention budget.
+- For confirmations that should block on a desktop UI dialog instead.
+- For multi-step interactive flows (this is yes/no, not a chat).

--- a/Releases/v5.0.0/.claude/PAI/DOCUMENTATION/Notifications/NotificationSystem.md
+++ b/Releases/v5.0.0/.claude/PAI/DOCUMENTATION/Notifications/NotificationSystem.md
@@ -8,6 +8,8 @@ This system provides:
 - Voice feedback when workflows start
 - Consistent user experience across all skills
 
+> See also: [TelegramCallbacks.md](./TelegramCallbacks.md) — inline-keyboard buttons on `@<DA>_bot` for any PAI worker (approval gates, alert triage, multi-stage workflows).
+
 ---
 
 ## Task Start Announcements

--- a/Releases/v5.0.0/.claude/PAI/DOCUMENTATION/Notifications/TelegramCallbacks.md
+++ b/Releases/v5.0.0/.claude/PAI/DOCUMENTATION/Notifications/TelegramCallbacks.md
@@ -1,0 +1,233 @@
+# Telegram Callback Bridge
+
+**Inline-keyboard buttons on `@<DA>_bot` for any PAI worker.**
+
+> **Infrastructure:** The Pulse Telegram daemon (`~/.claude/PAI/PULSE/modules/telegram.ts`) is the only consumer of `getUpdates` for the user's bot token. To let other workers receive `callback_query` presses without fighting Pulse for the long-poll connection, the daemon forwards every press to a JSONL side-channel that any process can tail.
+
+---
+
+## Why this exists
+
+Without a bridge, two pollers on one bot token earn `Conflict: terminated by other getUpdates request` from Telegram. Pulse holds the only connection, but its handler is `bot.on("message:text", …)` — `callback_query` updates are drained and discarded.
+
+This module fixes that with the smallest viable change: Pulse keeps the long-poll, and adds one extra handler that appends each press to a local file. Any worker (cron-driven poller, batch job, approval gate) can now ask the user a yes/no via inline-keyboard buttons.
+
+Use cases:
+- Long-running tasks that need human approval before a destructive step
+- Cron-triggered alerts where the user wants to triage from their phone
+- Booking-style flows that find candidates and need a "book it / skip" decision
+- Multi-stage workflows that pause for a "continue / abort" gate
+
+---
+
+## How it works
+
+```
+┌──────────────────────────┐
+│  Worker (e.g. cron job)  │
+│  1. POST sendMessage     │── inline_keyboard ──▶  Telegram
+│     with reply_markup    │
+│                          │
+│  2. waitForCallback(...) │◀── tails JSONL ──┐
+└──────────────────────────┘                  │
+                                              │
+┌──────────────────────────┐                  │
+│  Pulse Telegram daemon   │                  │
+│  bot.on("callback_query")│── appends ───────┘
+│  → callbacks.jsonl       │
+│  → answerCallbackQuery() │── ack ──▶ Telegram (clears spinner)
+└──────────────────────────┘
+```
+
+1. The worker sends a message to the user with an inline keyboard via the Telegram Bot API directly.
+2. The user taps a button. Telegram delivers a `callback_query` update.
+3. Pulse's `getUpdates` loop receives the update, the `callback_query:data` handler runs, the press is appended to `callbacks.jsonl`, and Telegram is acked (clears the loading spinner on the user's button).
+4. The worker (running in a different process) tails the JSONL via `waitForCallback` and acts on the press.
+
+---
+
+## JSONL contract
+
+**Path:** `~/.claude/PAI/PULSE/state/telegram/callbacks.jsonl`
+**Mode:** `0600` (file), inside `STATE_DIR` (Pulse-managed)
+**Atomicity:** entries are appended in single `O_APPEND` writes ≤ 4 KB — POSIX atomicity for concurrent appends.
+
+**Schema** (one JSON object per line):
+
+| Field | Type | Source |
+|---|---|---|
+| `update_id` | number | Telegram update id (monotonic per bot). Use for cross-run dedup. |
+| `ts` | number | Epoch ms when Pulse logged the press. |
+| `callback_query_id` | string | Telegram callback id (already acked by Pulse). |
+| `from_id` | number | Telegram user id of the presser (already passed Pulse's allowedUsers gate). |
+| `from_username` | string \| null | Optional Telegram username. |
+| `message_id` | number \| null | The message that owned the keyboard. |
+| `chat_id` | number \| null | The chat the message was in. |
+| `data` | string | Raw `callback_data` from the button. **UNTRUSTED** — see security model below. |
+
+Example line:
+
+```json
+{"update_id":1234,"ts":1730819400123,"callback_query_id":"abcd","from_id":85664591,"from_username":"alice","message_id":42,"chat_id":85664591,"data":"approve:c1f2-3a4b"}
+```
+
+---
+
+## Producer (sender)
+
+The bridge does NOT provide a sender — `Pulse/modules/telegram.ts` already handles outbound for DA chats, and workers have unique enough send needs that a shared helper would over-fit. Just call the Telegram Bot API directly:
+
+```bash
+TOKEN="$TELEGRAM_BOT_TOKEN"   # from .env
+CHAT_ID="$TELEGRAM_ALLOWED_USERS"  # comma-list; first id is fine
+CANDIDATE_ID="$(uuidgen)"
+
+curl -s "https://api.telegram.org/bot${TOKEN}/sendMessage" \
+  -H "content-type: application/json" \
+  -d "$(cat <<JSON
+{
+  "chat_id": ${CHAT_ID},
+  "text": "Continue with deploy?",
+  "reply_markup": {
+    "inline_keyboard": [[
+      {"text": "✅ Approve", "callback_data": "approve:${CANDIDATE_ID}"},
+      {"text": "🚫 Reject",  "callback_data": "reject:${CANDIDATE_ID}"}
+    ]]
+  }
+}
+JSON
+)"
+```
+
+In TypeScript:
+
+```ts
+const res = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({
+    chat_id: chatId,
+    text: "Continue with deploy?",
+    reply_markup: {
+      inline_keyboard: [[
+        { text: "✅ Approve", callback_data: `approve:${candidateId}` },
+        { text: "🚫 Reject",  callback_data: `reject:${candidateId}` },
+      ]],
+    },
+  }),
+});
+const sent = (await res.json()).result; // { message_id, chat: { id }, ... }
+```
+
+---
+
+## Consumer (waiter)
+
+Use `TOOLS/TelegramCallbacks.ts`. Single export: `waitForCallback`.
+
+```ts
+import { waitForCallback } from "PAI/TOOLS/TelegramCallbacks";
+
+const cb = await waitForCallback({
+  timeoutMs: 15 * 60 * 1000,                     // 15 min hard ceiling
+  predicate: (e) => e.data.endsWith(`:${candidateId}`),
+});
+
+if (!cb) {
+  // timeout — the user didn't tap. Edit the original message accordingly.
+} else {
+  const [action] = cb.data.split(":");
+  // act on `action`, NEVER pass `data` to a shell or eval.
+}
+```
+
+### Key behaviors
+
+- **Default offset is end-of-file.** A fresh `waitForCallback` call ignores any pre-existing entries — no stale-press replay.
+- **`sinceUpdateId` enables cross-run resume.** Persist the matched entry's `updateId` in your worker's state file; pass it back next run to replay anything newer that arrived while you were down. Together with the EOF default, this gives you "exactly-once intent" for the workers that need it (and "at-most-once" for the ones that don't).
+- **No double-ack.** Pulse already calls `answerCallbackQuery` on receive — don't ack again from the consumer.
+- **Schema validation.** Malformed lines are skipped (logged to stderr); the helper never throws on bad input.
+
+---
+
+## Security model
+
+The bridge ships with a deliberately minimal trust contract. Workers must respect it.
+
+### What the bridge guarantees
+
+- **Auth.** Only Telegram users on Pulse's `allowedUsers` list can produce JSONL entries. The `bot.use(allowedUsers)` middleware runs before `bot.on("callback_query")`; grammY guarantees middleware ordering.
+- **Local-only delivery.** The JSONL file is mode `0600` inside Pulse's `STATE_DIR`. Telegram's API is the *only* way an entry lands there.
+- **Bounded entries.** Pulse drops any callback whose serialized JSONL line would exceed 4 KB. Matches POSIX `O_APPEND` atomicity guarantee for concurrent writes.
+
+### What the bridge does NOT guarantee
+
+- **No signing.** A local process running as the user can append fake entries. This is the same trust boundary as everything else under `~/.claude/PAI/`. If your threat model includes hostile local processes, you have bigger problems.
+- **No replay protection across consumers.** Two workers tailing the same file will both see every entry. Make `callback_data` namespaced and unique per workflow (`<workflow>:<uuid>:<action>`) so each worker's predicate matches only its own presses.
+- **No commit semantics.** Pulse acks "I received your tap" — not "the action you intended is done." The consumer is responsible for everything after.
+
+### Required consumer patterns
+
+1. **Validate `data` before acting.**
+   ```ts
+   // GOOD — explicit allowlist
+   switch (action) {
+     case "approve": return runApprove(...);
+     case "reject":  return runReject(...);
+     default:        return; // unknown / spoofed
+   }
+
+   // BAD — never do this
+   exec(`./tools/run-${action}.sh`)
+   ```
+
+2. **Disable buttons after acting.** Telegram doesn't auto-disable inline keyboards on press. Without this, the user can tap the same button twice and trigger two consumer runs. Edit `reply_markup` to an empty keyboard right after you ack:
+
+   ```ts
+   await fetch(`https://api.telegram.org/bot${token}/editMessageReplyMarkup`, {
+     method: "POST",
+     headers: { "content-type": "application/json" },
+     body: JSON.stringify({ chat_id, message_id, reply_markup: { inline_keyboard: [] } }),
+   });
+   ```
+
+3. **Namespace your `callback_data`.** Format: `<workflow>:<uuid>:<action>`. Use `crypto.randomUUID()` for the UUID. This defends against confused-deputy collisions across workflows.
+
+4. **Use a throwaway bot for testing.** Never paste your production bot token into a fork's `.env`. Create a test bot via @BotFather, use its token for verification, revoke it via `/revoke` when done.
+
+---
+
+## Verifying the bridge
+
+After installing or upgrading PAI:
+
+1. Confirm Pulse has the handler:
+   ```sh
+   grep -n 'callback_query:data' ~/.claude/PAI/PULSE/modules/telegram.ts
+   ```
+
+2. Send a test message with buttons (substitute your token + chat id):
+   ```sh
+   curl -s "https://api.telegram.org/bot$TOKEN/sendMessage" \
+     -H "content-type: application/json" \
+     -d '{"chat_id":'"$CHAT_ID"',"text":"bridge test","reply_markup":{"inline_keyboard":[[{"text":"OK","callback_data":"t:1"}]]}}'
+   ```
+
+3. Tap "OK" on your phone, then check the JSONL grew:
+   ```sh
+   tail -1 ~/.claude/PAI/PULSE/state/telegram/callbacks.jsonl
+   # → {"update_id":...,"data":"t:1",...}
+   ```
+
+4. Run the helper tests:
+   ```sh
+   bun test ./Releases/v5.0.0/.claude/PAI/TOOLS/TelegramCallbacks.test.ts
+   ```
+
+---
+
+## Out of scope (future work)
+
+- **Log rotation.** `callbacks.jsonl` grows unbounded. Entries are tiny (~250 B), so the practical cap is months of presses, but a future opt-in rotation hook in Pulse could trim by date or size.
+- **Signed entries.** A symmetric MAC over each line, keyed by a per-user secret in STATE_DIR, would defeat local spoofing. Not added because the threat model is already single-user.
+- **Other update types.** The same pattern (additive `bot.on(...)` → JSONL → consumer helper) extends to `inline_query`, `chat_member`, etc. Ship the one with proven demand first.

--- a/Releases/v5.0.0/.claude/PAI/PULSE/modules/telegram.ts
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/modules/telegram.ts
@@ -39,6 +39,8 @@ const HOME = process.env.HOME ?? ""
 const CWD = join(HOME, ".claude")
 const STATE_DIR = join(HOME, ".claude", "PAI", "PULSE", "state", "telegram")
 const LOGS_DIR = join(HOME, ".claude", "PAI", "PULSE", "logs", "telegram")
+const CALLBACKS_LOG = join(STATE_DIR, "callbacks.jsonl")
+const CALLBACKS_MAX_BYTES = 4096
 const MAX_TELEGRAM_LENGTH = 4096
 const CURSOR = " ▌"
 
@@ -335,6 +337,51 @@ CRITICAL RULES FOR TELEGRAM MODE:
     } finally {
       processing = false
     }
+  })
+
+  // ── Callback bridge ──
+  //
+  // Inline-keyboard `callback_query` updates have no other handler in this
+  // module — grammY's polling loop drains them anyway, so without a bridge any
+  // *second* worker on the same bot token gets `Conflict: terminated by other
+  // getUpdates request` from Telegram. We forward each press to a JSONL
+  // side-channel that other PAI workers (cron-driven pollers, batch jobs,
+  // approval gates) can tail.
+  //
+  // Trust boundary: JSONL entries are local-trusted. STATE_DIR is owner-only
+  // (any process running as the user can read/write); a malicious local
+  // process is already in scope of "anyone with write access here can do
+  // worse." Consumers MUST treat `data` as untrusted user input — never
+  // shell-exec it, never SQL-concat it. Acks here mean "received," not
+  // "committed"; the consumer is responsible for editing the message after
+  // taking action and for using namespaced callback_data (e.g.
+  // `<workflow>:<uuid>:<action>`) to avoid confused-deputy collisions.
+  //
+  // POSIX guarantees writes ≤ PIPE_BUF (4096 B) on `O_APPEND` files are
+  // atomic; we cap each line accordingly.
+  bot.on("callback_query:data", async (ctx) => {
+    const cb = ctx.callbackQuery
+    const entry = {
+      update_id: ctx.update.update_id,
+      ts: Date.now(),
+      callback_query_id: cb.id,
+      from_id: cb.from?.id,
+      from_username: cb.from?.username,
+      message_id: cb.message?.message_id,
+      chat_id: cb.message?.chat?.id,
+      data: cb.data,
+    }
+    const line = JSON.stringify(entry) + "\n"
+    if (Buffer.byteLength(line, "utf8") > CALLBACKS_MAX_BYTES) {
+      log("warn", "Dropping oversized callback entry", { update_id: entry.update_id, len: line.length })
+    } else {
+      try {
+        await appendFile(CALLBACKS_LOG, line, { mode: 0o600 })
+      } catch (e) {
+        log("error", "Failed to log callback", { error: String(e) })
+      }
+    }
+    await ctx.answerCallbackQuery().catch(() => {})
   })
 
   // Start polling — await keeps startTelegram() alive until bot.stop() is called.

--- a/Releases/v5.0.0/.claude/PAI/TOOLS/TelegramCallbacks.test.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/TelegramCallbacks.test.ts
@@ -1,0 +1,122 @@
+/**
+ * TelegramCallbacks.test.ts — fixture-based tests for the JSONL reader.
+ * Run: `bun test Releases/v5.0.0/.claude/PAI/TOOLS/TelegramCallbacks.test.ts`
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, appendFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { waitForCallback } from "./TelegramCallbacks";
+
+let tmp: string;
+let logPath: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "tg-cb-"));
+  logPath = join(tmp, "callbacks.jsonl");
+});
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function writeEntry(updateId: number, data: string, opts: { messageId?: number; chatId?: number } = {}) {
+  const entry = {
+    update_id: updateId,
+    ts: Date.now(),
+    callback_query_id: `cbid-${updateId}`,
+    from_id: 12345,
+    from_username: "tester",
+    message_id: opts.messageId ?? 100 + updateId,
+    chat_id: opts.chatId ?? 9999,
+    data,
+  };
+  appendFileSync(logPath, JSON.stringify(entry) + "\n");
+}
+
+describe("waitForCallback", () => {
+  test("returns matching entry when predicate hits", async () => {
+    writeEntry(1, "approve:abc");
+    writeEntry(2, "skip:abc");
+    writeEntry(3, "approve:xyz");
+    const cb = await waitForCallback({
+      timeoutMs: 200,
+      pollMs: 20,
+      predicate: (e) => e.data === "skip:abc",
+      sinceUpdateId: 0,
+      path: logPath,
+    });
+    expect(cb).not.toBeNull();
+    expect(cb!.updateId).toBe(2);
+    expect(cb!.data).toBe("skip:abc");
+    expect(cb!.fromId).toBe(12345);
+  });
+
+  test("returns null on timeout when nothing matches", async () => {
+    writeEntry(1, "approve:abc");
+    const cb = await waitForCallback({
+      timeoutMs: 100,
+      pollMs: 20,
+      predicate: (e) => e.data === "never:matches",
+      sinceUpdateId: 0,
+      path: logPath,
+    });
+    expect(cb).toBeNull();
+  });
+
+  test("sinceUpdateId skips already-processed entries", async () => {
+    writeEntry(1, "approve:abc");
+    writeEntry(2, "approve:abc");
+    writeEntry(3, "approve:abc");
+    const cb = await waitForCallback({
+      timeoutMs: 100,
+      pollMs: 20,
+      predicate: (e) => e.data === "approve:abc",
+      sinceUpdateId: 2,
+      path: logPath,
+    });
+    expect(cb).not.toBeNull();
+    expect(cb!.updateId).toBe(3);
+  });
+
+  test("default offset starts at EOF — does not replay pre-existing entries", async () => {
+    writeEntry(1, "stale:1");
+    writeEntry(2, "stale:2");
+    const promise = waitForCallback({
+      timeoutMs: 200,
+      pollMs: 20,
+      predicate: (e) => e.data.startsWith("fresh:"),
+      path: logPath,
+    });
+    setTimeout(() => writeEntry(3, "fresh:3"), 50);
+    const cb = await promise;
+    expect(cb).not.toBeNull();
+    expect(cb!.updateId).toBe(3);
+  });
+
+  test("malformed JSON line is skipped, others still parsed", async () => {
+    writeEntry(1, "good:1");
+    writeFileSync(logPath, "{not valid json\n", { flag: "a" });
+    writeEntry(2, "good:2");
+    const cb = await waitForCallback({
+      timeoutMs: 100,
+      pollMs: 20,
+      predicate: (e) => e.data === "good:2",
+      sinceUpdateId: 0,
+      path: logPath,
+    });
+    expect(cb).not.toBeNull();
+    expect(cb!.updateId).toBe(2);
+  });
+
+  test("missing log file → returns null on timeout, no crash", async () => {
+    const missing = join(tmp, "does-not-exist.jsonl");
+    const cb = await waitForCallback({
+      timeoutMs: 80,
+      pollMs: 20,
+      predicate: () => true,
+      path: missing,
+    });
+    expect(cb).toBeNull();
+  });
+});

--- a/Releases/v5.0.0/.claude/PAI/TOOLS/TelegramCallbacks.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/TelegramCallbacks.ts
@@ -1,0 +1,135 @@
+/**
+ * TelegramCallbacks.ts — consumer-side helper for the Pulse Telegram callback
+ * bridge.
+ *
+ * Pulse's Telegram daemon (see PULSE/modules/telegram.ts) forwards every
+ * inline-keyboard `callback_query` press to a JSONL side-channel at
+ * `~/.claude/PAI/PULSE/state/telegram/callbacks.jsonl`. Any PAI worker that
+ * needs to ask the user a yes/no via `@<DA>_bot` reads that file with this
+ * helper.
+ *
+ * See DOCUMENTATION/Notifications/TelegramCallbacks.md for the producer-side
+ * contract and the full security model.
+ */
+
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const HOME = process.env.HOME ?? "";
+const DEFAULT_CALLBACKS_LOG = join(HOME, ".claude", "PAI", "PULSE", "state", "telegram", "callbacks.jsonl");
+
+export interface TelegramCallback {
+  /** Telegram update_id — monotonic per bot. Use this for cross-run dedup. */
+  updateId: number;
+  /** Epoch ms when Pulse logged the press. */
+  timestamp: number;
+  /** Telegram callback_query id (already acked by Pulse). */
+  id: string;
+  /** Telegram user id of the presser (passes Pulse's allowedUsers gate). */
+  fromId: number;
+  fromUsername?: string;
+  /** message_id of the message that owned the keyboard. */
+  messageId?: number;
+  chatId?: number;
+  /** Raw callback_data string. UNTRUSTED — validate before acting. */
+  data: string;
+}
+
+interface RawEntry {
+  update_id?: unknown;
+  ts?: unknown;
+  callback_query_id?: unknown;
+  from_id?: unknown;
+  from_username?: unknown;
+  message_id?: unknown;
+  chat_id?: unknown;
+  data?: unknown;
+}
+
+function parseEntry(line: string): TelegramCallback | null {
+  let raw: RawEntry;
+  try { raw = JSON.parse(line) as RawEntry; } catch { return null; }
+  if (typeof raw.update_id !== "number" ||
+      typeof raw.ts !== "number" ||
+      typeof raw.callback_query_id !== "string" ||
+      typeof raw.from_id !== "number" ||
+      typeof raw.data !== "string") {
+    return null;
+  }
+  return {
+    updateId: raw.update_id,
+    timestamp: raw.ts,
+    id: raw.callback_query_id,
+    fromId: raw.from_id,
+    fromUsername: typeof raw.from_username === "string" ? raw.from_username : undefined,
+    messageId: typeof raw.message_id === "number" ? raw.message_id : undefined,
+    chatId: typeof raw.chat_id === "number" ? raw.chat_id : undefined,
+    data: raw.data,
+  };
+}
+
+interface ReadResult { entries: TelegramCallback[]; nextOffset: number }
+
+function readEntriesAfter(path: string, byteOffset: number): ReadResult {
+  if (!existsSync(path)) return { entries: [], nextOffset: 0 };
+  const size = statSync(path).size;
+  if (size <= byteOffset) return { entries: [], nextOffset: size };
+  const slice = readFileSync(path).subarray(byteOffset, size);
+  const text = slice.toString("utf8");
+  const entries: TelegramCallback[] = [];
+  let consumed = 0;
+  for (const rawLine of text.split("\n")) {
+    if (rawLine.length === 0) { consumed += 1; continue; }
+    consumed += Buffer.byteLength(rawLine, "utf8") + 1;
+    const parsed = parseEntry(rawLine);
+    if (parsed) entries.push(parsed);
+    else process.stderr.write(`[TelegramCallbacks] skipping malformed line at offset ${byteOffset + consumed}\n`);
+  }
+  return { entries, nextOffset: byteOffset + Math.min(consumed, slice.length) };
+}
+
+export interface WaitOptions {
+  /** Hard ceiling. Returns null on timeout. */
+  timeoutMs: number;
+  /** Match function — return true on the entry you want. */
+  predicate: (cb: TelegramCallback) => boolean;
+  /** File-poll cadence in ms. Default 1500. */
+  pollMs?: number;
+  /**
+   * Resume across restarts: skip entries whose `updateId` is ≤ this value.
+   * Persist the returned entry's `updateId` and pass it back next time.
+   * If omitted, helper starts at end-of-file (no replay of stale presses).
+   */
+  sinceUpdateId?: number;
+  /** Override the JSONL path. Defaults to ~/.claude/PAI/PULSE/state/telegram/callbacks.jsonl. */
+  path?: string;
+}
+
+/**
+ * Tail the Pulse callback JSONL until `predicate` matches an entry or
+ * `timeoutMs` elapses. Returns the matching callback (already acked by
+ * Pulse) or null on timeout.
+ */
+export async function waitForCallback(opts: WaitOptions): Promise<TelegramCallback | null> {
+  const path = opts.path ?? DEFAULT_CALLBACKS_LOG;
+  const pollMs = opts.pollMs ?? 1500;
+  let offset: number;
+  if (opts.sinceUpdateId === undefined) {
+    offset = existsSync(path) ? statSync(path).size : 0;
+  } else {
+    offset = 0;
+  }
+  const deadline = Date.now() + opts.timeoutMs;
+  while (Date.now() < deadline) {
+    const { entries, nextOffset } = readEntriesAfter(path, offset);
+    offset = nextOffset;
+    for (const e of entries) {
+      if (opts.sinceUpdateId !== undefined && e.updateId <= opts.sinceUpdateId) continue;
+      if (opts.predicate(e)) return e;
+    }
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+  return null;
+}
+
+export { DEFAULT_CALLBACKS_LOG };


### PR DESCRIPTION
## Problem

Pulse's Telegram daemon (`PULSE/modules/telegram.ts`) only handles `message:text` updates. grammY's polling loop drains *every* update type for the bot — including `callback_query` from inline-keyboard buttons, which it then drops on the floor.

Net effect: **a second PAI worker that wants to use inline-keyboard buttons on `@<DA>_bot` cannot.** Telegram only allows one `getUpdates` connection per bot token, and Pulse owns it. Any worker that tries to long-poll the same token earns `Conflict: terminated by other getUpdates request`.

This blocks every long-running task that wants to ask the user a yes/no — approval gates before destructive steps, alert triage from the user's phone, multi-stage workflows that pause for "continue / abort", batch jobs that need confirmation. They all hit the same wall.

## Approach

Smallest viable change: Pulse keeps the long-poll, and gains one extra handler. That handler appends each press to a JSONL side-channel and acks the spinner. Any worker — running in its own process — can tail the JSONL and act on entries.

```
┌──────────────────────────┐
│  Worker (e.g. cron job)  │
│  1. POST sendMessage     │── inline_keyboard ──▶  Telegram
│     with reply_markup    │
│                          │
│  2. waitForCallback(...) │◀── tails JSONL ──┐
└──────────────────────────┘                  │
                                              │
┌──────────────────────────┐                  │
│  Pulse Telegram daemon   │                  │
│  bot.on("callback_query")│── appends ───────┘
│  → callbacks.jsonl       │
│  → answerCallbackQuery() │── ack ──▶ Telegram
└──────────────────────────┘
```

Strictly additive — `message:text` routing, chat-log, conversations.json, auth middleware all unchanged.

## What's added

| File | Change |
|---|---|
| `Releases/v5.0.0/.claude/PAI/PULSE/modules/telegram.ts` | +47 lines: `callback_query:data` handler + length cap + trust-boundary comment block |
| `Releases/v5.0.0/.claude/PAI/TOOLS/TelegramCallbacks.ts` | New: consumer-side helper with `waitForCallback({ timeoutMs, predicate, sinceUpdateId?, path? })` |
| `Releases/v5.0.0/.claude/PAI/TOOLS/TelegramCallbacks.test.ts` | New: 6 fixture-based bun tests (all pass) |
| `Releases/v5.0.0/.claude/PAI/DOCUMENTATION/Notifications/TelegramCallbacks.md` | New: producer/consumer contract, JSONL schema, security model |
| `Releases/v5.0.0/.claude/PAI/DOCUMENTATION/Notifications/NotificationSystem.md` | +1 line cross-link |
| `Packs/Confirm/` | New worked-example pack: `/confirm "<question>"` returns user's tap. Doubles as integration test |

Total: 11 files, +996 lines, no deletions.

## Threat model

Documented in full in `TelegramCallbacks.md`. Summary:

| What it guarantees | What it doesn't |
|---|---|
| Auth via existing `bot.use(allowedUsers)` middleware | Signing — local processes running as the user can spoof entries |
| File mode 0600 inside Pulse-managed STATE_DIR | Replay protection across multiple consumers |
| 4 KB per-line cap (POSIX `O_APPEND` atomicity) | Commit semantics — ack means "received," not "done" |

Required consumer patterns are spelled out in the doc:
- Validate `data` (allowlist switch, never shell-exec)
- Disable buttons via `editMessageReplyMarkup` after acting
- Namespace `callback_data` as `<workflow>:<uuid>:<action>`
- Use a throwaway bot for testing; never paste production tokens into experimental code

## Compat

- Existing `message:text` consumers see no behavior change.
- No new dependencies (grammY already imported; `appendFile` already imported).
- No breaking changes to JSONL schema (new file, new contract).
- The Confirm pack is opt-in — only installed when the user runs the wizard.

## How to verify

1. Confirm the bridge handler is loaded: `grep -n 'callback_query:data' Releases/v5.0.0/.claude/PAI/PULSE/modules/telegram.ts`
2. Run helper unit tests: `bun test ./Releases/v5.0.0/.claude/PAI/TOOLS/TelegramCallbacks.test.ts` → 6 pass
3. Manual round-trip with a throwaway bot (recipe in `TelegramCallbacks.md`):
   - Create a test bot via @BotFather, `/start` it from your phone
   - Send a message with an inline keyboard via `curl` to `sendMessage`
   - Tap a button on phone
   - Confirm a new line in `~/.claude/PAI/PULSE/state/telegram/callbacks.jsonl`
4. Confirm pack round-trip: `bun run ~/.claude/skills/Confirm/Tools/Ask.ts "Test?" --timeout-ms 30000` → tap on phone → JSON on stdout

The PR was developed against a throwaway bot; a self-contained test bridge that mimics Pulse's bridge for any bot token validated the full sender→Pulse→JSONL→helper→consumer round trip end-to-end. No production tokens were used in PR development.

## Out of scope (future work)

- Log rotation for `callbacks.jsonl` — entries are tiny (~250 B); rotation is opt-in future work.
- Signed entries — defeat local spoofing if the threat model evolves to multi-user.
- Other update types (`inline_query`, `chat_member`) — same pattern would extend cleanly.

## Sign-off

Commit is signed off (`-s`) for DCO defensiveness. Author identity is the GitHub no-reply address.
