### PR TITLE
feat(Research): add provider-specific execution guides for researcher agents

### DIFF
--- a/Releases/v5.0.0/.claude/agents/ClaudeResearcher.md
+++ b/Releases/v5.0.0/.claude/agents/ClaudeResearcher.md
@@ -83,7 +83,13 @@ curl -X POST http://localhost:31337/notify \
    - This loads all necessary Skills, standards, and domain knowledge
    - DO NOT proceed until you've read this file
 
-3. **Then proceed with your task**
+3. **Load your provider execution guide:**
+   - Read: `~/.claude/skills/Research/Workflows/Execution/ClaudeExecution.md`
+   - This file holds the WebSearch protocol used by this researcher, multi-mode depth strategy, citation handling, URL verification protocol, and file-based output schema
+   - Unlike the Gemini, Grok, and Perplexity researchers, this researcher does not call an external provider API; the execution guide documents the WebSearch path for parity with the other three
+   - DO NOT proceed until you've read this file
+
+4. **Then proceed with your task**
 
 **This is NON-NEGOTIABLE. Load your context first.**
 

--- a/Releases/v5.0.0/.claude/agents/GeminiResearcher.md
+++ b/Releases/v5.0.0/.claude/agents/GeminiResearcher.md
@@ -83,7 +83,13 @@ curl -X POST http://localhost:31337/notify \
    - This loads all necessary Skills, standards, and domain knowledge
    - DO NOT proceed until you've read this file
 
-3. **Then proceed with your task**
+3. **Load your provider execution guide:**
+   - Read: `~/.claude/skills/Research/Workflows/Execution/GeminiExecution.md`
+   - This file holds the gemini CLI invocation shape, model selection table by research mode, fallback chain on rate-limit or timeout, citation extraction rules, URL verification protocol, and file-based output schema
+   - Execute according to that file. Never silently fall back to Claude WebSearch for primary research; if the gemini CLI is unavailable or fails after one retry at a lower model tier, return the structured error documented in the execution guide
+   - DO NOT proceed until you've read this file
+
+4. **Then proceed with your task**
 
 **This is NON-NEGOTIABLE. Load your context first.**
 

--- a/Releases/v5.0.0/.claude/agents/GrokResearcher.md
+++ b/Releases/v5.0.0/.claude/agents/GrokResearcher.md
@@ -89,7 +89,13 @@ curl -X POST http://localhost:31337/notify \
    - This loads all necessary Skills, standards, and domain knowledge
    - DO NOT proceed until you've read this file
 
-3. **Then proceed with your task**
+3. **Load your provider execution guide:**
+   - Read: `~/.claude/skills/Research/Workflows/Execution/GrokExecution.md`
+   - This file holds the xAI Chat Completions API call shape with live search, model selection table by research mode, fallback chain on rate-limit or timeout, citation extraction rules, URL verification protocol, and file-based output schema
+   - Execute according to that file. Never silently fall back to Claude WebSearch for primary research; if the xAI API is unreachable or fails after one retry at a lower model tier, return the structured error documented in the execution guide
+   - DO NOT proceed until you've read this file
+
+4. **Then proceed with your task**
 
 **This is NON-NEGOTIABLE. Load your context first.**
 

--- a/Releases/v5.0.0/.claude/agents/PerplexityResearcher.md
+++ b/Releases/v5.0.0/.claude/agents/PerplexityResearcher.md
@@ -83,7 +83,13 @@ curl -X POST http://localhost:31337/notify \
    - This loads all necessary Skills, standards, and domain knowledge
    - DO NOT proceed until you've read this file
 
-3. **Then proceed with your task**
+3. **Load your provider execution guide:**
+   - Read: `~/.claude/skills/Research/Workflows/Execution/PerplexityExecution.md`
+   - This file holds the Perplexity Sonar API call shape, model selection table by research mode, fallback chain on rate-limit or timeout, citation extraction rules, URL verification protocol, and file-based output schema
+   - Execute according to that file. Never silently fall back to Claude WebSearch for primary research; if the Sonar API is unreachable or fails after one retry at a lower model tier, return the structured error documented in the execution guide
+   - DO NOT proceed until you've read this file
+
+4. **Then proceed with your task**
 
 **This is NON-NEGOTIABLE. Load your context first.**
 

