### PR TITLE
ISA Scaffold: use absolute ~/.claude/PAI/MEMORY/WORK paths consistently

### DIFF
--- a/Packs/ISA/src/Workflows/Scaffold.md
+++ b/Packs/ISA/src/Workflows/Scaffold.md
@@ -14,7 +14,7 @@ Generate a fresh ISA from a prompt at a specified effort tier. The output is a p
 |-------|----------|-------------|
 | prompt | yes | The user's request — verbatim or distilled |
 | tier | yes | E1 / E2 / E3 / E4 / E5 |
-| project | no | If task targets a known project from PROJECTS.md, the project ISA path is used; otherwise a task ISA at `MEMORY/WORK/{slug}/ISA.md` |
+| project | no | If task targets a known project from PROJECTS.md, the project ISA path is used; otherwise a task ISA at `~/.claude/PAI/MEMORY/WORK/{slug}/ISA.md` (always absolute — never relative to cwd) |
 | ephemeral_feature | no | If set, scaffold a feature-file excerpt instead of a full ISA |
 
 ## Output
@@ -118,7 +118,7 @@ When `ephemeral_feature` is set:
    - `## Test Strategy` entries matching those ISCs
    - `## Decisions` filtered to entries mentioning this feature's ISC IDs (optional)
    - Empty `## Verification` section ready to populate
-4. Write to `MEMORY/WORK/{slug}/_ephemeral/<feature>.md`.
+4. Write to `~/.claude/PAI/MEMORY/WORK/{slug}/_ephemeral/<feature>.md`.
 5. Add a header comment: `<!-- EPHEMERAL FEATURE FILE — derived from <master-isa-path>. Reconcile via Skill("ISA", "reconcile <this-path> → <master-path>"). Do not hand-edit master from this file. -->`
 
 ## Failure modes


### PR DESCRIPTION
## Problem

Two prescriptive references in `Packs/ISA/src/Workflows/Scaffold.md` write the task-ISA path as bare-relative `MEMORY/WORK/{slug}/...`:

- **Line 17** (Inputs table): "otherwise a task ISA at \`MEMORY/WORK/{slug}/ISA.md\`"
- **Line 121** (Ephemeral mode, step 4): "Write to \`MEMORY/WORK/{slug}/_ephemeral/<feature>.md\`"

When a session runs with cwd inside a project repo (the common case for IDE-launched Claude Code or any `cd $repo && claude` workflow), models resolve these relative strings against cwd and write ISA scaffolding into the project repo instead of the canonical PAI memory home.

In our setup this manifested as ~600 stray `MEMORY/WORK/{slug}/` directories scattered across 20+ repos before we caught it — including some that ended up committed because the repos didn't gitignore `MEMORY/`.

## Fix

Make the two stragglers consistent with the established pattern.

The same workflow's `## Output` section a few lines above (lines 24-25) already correctly says `~/.claude/PAI/MEMORY/WORK/{slug}/ISA.md` — this PR just propagates that absolute form to the two remaining bare-relative references. No new behavior, no new doctrine — only consistency.

## Diff

```diff
- | otherwise a task ISA at `MEMORY/WORK/{slug}/ISA.md` |
+ | otherwise a task ISA at `~/.claude/PAI/MEMORY/WORK/{slug}/ISA.md` (always absolute — never relative to cwd) |

- 4. Write to `MEMORY/WORK/{slug}/_ephemeral/<feature>.md`.
+ 4. Write to `~/.claude/PAI/MEMORY/WORK/{slug}/_ephemeral/<feature>.md`.
```

## Scope

Two lines in one file. Nothing else.