### PR TITLE
fix(v5): restore identity context after compaction

### DIFF
--- a/Releases/v5.0.0/.claude/settings.json
+++ b/Releases/v5.0.0/.claude/settings.json
@@ -1208,7 +1208,9 @@
   "postCompactRestore": {
     "_docs": "System default files re-injected after compaction. User additions via EXTRA_COMPACT_RESTORE in PAI_CONFIG.yaml.",
     "fullFiles": [
-      "USER/PROJECTS/PROJECTS.md"
+      "USER/PROJECTS/PROJECTS.md",
+      "USER/DA_IDENTITY.md",
+      "USER/PRINCIPAL_IDENTITY.md"
     ]
   },
   "contextFiles": [],


### PR DESCRIPTION
## What

Adds `USER/DA_IDENTITY.md` and `USER/PRINCIPAL_IDENTITY.md` to `postCompactRestore.fullFiles` in the v5.0.0 release settings.

## Why

These two files define the core of the DA–Principal relationship: who the DA is, who it's working for, how they collaborate. They're loaded at session start via `@`-imports in CLAUDE.md:

```
@PAI/USER/PRINCIPAL_IDENTITY.md
@PAI/USER/DA_IDENTITY.md
```

But `@`-imports only fire at session start — they do **not** re-fire after mid-session context compaction. Long sessions (deep Algorithm runs, multi-step builds, extensive research) routinely hit the compaction threshold. When they do, these files are lost from context, and the DA loses awareness of who it is and who it's working for.

This is not a user preference — it's a gap in the default config that undermines PAI's core design.

### Philosophy reference

From the [Life OS Thesis](Releases/v5.0.0/.claude/PAI/DOCUMENTATION/LifeOs/LifeOsThesis.md):

> *"PAI is the Life Operating System... it manages the resources, processes, **identity**, memory, and interfaces that let you live and work."*

> *"Every real assistant does one job: **understand your current state, understand your ideal state**, and hill-climb you from one to the other."*

> *"Everyone running PAI names their own DA. The DA is personal — **a name, a voice, a personality, an identity**."*

From the [System Prompt](Releases/v5.0.0/.claude/PAI/PAI_SYSTEM_PROMPT.md):

> *"Its **primary directive is understanding the Principal** so that it can help them move from their current state to their IDEAL STATE."*

Identity is the foundation of the Current State → Ideal State loop. If the DA doesn't know who the Principal is — their goals, challenges, work patterns, communication preferences — it can't hill-climb toward anything. `postCompactRestore` exists precisely for files that must survive compaction. Identity files are the textbook case.

`PROJECTS.md` is already in `postCompactRestore` (correctly). The identity files belong alongside it — they're at least as load-bearing.

## Scope

- 1 file changed: `Releases/v5.0.0/.claude/settings.json`
- Net: +3 lines, -1 line
- Adds two entries to an existing array