### PR TITLE
Fix GenerateTelosSummary parser for real TELOS files

### DIFF
--- a/Releases/v5.0.0/.claude/PAI/TOOLS/GenerateTelosSummary.test.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/GenerateTelosSummary.test.ts
@@ -1,0 +1,152 @@
+#!/usr/bin/env bun
+/**
+ * Fixture test for GenerateTelosSummary.ts
+ *
+ * Validates the four parser fixes against a representative TELOS shape:
+ *   1. parseItems regex matches "- **ID:** text" bullets
+ *   2. parseStrategies reads bullet format (S0, S1, ...)
+ *   3. parseModels reads ID-less bold bullets
+ *   4. title is sourced from PRINCIPAL_IDENTITY
+ *
+ * Run: bun test Releases/v5.0.0/.claude/PAI/TOOLS/GenerateTelosSummary.test.ts
+ */
+
+import { test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { spawnSync } from 'child_process';
+
+const TMP_HOME = join(tmpdir(), `telos-summary-test-${process.pid}`);
+const TELOS_DIR = join(TMP_HOME, '.claude/PAI/USER/TELOS');
+const IDENTITY_PATH = join(TMP_HOME, '.claude/PAI/USER/PRINCIPAL_IDENTITY.md');
+const OUTPUT_PATH = join(TELOS_DIR, 'PRINCIPAL_TELOS.md');
+const SCRIPT_PATH = join(import.meta.dir, 'GenerateTelosSummary.ts');
+
+function writeFixture(name: string, body: string) {
+  writeFileSync(join(TELOS_DIR, name), body);
+}
+
+beforeAll(() => {
+  if (existsSync(TMP_HOME)) rmSync(TMP_HOME, { recursive: true, force: true });
+  mkdirSync(TELOS_DIR, { recursive: true });
+
+  writeFileSync(IDENTITY_PATH, [
+    '# Principal Identity — TestUser',
+    '',
+    '## Quick Reference',
+    '',
+    '- **Name:** TestUser',
+    '- **Pronunciation:** TestUser',
+    '',
+  ].join('\n'));
+
+  writeFixture('MISSION.md', [
+    '# Mission',
+    '',
+    '- **M0:** Build tools that move agency to individuals.',
+    '',
+  ].join('\n'));
+
+  writeFixture('GOALS.md', [
+    '# Goals',
+    '',
+    '- **G0:** Ship product MVP — measurable outcome required.',
+    '- **G1:** Publish weekly newsletter.',
+    '- **G2:** Older deferred goal that should not be active.',
+    '',
+  ].join('\n'));
+
+  writeFixture('PROBLEMS.md', [
+    '# Problems',
+    '',
+    '## P0: Tools fight the user instead of helping',
+    '',
+    'Body text.',
+    '',
+    '## P1: Information access is uneven (legacy systems)',
+    '',
+    'Body text.',
+    '',
+  ].join('\n'));
+
+  writeFixture('STRATEGIES.md', [
+    '# Strategies',
+    '',
+    '- **S0:** Ship the crappy version, then iterate in public.',
+    '- **S1:** Write before building.',
+    '',
+  ].join('\n'));
+
+  writeFixture('NARRATIVES.md', [
+    '# Narratives',
+    '',
+    '- **N0:** I build tools that move power to individuals.',
+    '- **N1:** Pattern-spotter who ships.',
+    '- **N2:** Secondary narrative that gets compressed.',
+    '',
+  ].join('\n'));
+
+  writeFixture('CHALLENGES.md', [
+    '# Challenges',
+    '',
+    '- **C0:** I start more projects than I finish.',
+    '',
+  ].join('\n'));
+
+  writeFixture('MODELS.md', [
+    '# Mental Models',
+    '',
+    '- **First principles** — break problems down to fundamentals rather than analogy.',
+    '- **Systems thinking** — behaviour comes from structure.',
+    '- **Pareto** — most outcomes from a small share of inputs.',
+    '',
+  ].join('\n'));
+
+  const result = spawnSync('bun', ['run', SCRIPT_PATH], {
+    env: { ...process.env, HOME: TMP_HOME },
+    encoding: 'utf-8',
+  });
+  if (result.status !== 0) {
+    throw new Error(`Generator exited ${result.status}\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
+  }
+});
+
+afterAll(() => {
+  rmSync(TMP_HOME, { recursive: true, force: true });
+});
+
+test('title sources principal name from PRINCIPAL_IDENTITY.md', () => {
+  const out = readFileSync(OUTPUT_PATH, 'utf-8');
+  expect(out).toMatch(/^# Principal TELOS — TestUser/m);
+});
+
+test('parseItems reads `- **ID:** text` mission bullets', () => {
+  const out = readFileSync(OUTPUT_PATH, 'utf-8');
+  expect(out).toMatch(/\*\*M0\*\*: Build tools that move agency to individuals/);
+});
+
+test('parseStrategies reads bullet format (S0, S1)', () => {
+  const out = readFileSync(OUTPUT_PATH, 'utf-8');
+  expect(out).toMatch(/\*\*S0\*\*: Ship the crappy version/);
+  expect(out).toMatch(/\*\*S1\*\*: Write before building/);
+});
+
+test('parseModels reads ID-less bold bullets', () => {
+  const out = readFileSync(OUTPUT_PATH, 'utf-8');
+  expect(out).toMatch(/\*\*First principles\*\* — break problems down to fundamentals/);
+  expect(out).toMatch(/\*\*Systems thinking\*\* — behaviour comes from structure/);
+});
+
+test('problems parsed from `## P0:` headers', () => {
+  const out = readFileSync(OUTPUT_PATH, 'utf-8');
+  expect(out).toMatch(/\*\*P0\*\*: Tools fight the user instead of helping/);
+  expect(out).toMatch(/\*\*P1\*\*: Information access is uneven/);
+});
+
+test('active vs deferred goal split', () => {
+  const out = readFileSync(OUTPUT_PATH, 'utf-8');
+  expect(out).toMatch(/\*\*G0\*\*: Ship product MVP/);
+  expect(out).toMatch(/\*\*G1\*\*: Publish weekly newsletter/);
+  expect(out).toMatch(/Deferred.*G2/);
+});

--- a/Releases/v5.0.0/.claude/PAI/TOOLS/GenerateTelosSummary.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/GenerateTelosSummary.ts
@@ -42,17 +42,22 @@ function readTelosFile(filename: string): string {
 }
 
 /**
- * Parse items in format "- **ID**: text" or "- ID: text"
+ * Parse items in any of these bullet formats:
+ *   "- **ID:** text"   (colon inside bold — current TELOS file standard)
+ *   "- **ID**: text"   (colon outside bold)
+ *   "- ID: text"        (plain)
  */
 function parseItems(content: string): ParsedItem[] {
   const items: ParsedItem[] = [];
   const lines = content.split('\n');
 
   for (const line of lines) {
-    // Match "- **M0**: text" or "- M0: text" or "- **G0**: text" patterns
-    const match = line.match(/^-\s+\*?\*?(\w+)\*?\*?:\s*(.+)/);
+    // Match "- **M0:** text", "- **M0**: text", or "- M0: text"
+    const match = line.match(/^-\s+(?:\*\*)?(\w+)(?:\*\*:|:\*\*|:)\s*(.+)/);
     if (match) {
-      items.push({ id: match[1], text: match[2].trim() });
+      // Strip any leading bold close that survived (e.g., "** text" → "text")
+      const text = match[2].replace(/^\*+\s*/, '').trim();
+      items.push({ id: match[1], text });
     }
   }
   return items;
@@ -127,11 +132,20 @@ function parseStrategies(): string[] {
   const content = readTelosFile('STRATEGIES.md');
   const lines: string[] = [];
 
-  // Extract strategy headers: ## S0: name or ### S1: name
-  const headers = [...content.matchAll(/^#{2,3}\s+(S\d+):\s*(.+?)(?:\s*\(.*\))?\s*$/gm)];
-  for (const match of headers) {
-    const short = match[2].length > 60 ? match[2].substring(0, 57) + '...' : match[2];
-    lines.push(`- **${match[1]}**: ${short}`);
+  // Modern format: bullets `- **S0:** text`
+  const items = parseItems(content);
+  for (const item of items) {
+    if (!/^S\d+$/.test(item.id)) continue;
+    lines.push(`- **${item.id}**: ${truncate(item.text, 70)}`);
+  }
+
+  // Legacy fallback: header format `## S0: name`
+  if (lines.length === 0) {
+    const headers = [...content.matchAll(/^#{2,3}\s+(S\d+):\s*(.+?)(?:\s*\(.*\))?\s*$/gm)];
+    for (const match of headers) {
+      const short = match[2].length > 60 ? match[2].substring(0, 57) + '...' : match[2];
+      lines.push(`- **${match[1]}**: ${short}`);
+    }
   }
 
   return lines;
@@ -193,19 +207,42 @@ function parseTraumas(): string[] {
 }
 
 /**
- * Parse models from MODELS.md (first sentence only)
+ * Parse models from MODELS.md (first sentence only).
+ * MODELS.md uses `- **Name** — description` (no IDs), so parse directly.
  */
 function parseModels(): string[] {
   const content = readTelosFile('MODELS.md');
-  const items = parseItems(content);
-  return items.slice(0, 3).map(i => {
-    const first = i.text.split(/\.\s/)[0].trim();
-    return `- ${truncate(first, 65)}`;
-  });
+  const out: string[] = [];
+  const lines = content.split('\n');
+  for (const line of lines) {
+    const m = line.match(/^-\s+\*\*([^*]+)\*\*\s*[—–-]\s*(.+)$/);
+    if (!m) continue;
+    const name = m[1].trim();
+    const first = m[2].split(/\.\s/)[0].trim();
+    out.push(`- **${name}** — ${truncate(first, 65)}`);
+    if (out.length >= 4) break;
+  }
+  return out;
+}
+
+/**
+ * Read principal name from PRINCIPAL_IDENTITY.md (Quick Reference → **Name:** value).
+ * Falls back to placeholder if absent.
+ */
+function readPrincipalName(): string {
+  const path = join(process.env.HOME || '', '.claude/PAI/USER/PRINCIPAL_IDENTITY.md');
+  if (!existsSync(path)) return '{{PRINCIPAL_FULL_NAME}}';
+  const content = readFileSync(path, 'utf-8');
+  const m = content.match(/^-\s*\*\*Name:\*\*\s*([^\n|]+?)\s*$/m);
+  if (!m) return '{{PRINCIPAL_FULL_NAME}}';
+  const name = m[1].trim();
+  if (!name || /^User$/i.test(name)) return '{{PRINCIPAL_FULL_NAME}}';
+  return name;
 }
 
 function generate(): string {
   const now = new Date().toISOString();
+  const principalName = readPrincipalName();
   const missions = parseMissions();
   const goals = parseGoals();
   const problems = parseProblems();
@@ -217,7 +254,7 @@ function generate(): string {
   const models = parseModels();
 
   const lines: string[] = [
-    '# Principal TELOS — {{PRINCIPAL_FULL_NAME}}',
+    `# Principal TELOS — ${principalName}`,
     '',
     '> Auto-generated from TELOS source files. Do not edit manually.',
     `> Generated: ${now} | Sources: MISSION, GOALS, PROBLEMS, STRATEGIES, NARRATIVES, CHALLENGES, WRONG, TRAUMAS, MODELS`,


### PR DESCRIPTION
## Summary

Fixes `GenerateTelosSummary.ts` parser failures against real TELOS source files. The existing parser was over-specific and produced empty sections for several TELOS files.

## Changes

Four parser fixes:

1. **`parseItems`** — broadened regex to match all three bullet variants (`- **ID:** text`, `- **ID**: text`, `- ID: text`)
2. **`parseStrategies`** — switched to bullet format (`- **S0:** ...`); kept legacy `## S0:` header parsing as fallback
3. **`parseModels`** — rewrote for ID-less bold bullets (`- **Name** — description`), which matches `MODELS.md` shape
4. **Title** — sourced from `PRINCIPAL_IDENTITY.md` `**Name:**` field instead of hardcoded placeholder

## Testing

Added `GenerateTelosSummary.test.ts` — 6 fixture-based tests covering all 4 parser changes plus regression coverage for `parseProblems` (`## P0:` headers) and the active-vs-deferred goal split.

```
$ bun test ./Releases/v5.0.0/.claude/PAI/TOOLS/GenerateTelosSummary.test.ts
 6 pass
 0 fail
 11 expect() calls
Ran 6 tests across 1 file. [74.00ms]
```

The test isolates against a temp `HOME` directory with synthetic TELOS fixtures — no real TELOS data is touched.

## Caveat

The parser-shape assumptions are derived from a single TELOS instance (mine). If upstream maintains different canonical TELOS shape conventions, this may need to be schema-aware or gated on file-structure detection. Happy to adjust based on maintainer guidance.
