### PR TITLE
fix(pulse): auto-start user-index module on Pulse startup

### DIFF
--- a/Releases/v5.0.0/.claude/PAI/PULSE/PULSE.toml.example
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/PULSE.toml.example
@@ -9,6 +9,7 @@ host = "localhost"
 # Enable/disable modules by setting to true/false
 hooks = true
 observability = true
+user_index = true   # auto-builds Pulse/state/user-index.json + fs.watch USER/
 
 # Example custom module — create your own in modules/
 # my_module = true

--- a/Releases/v5.0.0/.claude/PAI/PULSE/pulse.ts
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/pulse.ts
@@ -76,6 +76,7 @@ let imessageModule: any = null
 let assistantModule: any = null
 let performanceModule: any = null
 let syslogModule: any = null
+let userIndexModule: any = null
 
 async function loadModules(config: PulseConfig) {
   if (config.voice?.enabled !== false) {
@@ -97,6 +98,13 @@ async function loadModules(config: PulseConfig) {
     wikiModule = await import("./modules/wiki")
   } catch (err) {
     log("warn", "Wiki module not available", { error: String(err) })
+  }
+  // User-index module — always load (no config gate). Builds
+  // Pulse/state/user-index.json on startup and keeps it fresh via fs.watch.
+  try {
+    userIndexModule = await import("./modules/user-index")
+  } catch (err) {
+    log("warn", "User-index module not available", { error: String(err) })
   }
   if (config.telegram?.enabled) {
     try {
@@ -356,6 +364,16 @@ async function main() {
   if (wikiModule) {
     wikiModule.startWiki()
     log("info", "Wiki module loaded")
+  }
+
+  if (userIndexModule) {
+    try {
+      await userIndexModule.start()
+      log("info", "User-index module loaded")
+    } catch (err) {
+      log("error", "User-index module failed to start", { error: String(err) })
+      userIndexModule = null
+    }
   }
 
   if (assistantModule && config.da?.enabled) {


### PR DESCRIPTION
## Summary

The user-index module (`Pulse/modules/user-index.ts`) exports a full
`start()` / `stop()` / `health()` lifecycle and is designed to be a
first-class Pulse module — it scans `USER/`, builds
`Pulse/state/user-index.json`, and sets up `fs.watch` for live
updates. However, `pulse.ts` never imports or starts it, so the index
is only built when a user manually runs
`bun run Pulse/modules/user-index.ts`.

Result on a fresh install: the Life Dashboard, `/api/user-index`, the
Daemon publish_feed, and the Interview skill's gap detection all read
a missing or stale index until the user discovers the manual command.

## Reproduction

1. Fresh PAI install, Pulse running
2. Add or edit any file under `USER/` (e.g. create `USER/TELOS/Foo.md`)
3. Visit `http://localhost:31337/life` or hit `/api/user-index`
4. Observe: new file does not appear; `Pulse/state/user-index.json`
   mtime is unchanged from install time

## Fix

Wire `modules/user-index` into `pulse.ts` using the same always-load
pattern as `modules/wiki`:

- Conditional import in `loadModules()` (try/catch — module is optional)
- `await userIndexModule.start()` in the startup sequence so the
  initial scan + `fs.watch` daemon both run

Also documents the module in `PULSE.toml.example`.

## Risk

Minimal. Module is opt-out via try/catch (matches wiki). The
`start()` function already exists, was already tested via the
standalone CLI, and writes to a path Pulse's own observability module
already serves. No new deps. No breaking changes.

## Verification

- [x] Patched `pulse.ts` transpiles cleanly (`bun build --no-bundle`)
- [x] Edits match the existing always-load module pattern (wiki) line-for-line
- [x] No changes to module API surface — user-index.ts is unmodified

Maintainer testing recommended:

- [ ] Pulse starts cleanly with the change applied
- [ ] `Pulse/state/user-index.json` is written on first startup
- [ ] Editing a `USER/*.md` file updates the index within ~250ms
  (existing debounce in user-index.ts)
- [ ] `bun run Pulse/modules/user-index.ts` standalone CLI still works