### PR TITLE
fix: add notifyTaskComplete and notifyError exports to notifications.ts

### DIFF
--- a/Releases/v5.0.0/.claude/hooks/lib/notifications.ts
+++ b/Releases/v5.0.0/.claude/hooks/lib/notifications.ts
@@ -88,3 +88,15 @@ export async function sendPush(
     return false;
   }
 }
+
+// ============================================================================
+// Convenience wrappers (used by hooks that report task outcomes)
+// ============================================================================
+
+export async function notifyTaskComplete(message: string): Promise<boolean> {
+  return sendPush(message || 'Task complete', { title: 'PAI', tags: ['white_check_mark'] });
+}
+
+export async function notifyError(message: string): Promise<boolean> {
+  return sendPush(message || 'Error occurred', { title: 'PAI Error', priority: 'high', tags: ['x'] });
+}


### PR DESCRIPTION
## Problem

`hooks/lib/notifications.ts` does not export `notifyTaskComplete` or `notifyError`. Any hook that imports these functions (e.g. via `import { notifyTaskComplete } from '../lib/notifications'`) throws a SyntaxError at load time, silently breaking the hook.

## Fix

Add two convenience wrapper functions after `sendPush`:

```typescript
export async function notifyTaskComplete(message: string): Promise<boolean> {
  return sendPush(message || 'Task complete', { title: 'PAI', tags: ['white_check_mark'] });
}

export async function notifyError(message: string): Promise<boolean> {
  return sendPush(message || 'Error occurred', { title: 'PAI Error', priority: 'high', tags: ['x'] });
}
```

## Notes

- Both functions delegate to the existing `sendPush` — no new infrastructure
- This is the minimal patch applied locally to fix the import error; submitting upstream so future installs work out of the box
- Only `Releases/v5.0.0/.claude/hooks/lib/notifications.ts` is changed