### PR TITLE
fix(v5): resolve DA identity via _registry.yaml in PostCompact restore

### DIFF
--- a/Releases/v5.0.0/.claude/hooks/RestoreContext.hook.ts
+++ b/Releases/v5.0.0/.claude/hooks/RestoreContext.hook.ts
@@ -127,16 +127,31 @@ function main() {
   }
 
   // --- Tier 2: Identity anchors (critical sections only) ---
+  //
+  // Resolve the active DA via USER/DA/_registry.yaml (schema-v1). Fall back to
+  // the legacy flat USER/DA_IDENTITY.md path for fresh installs that haven't
+  // run /interview yet (registry doesn't exist until then).
+  // See PAI/DOCUMENTATION/Pulse/DaSubsystem.md for the registry schema.
 
-  const identityPath = paiPath('USER', 'DA_IDENTITY.md');
+  const registryContent = safeRead(paiPath('USER', 'DA', '_registry.yaml'));
+  const primaryMatch = registryContent.match(/^primary:\s*(.+?)\s*$/m);
+  const primaryDa = primaryMatch ? primaryMatch[1].trim() : null;
+  const identityPath = primaryDa
+    ? paiPath('USER', 'DA', primaryDa, 'DA_IDENTITY.md')
+    : paiPath('USER', 'DA_IDENTITY.md');
+
   const identitySections = extractSections(identityPath, [
-    'My Identity',
+    // schema-v1 sections (current)
     'First-Person Voice',
+    'Personality',
+    'Writing',
+    'Relationship',
+    'Autonomy',
+    // legacy sections (pre-schema-v1, kept for backward compat)
+    'My Identity',
     'Core Values',
-    'Personality & Behavior',
-    'Cussing & Frustration Protocol',
-    'Relationship Model',
-    'Pronoun Convention',
+    'Cussing',
+    'Pronoun',
   ]);
 
   if (identitySections) {


### PR DESCRIPTION
## What

Fixes `Releases/v5.0.0/.claude/hooks/RestoreContext.hook.ts` to resolve the active DA's `DA_IDENTITY.md` via the schema-v1 registry (`USER/DA/_registry.yaml`) instead of the deprecated flat path (`USER/DA_IDENTITY.md`).

## Why

Tier 2 of the PostCompact restore (the "DA Identity (Critical Sections)" block re-injected after mid-session compaction) was hardcoded to read:

```typescript
const identityPath = paiPath('USER', 'DA_IDENTITY.md');
```

Schema-v1 — introduced for the Pulse DA subsystem — moved the canonical DA identity to `USER/DA/<primary>/DA_IDENTITY.md`, with the active DA selected via `USER/DA/_registry.yaml` (`primary: <da-name>`). The flat `USER/DA_IDENTITY.md` is now a deprecated placeholder kept for backward compat; on systems that have run `/interview`, it's a `deprecated: true` stub pointing at the new path.

Reference: [`PAI/DOCUMENTATION/Pulse/DaSubsystem.md`](../blob/main/Releases/v5.0.0/.claude/PAI/DOCUMENTATION/Pulse/DaSubsystem.md) — registry schema (line ~66) + migration table (line ~262: `PAI/USER/DA_IDENTITY.md` → `PAI/USER/DA/your-da/DA_IDENTITY.md`).

After the migration, the post-compact restore was silently giving the DA the wrong identity context — either a stale legacy snapshot or a deprecated-stub header — depending on install age. This is exactly the failure mode `postCompactRestore` exists to prevent.

The section-name list was also stale relative to schema-v1's generated headings.

## What ships

`Releases/v5.0.0/.claude/hooks/RestoreContext.hook.ts` — Tier 2 path resolution + section list:

```typescript
// Resolve the active DA via USER/DA/_registry.yaml (schema-v1). Fall back to
// the legacy flat USER/DA_IDENTITY.md path for fresh installs that haven't
// run /interview yet (registry doesn't exist until then).
const registryContent = safeRead(paiPath('USER', 'DA', '_registry.yaml'));
const primaryMatch = registryContent.match(/^primary:\s*(.+?)\s*$/m);
const primaryDa = primaryMatch ? primaryMatch[1].trim() : null;
const identityPath = primaryDa
  ? paiPath('USER', 'DA', primaryDa, 'DA_IDENTITY.md')
  : paiPath('USER', 'DA_IDENTITY.md');

const identitySections = extractSections(identityPath, [
  // schema-v1 sections (current)
  'First-Person Voice', 'Personality', 'Writing', 'Relationship', 'Autonomy',
  // legacy sections (pre-schema-v1, kept for backward compat)
  'My Identity', 'Core Values', 'Cussing', 'Pronoun',
]);
```

### Behavior matrix

| Install state | Old behavior | New behavior |
|---|---|---|
| Fresh install, no `/interview` run | Reads legacy `USER/DA_IDENTITY.md` (template) | Same — registry missing → legacy fallback |
| Post-`/interview`, schema-v1 | Reads legacy file (now a deprecated stub) | Reads `USER/DA/<primary>/DA_IDENTITY.md` (correct) |
| Multiple DAs | First DA hardcoded | `primary:` from registry — correct active DA |

## Scope

- 1 file changed: `Releases/v5.0.0/.claude/hooks/RestoreContext.hook.ts`
- Net: +21 / -6 lines
- No new dependencies. The registry is parsed via single regex against `primary:` since that's the only field this hook needs.

## Out of scope

- `Releases/v5.0.0/.claude/settings.json` `postCompactRestore.fullFiles` — see #1212 for that conversation. (I left a comment there suggesting the schema-v1 path; the two PRs are independent.)
- Updating the section-name list semantics beyond schema-v1 vs legacy. The matching function uses `.includes()`, so partial matches still work.

## Testing

Verified locally on `~/.claude/`:

```
$ bun ~/.claude/hooks/RestoreContext.hook.ts
🔄 Restored: USER/PRINCIPAL_IDENTITY.md (4782 chars)
🔄 Restored: USER/DA/<primary>/DA_IDENTITY.md (1987 chars)
🔄 Restored: DA_IDENTITY critical sections (1653 chars)
```

Pre-fix the same run pulled from `USER/DA_IDENTITY.md` (the deprecated stub). Post-fix it pulls from the registry-resolved path with no errors.

Fallback path verified by temporarily renaming `USER/DA/_registry.yaml` — the hook quietly drops back to legacy `USER/DA_IDENTITY.md` with no error.
