### PR TITLE
Fix tools directory for pai alias

### DIFF
--- a/Releases/v5.0.0/.claude/PAI/PAI-Install/engine/actions.ts
+++ b/Releases/v5.0.0/.claude/PAI/PAI-Install/engine/actions.ts
@@ -1525,7 +1525,7 @@ export async function runConfiguration(
   const userShell = process.env.SHELL || "/bin/zsh";
   const rcFile = userShell.includes("bash") ? ".bashrc" : userShell.includes("fish") ? ".config/fish/config.fish" : ".zshrc";
   const rcPath = join(homedir(), rcFile);
-  const aliasLine = `alias pai='bun ${join(paiDir, "PAI", "Tools", "pai.ts")}'`;
+  const aliasLine = `alias pai='bun ${join(paiDir, "PAI", "TOOLS", "pai.ts")}'`;
   const marker = "# PAI alias";
 
   if (existsSync(rcPath)) {


### PR DESCRIPTION
The current code adds the alias `alias pai='bun <home-dir>/.claude/PAI/Tools/pai.ts'`. However the `Tools` directory is actually `TOOLS`. This creates a broken alias on Linux.