### PR TITLE
fix(pulse): declare runtime deps + show error state when /api/wiki fails

### DIFF
--- a/Releases/v5.0.0/.claude/PAI/PULSE/Observability/src/app/docs/page.tsx
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/Observability/src/app/docs/page.tsx
@@ -312,31 +312,100 @@ function DocsLanding({ data }: { data: WikiIndex }) {
   );
 }
 
+function WikiErrorState({
+  title,
+  message,
+  hint,
+  onRetry,
+}: {
+  title: string;
+  message: string;
+  hint?: string;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="flex items-center justify-center h-full p-6">
+      <div className="max-w-md text-center space-y-3">
+        <div className="text-lg font-semibold" style={{ ...FONT_HEADING, color: "#F87171" }}>
+          {title}
+        </div>
+        <div className="text-sm text-slate-300" style={FONT_BODY}>
+          {message}
+        </div>
+        {hint && (
+          <div className="text-xs text-slate-500" style={FONT_BODY}>
+            {hint}
+          </div>
+        )}
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-2 px-4 py-1.5 text-sm rounded border border-slate-600 text-slate-200 hover:bg-slate-800"
+          style={FONT_BODY}
+        >
+          Retry
+        </button>
+      </div>
+    </div>
+  );
+}
+
 function DocsPageInner() {
   const searchParams = useSearchParams();
   const docSlug = searchParams.get("doc");
   const isViewing = !!docSlug;
 
-  const { data: indexData } = useQuery<WikiIndex>({
+  const {
+    data: indexData,
+    isError: indexIsError,
+    error: indexError,
+    refetch: refetchIndex,
+  } = useQuery<WikiIndex>({
     queryKey: ["wiki-index"],
     queryFn: async () => {
       const res = await fetch("/api/wiki");
-      if (!res.ok) throw new Error("Failed to fetch wiki index");
+      if (!res.ok) throw new Error(`Failed to fetch wiki index (HTTP ${res.status})`);
       return res.json();
     },
     staleTime: 30_000,
     enabled: !isViewing,
   });
 
-  const { data: docDetail } = useQuery<PageDetail>({
+  const {
+    data: docDetail,
+    isError: docIsError,
+    error: docError,
+    refetch: refetchDoc,
+  } = useQuery<PageDetail>({
     queryKey: ["wiki-doc", docSlug],
     queryFn: async () => {
       const res = await fetch(`/api/wiki/doc/${docSlug}`);
-      if (!res.ok) throw new Error("Failed to fetch doc");
+      if (!res.ok) throw new Error(`Failed to fetch doc (HTTP ${res.status})`);
       return res.json();
     },
     enabled: isViewing,
   });
+
+  if (isViewing && docIsError) {
+    return (
+      <WikiErrorState
+        title="Couldn't load this doc"
+        message={docError instanceof Error ? docError.message : "Unknown error"}
+        onRetry={() => refetchDoc()}
+      />
+    );
+  }
+
+  if (!isViewing && indexIsError) {
+    return (
+      <WikiErrorState
+        title="Couldn't load the wiki"
+        message={indexError instanceof Error ? indexError.message : "Unknown error"}
+        onRetry={() => refetchIndex()}
+        hint="The Pulse wiki module may not be running. Check pulse.log for details."
+      />
+    );
+  }
 
   if (isViewing && docDetail) {
     return (

--- a/Releases/v5.0.0/.claude/PAI/PULSE/package.json
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "pai-pulse",
+  "private": true,
+  "type": "module",
+  "description": "PAI Pulse daemon — runtime dependencies for pulse.ts and its modules.",
+  "dependencies": {
+    "minisearch": "^7.2.0"
+  }
+}

--- a/Releases/v5.0.0/.claude/PAI/PULSE/package.json
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "description": "PAI Pulse daemon — runtime dependencies for pulse.ts and its modules.",
   "dependencies": {
-    "minisearch": "^7.2.0"
+    "minisearch": "^7.2.0",
+    "smol-toml": "^1.6.1"
   }
 }


### PR DESCRIPTION
## Problem

A fresh PAI 5.0.0 install hits two compounding defects when loading the Pulse `/docs` page:

1. **Undeclared runtime dependencies.** Pulse's daemon imports `minisearch` (in [`modules/wiki.ts`](Releases/v5.0.0/.claude/PAI/PULSE/modules/wiki.ts#L34)) and `smol-toml` (in [`pulse.ts`](Releases/v5.0.0/.claude/PAI/PULSE/pulse.ts), [`lib.ts`](Releases/v5.0.0/.claude/PAI/PULSE/lib.ts), and others — to parse `PULSE.toml`), but neither is declared as a dependency anywhere in the release. `pulse.log` shows `ResolveMessage: Cannot find package 'minisearch'` and `pulse.ts` swallows the error, so `/api/wiki/*` falls through to Pulse's 404 handler. `smol-toml` would crash startup outright.
2. **Missing error branch in the React UI.** [`docs/page.tsx`](Releases/v5.0.0/.claude/PAI/PULSE/Observability/src/app/docs/page.tsx#L320) destructures only `data` from `useQuery`. When the fetch errors, `data` is `undefined` — indistinguishable from the pending state — so the component falls through to the `Loading...` branch forever. The user sees an infinite spinner with no error and no console hint.

Either fix alone would mask the other.

## Changes

### 1. Declare Pulse runtime dependencies
- New [`Releases/v5.0.0/.claude/PAI/PULSE/package.json`](Releases/v5.0.0/.claude/PAI/PULSE/package.json) declaring `minisearch ^7.2.0` and `smol-toml ^1.6.1`.
- Co-located with `pulse.ts` so deps live next to the daemon that uses them.
- Bun resolves dependencies upward, so `bun install` in `PAI/PULSE/` is sufficient.

**Scope note:** the daemon also has optional imports for `grammy`, `jose`, and `@anthropic-ai/claude-agent-sdk` (used by the telegram, github-work, and imessage modules respectively, all wrapped in try/catch). These are deliberately not declared in this PR — they need an `optionalDependencies` vs. plain `dependencies` design decision and belong in a follow-up. `grammy` already shows up in `pulse.log` as a missing-package warning today; this PR doesn't change that.

**Installer follow-up needed:** the installer (`install.sh` / `PAI-Install/engine/actions.ts`) doesn't currently run `bun install` in `PAI/PULSE/`. That's a separate PR — declaring the deps is the prerequisite.

### 2. Surface fetch errors in the React UI
- New `WikiErrorState` component — title, message, optional hint, retry button.
- Both `useQuery` hooks now propagate `isError`, `error`, and `refetch` to the UI.
- Error messages include the HTTP status code so the user sees `HTTP 404` instead of a generic string.
- No change to the success path.

## Verification

- Reproduced original bug locally: stopped the wiki module, `/api/wiki` → 404, `/docs` stuck on `Loading...` forever.
- Applied error-UI patch: `/docs` now renders **"Couldn't load the wiki — Failed to fetch wiki index (HTTP 404)"** with a hint pointing to `pulse.log` and a Retry button.
- Installed `minisearch` (mirroring what the new `package.json` declares), restarted Pulse: wiki module loads, `/api/wiki/search` returns 200, `/docs` renders normally.
- Verified `smol-toml` is imported by 4 daemon files (`pulse.ts`, `lib.ts`, `pulse-unified.ts`, `checks/github-work.ts`) — load-bearing for PULSE.toml parsing.

## Notes

- Pre-existing `Cannot find module 'react'` TypeScript diagnostics in this directory are unrelated — `Releases/v5.0.0/` ships without `node_modules`. Not introduced here.