--- a/Releases/v5.0.0/.claude/skills/Research/SKILL.md
+++ b/Releases/v5.0.0/.claude/skills/Research/SKILL.md
@@ -94,6 +94,17 @@ Route to the appropriate workflow based on the request.
 - Enhance/improve content -> `Workflows/Enhance.md`
 - Extract knowledge from content -> `Workflows/ExtractKnowledge.md`
 
+### Agent Execution Guides
+
+The four Researcher agents (Claude, Gemini, Grok, Perplexity) load a sibling execution guide as the third step of their startup sequence. Each guide owns the provider-specific call shape (API endpoint or CLI), model selection table by research mode, fallback chain on rate-limit or timeout, citation extraction rules, URL verification protocol, and file-based output schema.
+
+- Claude (built-in WebSearch tool) -> `Workflows/Execution/ClaudeExecution.md`
+- Gemini (`gemini` CLI with Google Search grounding) -> `Workflows/Execution/GeminiExecution.md`
+- Grok (xAI Chat Completions API with live search) -> `Workflows/Execution/GrokExecution.md`
+- Perplexity (Sonar Chat Completions API) -> `Workflows/Execution/PerplexityExecution.md`
+
+These guides keep the agent files focused on persona, voice, and output format; the execution wire format lives with the skill that delegates to them. Each guide enforces a no-silent-fallback rule: a researcher whose provider fails returns a structured error rather than swapping to a different provider, so the skill orchestrator can decide whether to surface the gap or substitute a different researcher.
+
 ---
 
 ## Quick Reference

