### PR TITLE
Fix: counts.files always 0 (PAI/USER doubled prefix)

### DIFF
--- a/Releases/v5.0.0/.claude/PAI/TOOLS/GetCounts.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/GetCounts.ts
@@ -172,7 +172,7 @@ function getCounts(): Counts {
     workflows: countWorkflowFiles(join(PAI_DIR, "skills")),
     hooks: countHooks(),
     signals: countFilesRecursive(join(PAI_DIR, "MEMORY/LEARNING"), ".md"),
-    files: countFilesRecursive(join(PAI_DIR, "PAI/USER")),
+    files: countFilesRecursive(join(PAI_DIR, "USER")),
     work: (() => {
       let count = 0;
       try {

--- a/Releases/v5.0.0/.claude/hooks/handlers/UpdateCounts.ts
+++ b/Releases/v5.0.0/.claude/hooks/handlers/UpdateCounts.ts
@@ -171,7 +171,7 @@ function getCounts(paiDir: string): Counts {
     workflows: countWorkflowFiles(join(getClaudeDir(), 'skills')),
     hooks: countHooks(paiDir),
     signals: countFilesRecursive(join(paiDir, 'MEMORY/LEARNING'), '.md'),
-    files: countFilesRecursive(join(paiDir, 'PAI/USER')),
+    files: countFilesRecursive(join(paiDir, 'USER')),
     work: countSubdirs(join(paiDir, 'MEMORY/WORK')),
     sessions: countFilesRecursive(join(paiDir, 'MEMORY'), '.jsonl'),
     research: countFilesRecursive(join(paiDir, 'MEMORY/RESEARCH'), '.md') +


### PR DESCRIPTION
## Summary

Fixes #1227.

`counts.files` in `settings.json` is always `0` in v5.0.0 because two `getCounts()` call sites build the wrong path to `USER/`. `paiDir` already resolves to `~/.claude/PAI`, but the `files:` line joins with the literal `'PAI/USER'`, producing `~/.claude/PAI/PAI/USER` — which does not exist. `countFilesRecursive` swallows the `ENOENT` in a `try/catch` and silently returns `0`.

Every other path in the same `getCounts()` function uses `paiDir`-relative paths (`'MEMORY/LEARNING'`, `'MEMORY/WORK'`, etc.) — the `'PAI/'` prefix on this single line is the outlier. `GetCounts.ts:16` documents the intent as *"Files: All files in PAI/USER/ (recursive)"*, which is `${PAI_DIR}/USER` (the actual layout in the v5.0.0 release tree).

## Changes

Two single-line fixes:

```diff
--- a/Releases/v5.0.0/.claude/hooks/handlers/UpdateCounts.ts
+++ b/Releases/v5.0.0/.claude/hooks/handlers/UpdateCounts.ts
-    files: countFilesRecursive(join(paiDir, 'PAI/USER')),
+    files: countFilesRecursive(join(paiDir, 'USER')),
```

```diff
--- a/Releases/v5.0.0/.claude/PAI/TOOLS/GetCounts.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/GetCounts.ts
-    files: countFilesRecursive(join(PAI_DIR, "PAI/USER")),
+    files: countFilesRecursive(join(PAI_DIR, "USER")),
```

Total: **2 lines** across 2 files.

## Test plan

- [ ] `bun ~/.claude/hooks/handlers/UpdateCounts.ts` writes a non-zero `files` count to `~/.claude/settings.json` when `PAI/USER/` is non-empty.
- [ ] `bun ~/.claude/PAI/TOOLS/GetCounts.ts` JSON output's `files` value equals `find ~/.claude/PAI/USER -type f | wc -l`.
- [ ] Banner's `userFiles` now reads the same value via `settings.json.counts.files`.
- [ ] All other counts (`skills`, `workflows`, `hooks`, `signals`, `work`, `sessions`, `research`, `ratings`) unchanged.

## Notes (out of scope, for a follow-up)

`countFilesRecursive`'s `try { ... } catch {}` makes a path typo indistinguishable from an empty directory — that's how this bug stayed alive. Worth logging ENOENT separately so similar mistakes surface earlier. Happy to send a separate PR for that if you'd like.