### PR TITLE
feat(statusline): add GeneratePaiState tool and daily Pulse job

### DIFF
--- a/Releases/v5.0.0/.claude/PAI/PULSE/PULSE.toml
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/PULSE.toml
@@ -176,6 +176,14 @@ output = "log"
 enabled = false
 
 [[job]]
+name = "generate-pai-state"
+schedule = "0 6 * * *"
+type = "script"
+command = "bun run ~/.claude/PAI/TOOLS/GeneratePaiState.ts"
+output = "log"
+enabled = true
+
+[[job]]
 name = "monitor-toofless"
 schedule = "*/5 * * * *"
 type = "script"

--- a/Releases/v5.0.0/.claude/PAI/TOOLS/GeneratePaiState.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/GeneratePaiState.ts
@@ -1,0 +1,84 @@
+#!/usr/bin/env bun
+
+/**
+ * GeneratePaiState — reads DIMENSIONS.md and writes PAI_STATE.json.
+ *
+ * PAI_STATE.json is read by statusline-command.sh to populate the STATE meter.
+ * Run this any time DIMENSIONS.md is updated (cur/velo values change).
+ *
+ * Usage:
+ *   bun GeneratePaiState.ts          Write PAI_STATE.json, print summary
+ *   bun GeneratePaiState.ts --dry    Print JSON to stdout, do not write
+ */
+
+import { readFileSync, writeFileSync, existsSync } from "fs";
+import { join } from "path";
+
+const HOME = process.env.HOME || "";
+const PAI_DIR = process.env.PAI_DIR || join(HOME, ".claude", "PAI");
+const DIMENSIONS_MD = join(PAI_DIR, "USER", "TELOS", "DIMENSIONS.md");
+const OUT_FILE = join(PAI_DIR, "USER", "TELOS", "PAI_STATE.json");
+
+type DimensionEntry = {
+  pct: number;
+  cur: number;
+  ideal: number;
+  velo: number;
+};
+
+function parseDimensions(src: string): Record<string, DimensionEntry> {
+  const result: Record<string, DimensionEntry> = {};
+  for (const line of src.split("\n")) {
+    // Format: - id | Label | cur | ideal | velo | color
+    const m = line.match(/^-\s+(\S+)\s*\|\s*[^|]+\|\s*([\d.]+)\s*\|\s*([\d.]+)\s*\|\s*([\d.]+)/);
+    if (!m) continue;
+    const [, id, cur, ideal, velo] = m;
+    const c = parseFloat(cur);
+    const t = parseFloat(ideal);
+    result[id] = {
+      pct: t > 0 ? Math.round((c / t) * 100) : 0,
+      cur: c,
+      ideal: t,
+      velo: parseFloat(velo),
+    };
+  }
+  return result;
+}
+
+function main(): void {
+  const dry = process.argv.includes("--dry");
+
+  if (!existsSync(DIMENSIONS_MD)) {
+    console.error(`DIMENSIONS.md not found: ${DIMENSIONS_MD}`);
+    process.exit(1);
+  }
+
+  const src = readFileSync(DIMENSIONS_MD, "utf-8");
+  const dimensions = parseDimensions(src);
+
+  if (Object.keys(dimensions).length === 0) {
+    console.error("No dimension rows parsed from DIMENSIONS.md");
+    process.exit(1);
+  }
+
+  const payload = {
+    generated: new Date().toISOString(),
+    source: "DIMENSIONS.md",
+    dimensions,
+  };
+
+  const json = JSON.stringify(payload, null, 2);
+
+  if (dry) {
+    console.log(json);
+    return;
+  }
+
+  writeFileSync(OUT_FILE, json, "utf-8");
+  console.log(`Wrote ${OUT_FILE}`);
+  for (const [id, d] of Object.entries(dimensions)) {
+    console.log(`  ${id.padEnd(14)} ${d.cur}/${d.ideal} = ${d.pct}%`);
+  }
+}
+
+main();

--- a/Releases/v5.0.0/.claude/PAI/statusline-command.sh
+++ b/Releases/v5.0.0/.claude/PAI/statusline-command.sh
@@ -1146,7 +1146,7 @@ printf "${SLATE_600}%s${RESET}\n" "$SEP_DASHED"
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # LINE: STATE METER — dimension meters toward Ideal State
-# Reads PAI/USER/TELOS/PAI_STATE.json (written by ComputeGap.ts on a schedule).
+# Reads PAI/USER/TELOS/PAI_STATE.json (written by GeneratePaiState.ts, run daily at 6am via Pulse).
 # Falls back to placeholder values if the state file is missing.
 # Format: STATE: HEALTH 68%│CREATIVE 31%│FREEDOM 78%│RELATIONSHIPS 84%│FINANCIAL 42%
 # ═══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Adds `GeneratePaiState.ts` — a lightweight tool that reads `TELOS/DIMENSIONS.md`, computes the `cur/ideal` percentage for each life dimension, and writes `PAI_STATE.json`. Wires it as a daily Pulse cron job (6am) so the statusline STATE meter populates automatically on fresh installs and stays current without manual steps.

Also corrects the statusline comment that incorrectly named `ComputeGap.ts` as the writer of `PAI_STATE.json`.

## Changes

- `PAI/TOOLS/GeneratePaiState.ts` — new tool; reads pipe-delimited DIMENSIONS.md rows, writes `PAI_STATE.json` with per-dimension `pct`, `cur`, `ideal`, `velo`
- `PAI/PULSE/PULSE.toml` — new `[[job]] name = "generate-pai-state"`, daily at 6am, enabled
- `PAI/statusline-command.sh` — comment updated to name `GeneratePaiState.ts` as the writer

## Why daily at 6am?

DIMENSIONS.md is manually maintained — values only change after a life review or `/interview` run. Daily regeneration keeps PAI_STATE.json fresh without wasted cycles. Users can also run `bun GeneratePaiState.ts` directly for an immediate refresh after editing DIMENSIONS.md.

## Standalone

No dependency on other open PRs.