--- a/Releases/v5.0.0/.claude/skills/Research/Workflows/Execution/ClaudeExecution.md
+++ b/Releases/v5.0.0/.claude/skills/Research/Workflows/Execution/ClaudeExecution.md
@@ -1,0 +1,113 @@
+# Claude Researcher Execution
+
+Execution protocol for the Claude researcher. Claude does not call an external provider API; it uses the built-in `WebSearch` tool. This file documents the protocol so the four researchers stay homogeneous (one Execution file per researcher) and so anyone reviewing or extending the architecture sees the same shape across providers.
+
+## Provider
+
+| Field | Value |
+|-------|-------|
+| Backend | Built-in `WebSearch` tool |
+| API key required | No (uses host session credentials) |
+| External calls | None from the researcher itself |
+| Citation source | Search result blocks returned by `WebSearch` |
+
+## Model selection by research mode
+
+The host session decides the model. This researcher branches by depth instead of by model swap.
+
+| Mode | Behavior |
+|------|----------|
+| Quick | One `WebSearch` call, top three results, no follow-up reads. |
+| Standard | One `WebSearch` call, up to five results, optional follow-up `WebFetch` on the highest-signal page. |
+| Extensive | Up to three `WebSearch` calls with reformulated queries, follow-up `WebFetch` on the top two pages. |
+| Deep | Iterative `WebSearch` + `WebFetch` passes until the question is answered or three iterations are spent. |
+
+One query per call. Do not bundle multiple questions into a single `WebSearch`.
+
+## Execution shape
+
+```
+WebSearch query="<single, focused query>"
+# Optionally for higher modes:
+WebFetch url="<top result URL>" prompt="<extraction instruction>"
+```
+
+The researcher reads search-result blocks directly from tool output. No JSON parsing is required.
+
+## Citations
+
+Each `WebSearch` result block contains a URL and a title. The researcher captures both for the `sources` array of the output schema below. Never paraphrase a result and drop its URL; the URL is the citation.
+
+## URL verification
+
+Every URL included in `sources` must be verified before delivery:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" -L --max-time 8 "<url>"
+```
+
+A status code outside `200..399` means the URL fails verification: omit it from the `sources` array entirely, or substitute a verified alternative. Never write an unverified URL to a source object with `verified: true`.
+
+## File-based output
+
+When the researcher is invoked with a `research_dir` argument by the Research skill, it writes its findings to `${research_dir}/claude.json`. A downstream synthesis step (a separate synthesizer agent or the calling workflow's synthesis pass) reads these files to cross-reference findings, score consensus, and surface contrarian signal. The schema is shared by all four researchers so the synthesis layer stays researcher-agnostic.
+
+```json
+{
+  "agent": "claude",
+  "query": "<verbatim user query>",
+  "summary": [
+    "<key finding 1, short and self-contained>",
+    "<key finding 2>",
+    "..."
+  ],
+  "sources": [
+    { "title": "<source title>", "url": "<verified URL>", "verified": true }
+  ],
+  "confidence": 0.0,
+  "full_findings": "<complete detailed research output, no length limit>",
+
+  "provider": "claude-websearch",
+  "mode": "quick|standard|extensive|deep",
+  "started": "<ISO-8601 timestamp>",
+  "finished": "<ISO-8601 timestamp>"
+}
+```
+
+**Required fields** (the synthesis layer reads only these): `agent`, `query`, `summary` (array of up to 10 short strings), `sources` (array of `{title, url, verified}` objects), `confidence` (numeric `0.0` to `1.0`), `full_findings` (string).
+
+**Optional informational fields** (synthesis layer ignores them): `provider`, `mode`, `started`, `finished`. Useful for debugging and audit.
+
+If `research_dir` is not provided, the researcher returns the same payload inline to its caller and skips file writing.
+
+## Fallback policy
+
+The Claude researcher has no provider to fall back from. If `WebSearch` is unavailable, the researcher writes a stub file with the error recorded in `full_findings` and an empty `summary`. It does NOT attempt a different provider on its own. Switching providers is the Research skill's decision, not the researcher's.
+
+```json
+{
+  "agent": "claude",
+  "query": "<verbatim user query>",
+  "summary": [],
+  "sources": [],
+  "confidence": 0.0,
+  "full_findings": "ERROR: WebSearch tool unavailable in current session",
+  "status": "error",
+  "reason": "WebSearch tool unavailable in current session"
+}
+```
+
+The synthesis layer treats `summary: []` as agent-unavailable and continues with whichever other researchers produced output.
+
+## Self-verification checklist
+
+Before writing the output file (or returning inline), the researcher confirms:
+
+1. Every URL in `sources` was verified via curl (HTTP `200..399`) and is recorded with `verified: true`.
+2. The `summary` array has at most 10 items, each a short self-contained finding.
+3. The `confidence` value reflects overall reliability (`0.9` if every claim is solidly sourced and corroborated, `0.5` for mixed signal, `0.0` only when no findings were produced).
+4. Every quantitative claim in `full_findings` and `summary` appears in the cited source.
+5. No URL was invented or pattern-completed from training data.
+6. If file output was requested, the JSON validates against the schema above.
+
+A failed check blocks return; the researcher fixes the issue or lowers the `confidence` value and re-checks.

--- a/Releases/v5.0.0/.claude/skills/Research/Workflows/Execution/GeminiExecution.md
+++ b/Releases/v5.0.0/.claude/skills/Research/Workflows/Execution/GeminiExecution.md
@@ -1,0 +1,134 @@
+# Gemini Researcher Execution
+
+Execution protocol for the Gemini researcher. Uses the `gemini` CLI (Google Generative AI CLI) for real provider calls with Google Search grounding. Never falls back silently to `WebSearch`: if the CLI is unavailable or rate-limited, the researcher writes a stub error file (or returns a structured error inline) and the Research skill decides the next step.
+
+## Provider
+
+| Field | Value |
+|-------|-------|
+| Backend | `gemini` CLI (Google Generative AI CLI) |
+| API key | `GEMINI_API_KEY` in environment (loaded from `~/.claude/.env`) |
+| Grounding | Google Search grounding enabled by default for online modes |
+| Citation source | `grounding_metadata.web_search_queries` and inline citation markers in CLI output |
+
+## Model selection by research mode
+
+| Mode | Model | Rationale |
+|------|-------|-----------|
+| Quick | `gemini-2.5-flash` | Fast, single-pass, high recall on common queries |
+| Standard | `gemini-2.5-flash` | Same model; the depth comes from query decomposition, not model swap |
+| Extensive | `gemini-3-pro` | Deeper reasoning for stress-testing across 3-10 query variations |
+| Deep | `gemini-3-pro` | Long-context, multi-iteration synthesis |
+
+Replace the model name only at the configured tier boundary. Do not auto-upgrade mid-call.
+
+## Execution shape
+
+One query per call. No multi-query bundling.
+
+```bash
+gemini -m "$MODEL" -p "$QUERY" --grounding google_search
+```
+
+The researcher captures stdout, parses citation markers, and treats CLI exit code zero as success. Any non-zero exit code triggers the fallback policy below.
+
+### Multi-perspective decomposition
+
+For Standard and higher modes, the researcher generates query variations before invocation:
+
+```
+Original: "AI impact on labor markets"
+Variations:
+  1. AI impact on labor markets, optimistic tech-adoption view
+  2. AI impact on labor markets, displacement and skill-mismatch view
+  3. AI impact on labor markets, sector-specific (manufacturing, services, knowledge work)
+  4. Historical precedents for technological labor displacement
+```
+
+Each variation runs as a separate `gemini` invocation. Results are merged by the researcher into a single output (one summary array, one sources array, one confidence value).
+
+## Citations
+
+Gemini CLI returns inline citation markers (`[1]`, `[2]`, ...) and a citation list at the end of its response. The researcher maps each marker to its URL and writes both to the `sources` array of the output schema (`title`, `url`, `verified: true` after URL verification).
+
+If a finding cannot be tied to a specific citation, lower the overall `confidence` value and note the gap in `full_findings`.
+
+## URL verification
+
+Every URL produced by Gemini citation extraction must be verified before delivery:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" -L --max-time 8 "<url>"
+```
+
+Status codes outside `200..399` fail verification: omit the URL or substitute a verified alternative. Never write an unverified URL with `verified: true`.
+
+## File-based output
+
+When invoked with `research_dir`, write `${research_dir}/gemini.json`. A downstream synthesis step reads this file to cross-reference findings; the schema is shared by all four researchers.
+
+```json
+{
+  "agent": "gemini",
+  "query": "<verbatim user query>",
+  "summary": [
+    "<key finding 1, short and self-contained>",
+    "<key finding 2>",
+    "..."
+  ],
+  "sources": [
+    { "title": "<source title>", "url": "<verified URL>", "verified": true }
+  ],
+  "confidence": 0.0,
+  "full_findings": "<complete detailed research output, no length limit>",
+
+  "provider": "gemini-cli",
+  "model": "<model name used>",
+  "mode": "quick|standard|extensive|deep",
+  "query_variations": ["<variation 1>", "<variation 2>", "..."],
+  "started": "<ISO-8601 timestamp>",
+  "finished": "<ISO-8601 timestamp>"
+}
+```
+
+**Required fields** (the synthesis layer reads only these): `agent`, `query`, `summary` (array of up to 10 short strings), `sources` (array of `{title, url, verified}` objects), `confidence` (numeric `0.0` to `1.0`), `full_findings` (string).
+
+**Optional informational fields** (synthesis layer ignores them): `provider`, `model`, `mode`, `query_variations`, `started`, `finished`.
+
+If `research_dir` is not provided, the researcher returns the same payload inline to its caller and skips file writing.
+
+## Fallback policy
+
+If the `gemini` CLI is missing, the API key is absent, or the call returns a 429 or a timeout:
+
+1. Drop one model tier (for example `gemini-3-pro` -> `gemini-2.5-flash`) and retry once.
+2. If the retry also fails, write a stub file with the error recorded in `full_findings` and an empty `summary`. Do NOT fall back to `WebSearch`.
+
+```json
+{
+  "agent": "gemini",
+  "query": "<verbatim user query>",
+  "summary": [],
+  "sources": [],
+  "confidence": 0.0,
+  "full_findings": "ERROR: gemini CLI exit 429 after one retry at lower tier",
+  "status": "error",
+  "reason": "gemini CLI exit 429 after one retry at lower tier",
+  "model_attempts": ["gemini-3-pro", "gemini-2.5-flash"]
+}
+```
+
+The synthesis layer treats `summary: []` as agent-unavailable and continues with whichever other researchers produced output.
+
+## Self-verification checklist
+
+Before writing the output file (or returning inline), the researcher confirms:
+
+1. Every URL in `sources` was verified via curl (HTTP `200..399`) and is recorded with `verified: true`.
+2. The `summary` array has at most 10 items, each a short self-contained finding.
+3. The `confidence` value reflects overall reliability (drop it when citation markers were unmapped or when CLI grounding metadata was incomplete).
+4. Every quantitative claim in `full_findings` and `summary` appears in the cited source.
+5. The CLI exit code was zero, or the structured error path was taken.
+6. If `research_dir` was provided, the JSON validates against the schema.
+
+A failed check blocks return.

--- a/Releases/v5.0.0/.claude/skills/Research/Workflows/Execution/GrokExecution.md
+++ b/Releases/v5.0.0/.claude/skills/Research/Workflows/Execution/GrokExecution.md
@@ -1,0 +1,151 @@
+# Grok Researcher Execution
+
+Execution protocol for the Grok researcher. Uses the xAI Chat Completions API with live search enabled. Never falls back silently to `WebSearch`: if the API is unreachable or rate-limited, the researcher writes a stub error file (or returns a structured error inline) and the Research skill decides the next step.
+
+## Provider
+
+| Field | Value |
+|-------|-------|
+| Backend | xAI Chat Completions API |
+| Endpoint | `https://api.x.ai/v1/chat/completions` |
+| API key | `XAI_API_KEY` in environment (loaded from `~/.claude/.env`) |
+| Live search | Enabled by setting `search_parameters.mode = "on"` |
+| Differentiator | Real-time data including X (Twitter) signal; strong on STEM, math, current events |
+
+## Model selection by research mode
+
+| Mode | Model | Rationale |
+|------|-------|-----------|
+| Quick | `grok-3-mini` | Fast and cheap for narrow single-query lookups |
+| Standard | `grok-3` | Balanced reasoning, default for general research |
+| Extensive | `grok-4` | Deep reasoning, more search iterations per call |
+| Deep | `grok-4` | Same model, used across multiple iterative calls |
+
+Model names are pinned per tier. Do not auto-upgrade mid-call.
+
+## Execution shape
+
+One query per call. Build the JSON request body with `jq -n --arg` to safely escape the user query (never string-concatenate user input into a shell-quoted JSON):
+
+```bash
+BODY=$(jq -n \
+  --arg model "$MODEL" \
+  --arg q "$QUERY" \
+  '{
+    model: $model,
+    messages: [
+      { role: "system", content: "You are a research assistant. Return findings with inline citations." },
+      { role: "user", content: $q }
+    ],
+    search_parameters: { mode: "on" },
+    max_tokens: 2048,
+    temperature: 0.2
+  }')
+
+curl -sS --max-time 60 \
+  -H "Authorization: Bearer $XAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -X POST "https://api.x.ai/v1/chat/completions" \
+  -d "$BODY"
+```
+
+The researcher captures the response, parses it as JSON, and treats HTTP 200 as success. Any non-200 status triggers the fallback policy below.
+
+## Citation extraction
+
+xAI live search returns citations in the response. Two patterns must be handled depending on the API version returned at runtime:
+
+1. A top-level `citations` array of URLs.
+2. A per-message `citations` object inside the `choices[].message` field.
+
+The researcher reads whichever field is populated and maps it to the `sources` array of the output schema (`title`, `url`, `verified: true` after URL verification). When the API returns only URLs, the title field is populated from a follow-up `WebFetch` of the page if title context is needed; otherwise the host part of the URL is used as a minimal placeholder title.
+
+Inline numbered citation markers (`[1]`, `[2]`, ...) in the assistant's content map to the citation array by position.
+
+If a finding cannot be tied to any citation, lower the overall `confidence` value and note the gap in `full_findings`.
+
+## URL verification
+
+Every URL extracted from citations must be verified before delivery:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" -L --max-time 8 "<url>"
+```
+
+Status codes outside `200..399` fail verification: omit the URL or substitute a verified alternative. Never write an unverified URL with `verified: true`.
+
+## File-based output
+
+When invoked with `research_dir`, write `${research_dir}/grok.json`. A downstream synthesis step reads this file to cross-reference findings and to detect contrarian signal (Grok's distinguishing role); the schema is shared by all four researchers.
+
+```json
+{
+  "agent": "grok",
+  "query": "<verbatim user query>",
+  "summary": [
+    "<key finding 1, short and self-contained>",
+    "<key finding 2>",
+    "<a clearly-flagged contrarian finding when the data supports one>",
+    "..."
+  ],
+  "sources": [
+    { "title": "<source title>", "url": "<verified URL>", "verified": true }
+  ],
+  "confidence": 0.0,
+  "full_findings": "<complete detailed research output, no length limit>",
+
+  "provider": "xai-grok",
+  "model": "<model name used>",
+  "mode": "quick|standard|extensive|deep",
+  "live_search": true,
+  "x_signal_count": 0,
+  "started": "<ISO-8601 timestamp>",
+  "finished": "<ISO-8601 timestamp>"
+}
+```
+
+**Required fields** (the synthesis layer reads only these): `agent`, `query`, `summary` (array of up to 10 short strings), `sources` (array of `{title, url, verified}` objects), `confidence` (numeric `0.0` to `1.0`), `full_findings` (string).
+
+**Optional informational fields** (synthesis layer ignores them): `provider`, `model`, `mode`, `live_search`, `x_signal_count` (number of summary items that came from X / Twitter sources), `started`, `finished`.
+
+If `research_dir` is not provided, the researcher returns the same payload inline to its caller and skips file writing.
+
+## Fallback policy
+
+If the API call returns a 429, a 5xx, a network timeout, or an authentication error:
+
+1. Drop one model tier (for example `grok-4` -> `grok-3`) and retry once.
+2. If the retry also fails, write a stub file with the error recorded in `full_findings` and an empty `summary`. Do NOT fall back to `WebSearch`.
+
+```json
+{
+  "agent": "grok",
+  "query": "<verbatim user query>",
+  "summary": [],
+  "sources": [],
+  "confidence": 0.0,
+  "full_findings": "ERROR: xAI API HTTP 429 after one retry at lower tier",
+  "status": "error",
+  "reason": "xAI API HTTP 429 after one retry at lower tier",
+  "model_attempts": ["grok-4", "grok-3"]
+}
+```
+
+A missing or empty `XAI_API_KEY` is reported the same way (`full_findings: "ERROR: XAI_API_KEY not set in environment"`, `status: "error"`).
+
+The synthesis layer treats `summary: []` as agent-unavailable and continues with whichever other researchers produced output.
+
+## Self-verification checklist
+
+Before writing the output file (or returning inline), the researcher confirms:
+
+1. Every URL in `sources` was verified via curl (HTTP `200..399`) and is recorded with `verified: true`.
+2. The `summary` array has at most 10 items, each a short self-contained finding.
+3. Contrarian findings (where the data plausibly disagrees with consensus) are flagged in `summary` rather than dropped; this preserves the agent's distinguishing role.
+4. The `confidence` value reflects overall reliability (drop it when citation mapping was incomplete).
+5. Every quantitative claim in `full_findings` and `summary` appears in the cited source.
+6. The HTTP status was 200, or the structured error path was taken.
+7. The request body was built via `jq -n --arg` (no raw string concatenation of user input).
+8. If `research_dir` was provided, the JSON validates against the schema.
+
+A failed check blocks return.

--- a/Releases/v5.0.0/.claude/skills/Research/Workflows/Execution/PerplexityExecution.md
+++ b/Releases/v5.0.0/.claude/skills/Research/Workflows/Execution/PerplexityExecution.md
@@ -1,0 +1,146 @@
+# Perplexity Researcher Execution
+
+Execution protocol for the Perplexity researcher. Uses the Perplexity Sonar API; live web retrieval is built into every Sonar call before generation, with citations bundled in the response. Never falls back silently to `WebSearch`: if the API is unreachable or rate-limited, the researcher writes a stub error file (or returns a structured error inline) and the Research skill decides the next step.
+
+## Provider
+
+| Field | Value |
+|-------|-------|
+| Backend | Perplexity Sonar Chat Completions API |
+| Endpoint | `https://api.perplexity.ai/chat/completions` |
+| API key | `PERPLEXITY_API_KEY` in environment (loaded from `~/.claude/.env`) |
+| Retrieval | Live web retrieval runs before each generation |
+| Citation source | `citations` array on the response, plus inline numbered markers in content |
+| Differentiator | Retrieval-first architecture; citations included by default at no extra cost |
+
+## Model selection by research mode
+
+| Mode | Model | Rationale |
+|------|-------|-----------|
+| Quick | `sonar` | Fast online model, top results, single pass |
+| Standard | `sonar-pro` | Richer citation metadata, deeper synthesis |
+| Extensive | `sonar-reasoning` | Chain-of-thought style reasoning over retrieved sources |
+| Deep | `sonar-reasoning-pro` | Highest-fidelity reasoning, multi-step retrieval |
+
+Model names are pinned per tier. Do not auto-upgrade mid-call.
+
+## Execution shape
+
+One query per call. Build the JSON request body with `jq -n --arg` to safely escape the user query:
+
+```bash
+BODY=$(jq -n \
+  --arg model "$MODEL" \
+  --arg q "$QUERY" \
+  '{
+    model: $model,
+    messages: [
+      { role: "system", content: "You are a research assistant. Return findings with inline citations." },
+      { role: "user", content: $q }
+    ],
+    max_tokens: 2048,
+    temperature: 0.2,
+    return_citations: true
+  }')
+
+curl -sS --max-time 60 \
+  -H "Authorization: Bearer $PERPLEXITY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -X POST "https://api.perplexity.ai/chat/completions" \
+  -d "$BODY"
+```
+
+The researcher captures the response, parses it as JSON, and treats HTTP 200 as success. Any non-200 status triggers the fallback policy below.
+
+## Citation extraction
+
+Sonar responses include citations in two places, both of which the researcher reads:
+
+1. A top-level `citations` array of URLs in delivery order.
+2. Inline numbered markers (`[1]`, `[2]`, ...) inside the assistant's content; markers map to the citation array by position.
+
+`sonar-pro` and higher tiers return additional metadata per citation (title, snippet, sometimes publication date). The researcher captures the title into the `sources` array of the output schema when present; otherwise it derives a minimal title from the URL's host.
+
+If a finding cannot be tied to a citation index, lower the overall `confidence` value and note the gap in `full_findings`.
+
+## URL verification
+
+Every citation URL must be verified before delivery:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" -L --max-time 8 "<url>"
+```
+
+Status codes outside `200..399` fail verification: omit the URL or substitute a verified alternative. Never write an unverified URL with `verified: true`.
+
+## File-based output
+
+When invoked with `research_dir`, write `${research_dir}/perplexity.json`. A downstream synthesis step reads this file to cross-reference findings; the schema is shared by all four researchers.
+
+```json
+{
+  "agent": "perplexity",
+  "query": "<verbatim user query>",
+  "summary": [
+    "<key finding 1, short and self-contained>",
+    "<key finding 2>",
+    "..."
+  ],
+  "sources": [
+    { "title": "<source title>", "url": "<verified URL>", "verified": true }
+  ],
+  "confidence": 0.0,
+  "full_findings": "<complete detailed research output, no length limit>",
+
+  "provider": "perplexity-sonar",
+  "model": "<model name used>",
+  "mode": "quick|standard|extensive|deep",
+  "started": "<ISO-8601 timestamp>",
+  "finished": "<ISO-8601 timestamp>"
+}
+```
+
+**Required fields** (the synthesis layer reads only these): `agent`, `query`, `summary` (array of up to 10 short strings), `sources` (array of `{title, url, verified}` objects), `confidence` (numeric `0.0` to `1.0`), `full_findings` (string).
+
+**Optional informational fields** (synthesis layer ignores them): `provider`, `model`, `mode`, `started`, `finished`. The researcher MAY also include a `published` field per source object when Sonar returns publication dates; the synthesis layer is free to ignore it.
+
+If `research_dir` is not provided, the researcher returns the same payload inline to its caller and skips file writing.
+
+## Fallback policy
+
+If the API call returns a 429, a 5xx, a network timeout, or an authentication error:
+
+1. Drop one model tier (for example `sonar-reasoning-pro` -> `sonar-pro` -> `sonar`) and retry once.
+2. If the retry also fails, write a stub file with the error recorded in `full_findings` and an empty `summary`. Do NOT fall back to `WebSearch`.
+
+```json
+{
+  "agent": "perplexity",
+  "query": "<verbatim user query>",
+  "summary": [],
+  "sources": [],
+  "confidence": 0.0,
+  "full_findings": "ERROR: Perplexity API HTTP 429 after one retry at lower tier",
+  "status": "error",
+  "reason": "Perplexity API HTTP 429 after one retry at lower tier",
+  "model_attempts": ["sonar-reasoning-pro", "sonar-pro"]
+}
+```
+
+A missing or empty `PERPLEXITY_API_KEY` is reported the same way (`full_findings: "ERROR: PERPLEXITY_API_KEY not set in environment"`, `status: "error"`).
+
+The synthesis layer treats `summary: []` as agent-unavailable and continues with whichever other researchers produced output.
+
+## Self-verification checklist
+
+Before writing the output file (or returning inline), the researcher confirms:
+
+1. Every URL in `sources` was verified via curl (HTTP `200..399`) and is recorded with `verified: true`.
+2. The `summary` array has at most 10 items, each a short self-contained finding.
+3. The `confidence` value reflects overall reliability (drop it when citation mapping was incomplete).
+4. Every quantitative claim in `full_findings` and `summary` appears in the cited source.
+5. The HTTP status was 200, or the structured error path was taken.
+6. The request body was built via `jq -n --arg` (no raw string concatenation of user input).
+7. If `research_dir` was provided, the JSON validates against the schema.
+
+A failed check blocks return.


### PR DESCRIPTION
## Summary

Three of the four Researcher agents (Gemini, Grok, Perplexity) currently have no provider-specific call code anywhere in the Research skill or in the agent files. With no API/CLI wire-format defined, each non-Claude agent collapses to the same backend (built-in `WebSearch` under a different persona name), so "multi-model research" via Standard / Extensive mode does not actually exercise multiple models. This PR adds the missing execution layer.

## What's added

A new directory `Releases/v5.0.0/.claude/skills/Research/Workflows/Execution/` with four guides, one per researcher:

- `ClaudeExecution.md` documents the `WebSearch` path (included for parity, no behavior change)
- `GeminiExecution.md` documents the `gemini` CLI invocation with Google Search grounding
- `GrokExecution.md` documents the xAI Chat Completions API call with live search enabled
- `PerplexityExecution.md` documents the Perplexity Sonar Chat Completions API call

Each guide owns the provider call shape (CLI or `curl` with `jq -n --arg` for safe user-input escaping), the model selection table mapped to research modes, citation extraction rules, URL verification via `curl`, the file-based output JSON schema, and a fallback policy that retries once at a lower model tier then writes a stub error file. Never silently swaps providers.

## Agent changes

Each of `ClaudeResearcher.md`, `GeminiResearcher.md`, `GrokResearcher.md`, `PerplexityResearcher.md` gains step 3 in its Mandatory Startup Sequence: read the sibling execution guide. Existing persona, voice, output format, Research Philosophy and Research Methodology sections are unchanged. Nothing was removed.

## SKILL.md change

A new `### Agent Execution Guides` subsection under `## Workflow Routing` points to the four guides and states the no-silent-fallback policy at the skill level.

## File-based output schema

Each Execution guide documents a shared JSON shape for `${research_dir}/<agent-slug>.json`:

```json
{
  "agent": "claude|gemini|grok|perplexity",
  "query": "...",
  "summary": ["..."],
  "sources": [{ "title": "...", "url": "...", "verified": true }],
  "confidence": 0.0,
  "full_findings": "..."
}
```

The schema is shared across all four researchers so a downstream synthesis step can cross-reference findings agnostic of which provider produced them. Current upstream Research workflows synthesize inline as text rather than from files; this schema is therefore forward-looking with respect to the merged tree, standardizing the contract for any future file-based synthesizer. If `research_dir` is not provided by the caller, each researcher returns the same payload inline and skips file writing.

## Correctness property preserved

A researcher whose provider call fails writes a stub file (`summary: []`, error reason in `full_findings`) rather than substituting `WebSearch`. The orchestrator's decision stays explicit: it can surface the gap to the user or substitute a different researcher. Silent substitution would defeat the purpose of multi-model research.

## Why no OpenAI / GPT researcher

GPT plus web search via the OpenAI Responses API is architecturally similar to the Claude plus `WebSearch` path (LLM-with-search, citation-after-generation). It does not add an orthogonal coverage angle that the existing four researchers do not already cover. Grok contributes live X data and STEM strength; Perplexity contributes retrieval-first architecture with citations bundled into the response; Gemini contributes Google Search grounding. Each is structurally different. If a fifth researcher pointed at GPT-4o/5 is desired later, it can be added with the same Execution-guide pattern.

## Smoke test recipe

Local setup expects `~/.claude/.env` with `XAI_API_KEY`, `PERPLEXITY_API_KEY`, and `GEMINI_API_KEY` populated, plus the `gemini` CLI installed (validated against v0.39.1).

```bash
# Gemini
gemini -m gemini-2.5-flash -p "what is Bun JavaScript runtime" --grounding google_search

# xAI Grok
source ~/.claude/.env
BODY=$(jq -n --arg q "what is Bun JavaScript runtime" \
  '{model:"grok-3", messages:[{role:"system",content:"Research assistant. Cite sources."},{role:"user",content:$q}], search_parameters:{mode:"on"}, max_tokens:512}')
curl -sS -H "Authorization: Bearer $XAI_API_KEY" -H "Content-Type: application/json" \
  -d "$BODY" https://api.x.ai/v1/chat/completions | jq '.choices[0].message.content, .citations'

# Perplexity Sonar
BODY=$(jq -n --arg q "what is Bun JavaScript runtime" \
  '{model:"sonar", messages:[{role:"system",content:"Research assistant. Cite sources."},{role:"user",content:$q}], max_tokens:512, return_citations:true}')
curl -sS -H "Authorization: Bearer $PERPLEXITY_API_KEY" -H "Content-Type: application/json" \
  -d "$BODY" https://api.perplexity.ai/chat/completions | jq '.choices[0].message.content, .citations'
```

Expected: response content plus at least one citation URL. Missing-key scenarios should produce auth errors that each agent maps to the stub error file documented in the corresponding execution guide.

## Diff stat

```
9 files changed, 583 insertions(+), 4 deletions(-)
```
