### PR TITLE
fix: resolve path env vars (PAI_DIR/PROJECTS_DIR/CLAUDE_CONFIG_DIR) through paths.ts — settings.json env values are not shell-expanded

### DIFF
--- a/Releases/v5.0.0/.claude/PAI/PULSE/MenuBar/install.sh
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/MenuBar/install.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 HOME_DIR="$HOME"
+. "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/lib/paths.sh"
 APP_NAME="PAI Pulse"
 APP_DIR="$HOME_DIR/Applications"
 APP_DEST="$APP_DIR/$APP_NAME.app"
@@ -68,7 +69,7 @@ sed "s|__HOME__|$HOME_DIR|g" "$PLIST_SRC" > "$PLIST_DST"
 echo "  Installed $PLIST_DST"
 
 # Ensure logs directory exists
-mkdir -p "$HOME_DIR/.claude/PAI/PULSE/logs"
+mkdir -p "$(pai_path PULSE logs)"
 
 launchctl load "$PLIST_DST"
 echo "  Loaded $PLIST_LABEL"

--- a/Releases/v5.0.0/.claude/PAI/PULSE/Observability/observability.ts
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/Observability/observability.ts
@@ -27,6 +27,7 @@
 import { join, extname } from "path"
 import { readFileSync, readdirSync, existsSync, realpathSync } from "fs"
 import YAML from "yaml"
+import { getPaiDir } from "../../../hooks/lib/paths"
 
 // Bun is always the runtime here (Pulse launches this via `bun`). The Next
 // tsconfig's DOM+esnext lib doesn't include bun-types, so declare the minimal
@@ -1646,7 +1647,7 @@ function readDirMdFiles(dir: string): { name: string, content: string, sections:
 
 function handleUserIndexApi(filter: string | null): Response {
   try {
-    const PAI_DIR = process.env.PAI_DIR || join(process.env.HOME || "", ".claude", "PAI")
+    const PAI_DIR = getPaiDir()
     const indexPath = join(PAI_DIR, "Pulse", "state", "user-index.json")
     const raw = Bun.file(indexPath)
     if (!raw.size) {

--- a/Releases/v5.0.0/.claude/PAI/PULSE/checks/notification-governor.ts
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/checks/notification-governor.ts
@@ -31,9 +31,9 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync, appendFileSync } from "fs";
 import { join, dirname } from "path";
 import { createHash } from "crypto";
+import { getPaiDir } from "../../../hooks/lib/paths";
 
-const HOME = process.env.HOME || "";
-const PAI_DIR = process.env.PAI_DIR || join(HOME, ".claude", "PAI");
+const PAI_DIR = getPaiDir();
 const STATE_FILE = join(PAI_DIR, "Pulse", "state", "notification-governor.json");
 const LOG_FILE = join(PAI_DIR, "MEMORY", "OBSERVABILITY", "notification-governor.jsonl");
 const NOTIFY_URL = "http://localhost:31337/notify";

--- a/Releases/v5.0.0/.claude/PAI/PULSE/checks/poller-meta-monitor.ts
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/checks/poller-meta-monitor.ts
@@ -17,9 +17,9 @@
 
 import { readFileSync, existsSync } from "fs";
 import { join } from "path";
+import { getPaiDir } from "../../../hooks/lib/paths";
 
-const HOME = process.env.HOME || "";
-const PAI_DIR = process.env.PAI_DIR || join(HOME, ".claude", "PAI");
+const PAI_DIR = getPaiDir();
 const PULSE_STATE = join(PAI_DIR, "Pulse", "state", "state.json");
 const PULSE_TOML = join(PAI_DIR, "Pulse", "PULSE.toml");
 

--- a/Releases/v5.0.0/.claude/PAI/PULSE/manage.sh
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/manage.sh
@@ -2,7 +2,8 @@
 # PAI Pulse — Process Management
 # Usage: manage.sh {start|stop|restart|status|install|uninstall}
 
-PULSE_DIR="$HOME/.claude/PAI/PULSE"
+. "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/lib/paths.sh"
+PULSE_DIR="$(pai_path PULSE)"
 PLIST_NAME="com.pai.pulse"
 PLIST_SRC="$PULSE_DIR/$PLIST_NAME.plist"
 PLIST_DST="$HOME/Library/LaunchAgents/$PLIST_NAME.plist"

--- a/Releases/v5.0.0/.claude/PAI/PULSE/modules/user-index.ts
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/modules/user-index.ts
@@ -21,9 +21,9 @@
 
 import { readFileSync, writeFileSync, statSync, readdirSync, mkdirSync, existsSync, watch } from "fs"
 import { join, relative, basename, dirname } from "path"
+import { getPaiDir } from "../../../hooks/lib/paths"
 
-const HOME = process.env.HOME ?? ""
-const PAI_DIR = process.env.PAI_DIR || join(HOME, ".claude", "PAI")
+const PAI_DIR = getPaiDir()
 const USER_DIR = join(PAI_DIR, "USER")
 const STATE_DIR = join(PAI_DIR, "Pulse", "state")
 const INDEX_PATH = join(STATE_DIR, "user-index.json")

--- a/Releases/v5.0.0/.claude/PAI/TOOLS/AgentWatchdog.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/AgentWatchdog.ts
@@ -19,8 +19,9 @@
 
 import { existsSync, readFileSync, statSync } from "fs";
 import { join } from "path";
+import { getPaiDir } from "../../hooks/lib/paths";
 
-const PAI_DIR = process.env.PAI_DIR || join(process.env.HOME!, ".claude", "PAI");
+const PAI_DIR = getPaiDir();
 const OBS_DIR = join(PAI_DIR, "MEMORY", "OBSERVABILITY");
 const ACTIVITY_FILE = join(OBS_DIR, "tool-activity.jsonl");
 const STARTS_FILE = join(OBS_DIR, "subagent-starts.json");

--- a/Releases/v5.0.0/.claude/PAI/TOOLS/ApproveCurrentStateEntries.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/ApproveCurrentStateEntries.ts
@@ -18,9 +18,9 @@
 
 import { readFileSync, writeFileSync, existsSync } from "fs";
 import { join } from "path";
+import { getPaiDir } from "../../hooks/lib/paths";
 
-const HOME = process.env.HOME || "";
-const PAI_DIR = process.env.PAI_DIR || join(HOME, ".claude", "PAI");
+const PAI_DIR = getPaiDir();
 const QUEUE_FILE = join(PAI_DIR, "USER", "TELOS", "CURRENT_STATE", "proposals.jsonl");
 const CURRENT_STATE_DIR = join(PAI_DIR, "USER", "TELOS", "CURRENT_STATE");
 

--- a/Releases/v5.0.0/.claude/PAI/TOOLS/ArchitectureSummaryGenerator.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/ArchitectureSummaryGenerator.ts
@@ -14,13 +14,14 @@
 import { parseArgs } from "util";
 import * as fs from "fs";
 import * as path from "path";
+import { getPaiDir } from "../../hooks/lib/paths";
 
 // ============================================================================
 // Configuration
 // ============================================================================
 
 const HOME = process.env.HOME!;
-const PAI_DIR = process.env.PAI_DIR || path.join(HOME, ".claude", "PAI");
+const PAI_DIR = getPaiDir();
 const ARCH_SOURCE = path.join(PAI_DIR, "DOCUMENTATION", "PAISystemArchitecture.md");
 const SUMMARY_OUTPUT = path.join(PAI_DIR, "DOCUMENTATION", "ARCHITECTURE_SUMMARY.md");
 const ALGORITHM_DIR = path.join(PAI_DIR, "ALGORITHM");

--- a/Releases/v5.0.0/.claude/PAI/TOOLS/Arthur.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/Arthur.ts
@@ -5,10 +5,10 @@
 
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { homedir } from "node:os";
 import YAML from "yaml";
+import { getPaiDir } from "../../hooks/lib/paths";
 
-const PAI_DIR = process.env.PAI_DIR ?? join(homedir(), ".claude", "PAI");
+const PAI_DIR = getPaiDir();
 const POLICIES_PATH = join(PAI_DIR, "USER", "ARTHUR", "policies.yaml");
 const GCP_PROJECT = process.env.PAI_GCP_PROJECT ?? "";
 

--- a/Releases/v5.0.0/.claude/PAI/TOOLS/ComputeGap.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/ComputeGap.ts
@@ -22,9 +22,9 @@
 
 import { readFileSync, existsSync, appendFileSync, mkdirSync } from "fs";
 import { join, dirname } from "path";
+import { getPaiDir } from "../../hooks/lib/paths";
 
-const HOME = process.env.HOME || "";
-const PAI_DIR = process.env.PAI_DIR || join(HOME, ".claude", "PAI");
+const PAI_DIR = getPaiDir();
 const IDEAL_DIR = join(PAI_DIR, "USER", "TELOS", "IDEAL_STATE");
 const CURRENT_DIR = join(PAI_DIR, "USER", "TELOS", "CURRENT_STATE");
 const HEALTH_DIR = join(PAI_DIR, "USER", "HEALTH");

--- a/Releases/v5.0.0/.claude/PAI/TOOLS/FailureCapture.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/FailureCapture.ts
@@ -28,8 +28,9 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync } from 'fs';
 import { join, basename } from 'path';
 import { inference } from './Inference';
+import { getPaiDir } from '../../hooks/lib/paths';
 
-const PAI_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
+const PAI_DIR = getPaiDir();
 
 interface FailureCaptureInput {
   transcriptPath: string;

--- a/Releases/v5.0.0/.claude/PAI/TOOLS/GetCounts.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/GetCounts.ts
@@ -35,9 +35,13 @@
 
 import { readdirSync, existsSync, statSync } from "fs";
 import { join } from "path";
+import { getPaiDir, getClaudeDir } from "../../hooks/lib/paths";
 
 const HOME = process.env.HOME!;
-const PAI_DIR = process.env.PAI_DIR || join(HOME, ".claude");
+// PAI data (MEMORY, USER) lives under getPaiDir() (~/.claude/PAI);
+// skills/ live under Claude home (getClaudeDir(), ~/.claude).
+const PAI_DIR = getPaiDir();
+const CLAUDE_DIR = getClaudeDir();
 
 interface Counts {
   skills: number;
@@ -101,7 +105,7 @@ function countWorkflowFiles(dir: string): number {
  */
 function countSkills(): number {
   let count = 0;
-  const skillsDir = join(PAI_DIR, "skills");
+  const skillsDir = join(CLAUDE_DIR, "skills");
   try {
     for (const entry of readdirSync(skillsDir, { withFileTypes: true })) {
       // Handle both real directories and symlinks to directories
@@ -169,10 +173,10 @@ function countRatings(): number {
 function getCounts(): Counts {
   return {
     skills: countSkills(),
-    workflows: countWorkflowFiles(join(PAI_DIR, "skills")),
+    workflows: countWorkflowFiles(join(CLAUDE_DIR, "skills")),
     hooks: countHooks(),
     signals: countFilesRecursive(join(PAI_DIR, "MEMORY/LEARNING"), ".md"),
-    files: countFilesRecursive(join(PAI_DIR, "PAI/USER")),
+    files: countFilesRecursive(join(PAI_DIR, "USER")),
     work: (() => {
       let count = 0;
       try {

--- a/Releases/v5.0.0/.claude/PAI/TOOLS/IntegrityMaintenance.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/IntegrityMaintenance.ts
@@ -23,6 +23,7 @@ import { readFileSync, existsSync } from 'fs';
 import { join, basename, dirname } from 'path';
 import { inference } from './Inference';
 import { getIdentity } from '../../../.claude/hooks/lib/identity';
+import { getClaudeDir } from '../../../.claude/hooks/lib/paths';
 
 // ============================================================================
 // Types
@@ -108,8 +109,11 @@ interface UpdateData {
 // Constants
 // ============================================================================
 
-const PAI_DIR = process.env.HOME + '/.claude/PAI';
-const CREATE_UPDATE_SCRIPT = join(PAI_DIR, 'skills/_PAI/TOOLS/CreateUpdate.ts');
+// skills/ lives under Claude home, not PAI data dir. (Pre-existing: the
+// referenced skills/_PAI/TOOLS/CreateUpdate.ts does not exist in the tree —
+// see NOTE D in the fix spec; flagged separately, not resolved here.)
+const CLAUDE_DIR = getClaudeDir();
+const CREATE_UPDATE_SCRIPT = join(CLAUDE_DIR, 'skills/_PAI/TOOLS/CreateUpdate.ts');
 
 // Words that indicate generic/bad titles - reject these
 const GENERIC_TITLE_PATTERNS = [

--- a/Releases/v5.0.0/.claude/PAI/TOOLS/InterviewIdealState.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/InterviewIdealState.ts
@@ -17,9 +17,9 @@
 
 import { readFileSync, writeFileSync, existsSync, readdirSync } from "fs";
 import { join } from "path";
+import { getPaiDir } from "../../hooks/lib/paths";
 
-const HOME = process.env.HOME || "";
-const PAI_DIR = process.env.PAI_DIR || join(HOME, ".claude", "PAI");
+const PAI_DIR = getPaiDir();
 const TELOS_DIR = join(PAI_DIR, "USER", "TELOS");
 const IDEAL_DIR = join(TELOS_DIR, "IDEAL_STATE");
 const STATE_FILE = join(PAI_DIR, "USER", "TELOS", "CURRENT_STATE", "interview-state.json");

--- a/Releases/v5.0.0/.claude/PAI/TOOLS/InterviewScan.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/InterviewScan.ts
@@ -18,9 +18,9 @@
 
 import { readFileSync, existsSync } from "fs";
 import { join } from "path";
+import { getPaiDir } from "../../hooks/lib/paths";
 
-const HOME = process.env.HOME || "";
-const PAI_DIR = process.env.PAI_DIR || join(HOME, ".claude", "PAI");
+const PAI_DIR = getPaiDir();
 const USER_DIR = join(PAI_DIR, "USER");
 const TELOS_DIR = join(USER_DIR, "TELOS");
 const IDEAL_DIR = join(TELOS_DIR, "IDEAL_STATE");

--- a/Releases/v5.0.0/.claude/PAI/TOOLS/KnowledgeGraph.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/KnowledgeGraph.ts
@@ -26,13 +26,13 @@
 import { parseArgs } from "util";
 import * as fs from "fs";
 import * as path from "path";
+import { getPaiDir } from "../../hooks/lib/paths";
 
 // ============================================================================
 // Configuration
 // ============================================================================
 
-const HOME = process.env.HOME!;
-const PAI_DIR = process.env.PAI_DIR || path.join(HOME, ".claude", "PAI");
+const PAI_DIR = getPaiDir();
 const KNOWLEDGE_DIR = path.join(PAI_DIR, "MEMORY", "KNOWLEDGE");
 const DOMAINS = ["People", "Companies", "Ideas", "Research"];
 const SKIP_FILES = new Set(["_index.md", "_schema.md", "_log.md"]);

--- a/Releases/v5.0.0/.claude/PAI/TOOLS/KnowledgeHarvester.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/KnowledgeHarvester.ts
@@ -21,13 +21,14 @@
 import { parseArgs } from "util";
 import * as fs from "fs";
 import * as path from "path";
+import { getPaiDir } from "../../hooks/lib/paths";
 
 // ============================================================================
 // Configuration
 // ============================================================================
 
 const HOME = process.env.HOME!;
-const PAI_DIR = process.env.PAI_DIR || path.join(HOME, ".claude", "PAI");
+const PAI_DIR = getPaiDir();
 const MEMORY_DIR = path.join(PAI_DIR, "MEMORY");
 const KNOWLEDGE_DIR = path.join(MEMORY_DIR, "KNOWLEDGE");
 const WORK_DIR = path.join(MEMORY_DIR, "WORK");

--- a/Releases/v5.0.0/.claude/PAI/TOOLS/MemoryRetriever.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/MemoryRetriever.ts
@@ -35,13 +35,13 @@ import { parseArgs } from "util";
 import * as fs from "fs";
 import * as path from "path";
 import { spawnSync } from "child_process";
+import { getPaiDir } from "../../hooks/lib/paths";
 
 // ============================================================================
 // Configuration
 // ============================================================================
 
-const HOME = process.env.HOME!;
-const PAI_DIR = process.env.PAI_DIR || path.join(HOME, ".claude", "PAI");
+const PAI_DIR = getPaiDir();
 const KNOWLEDGE_DIR = path.join(PAI_DIR, "MEMORY", "KNOWLEDGE");
 const DOMAINS = ["People", "Companies", "Ideas", "Research"];
 

--- a/Releases/v5.0.0/.claude/PAI/TOOLS/MigrateApprove.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/MigrateApprove.ts
@@ -24,9 +24,10 @@
 
 import { readFileSync, writeFileSync, existsSync, appendFileSync, mkdirSync } from "fs";
 import { join, dirname } from "path";
+import { getPaiDir } from "../../hooks/lib/paths";
 
 const HOME = process.env.HOME || "";
-const PAI_DIR = process.env.PAI_DIR || join(HOME, ".claude", "PAI");
+const PAI_DIR = getPaiDir();
 const QUEUE_FILE = join(PAI_DIR, "MEMORY", "MIGRATION", "migration-proposals.jsonl");
 const COMMITTED_LOG = join(PAI_DIR, "MEMORY", "MIGRATION", "committed.jsonl");
 

--- a/Releases/v5.0.0/.claude/PAI/TOOLS/MigrateScan.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/MigrateScan.ts
@@ -22,9 +22,9 @@
 import { readFileSync, writeFileSync, existsSync, readdirSync, statSync, mkdirSync, appendFileSync } from "fs";
 import { join, basename, dirname, extname } from "path";
 import { randomUUID } from "crypto";
+import { getPaiDir } from "../../hooks/lib/paths";
 
-const HOME = process.env.HOME || "";
-const PAI_DIR = process.env.PAI_DIR || join(HOME, ".claude", "PAI");
+const PAI_DIR = getPaiDir();
 const QUEUE_FILE = join(PAI_DIR, "MEMORY", "MIGRATION", "migration-proposals.jsonl");
 
 type Target =

--- a/Releases/v5.0.0/.claude/PAI/TOOLS/OpinionTracker.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/OpinionTracker.ts
@@ -23,9 +23,10 @@
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
 import { join } from 'path';
+import { getPaiDir } from '../../hooks/lib/paths';
 
-const PAI_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
-const OPINIONS_FILE = join(PAI_DIR, 'PAI/USER/OPINIONS.md');
+const PAI_DIR = getPaiDir();
+const OPINIONS_FILE = join(PAI_DIR, 'USER/OPINIONS.md');
 const RELATIONSHIP_LOG = join(PAI_DIR, 'MEMORY/RELATIONSHIP');
 
 interface Evidence {

--- a/Releases/v5.0.0/.claude/PAI/TOOLS/ProposeCurrentStateEntry.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/ProposeCurrentStateEntry.ts
@@ -20,9 +20,9 @@
 import { appendFileSync, mkdirSync, existsSync } from "fs";
 import { join, dirname } from "path";
 import { randomUUID } from "crypto";
+import { getPaiDir } from "../../hooks/lib/paths";
 
-const HOME = process.env.HOME || "";
-const PAI_DIR = process.env.PAI_DIR || join(HOME, ".claude", "PAI");
+const PAI_DIR = getPaiDir();
 const QUEUE_FILE = join(PAI_DIR, "USER", "TELOS", "CURRENT_STATE", "proposals.jsonl");
 
 const ALLOWED_SOURCES = ["lifelog", "calendar", "gmail", "homebridge", "manual", "amazon", "bills"];

--- a/Releases/v5.0.0/.claude/PAI/TOOLS/Recommend.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/Recommend.ts
@@ -16,9 +16,9 @@
 
 import { readFileSync, existsSync } from "fs";
 import { join } from "path";
+import { getPaiDir } from "../../hooks/lib/paths";
 
-const HOME = process.env.HOME || "";
-const PAI_DIR = process.env.PAI_DIR || join(HOME, ".claude", "PAI");
+const PAI_DIR = getPaiDir();
 const TELOS_DIR = join(PAI_DIR, "USER", "TELOS");
 const CURRENT_DIR = join(TELOS_DIR, "CURRENT_STATE");
 

--- a/Releases/v5.0.0/.claude/PAI/TOOLS/RelationshipReflect.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/RelationshipReflect.ts
@@ -28,8 +28,9 @@
 import { readFileSync, writeFileSync, existsSync, readdirSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { execSync } from 'child_process';
+import { getPaiDir } from '../../hooks/lib/paths';
 
-const PAI_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
+const PAI_DIR = getPaiDir();
 
 interface RelationshipNote {
   type: 'W' | 'B' | 'O';
@@ -265,7 +266,7 @@ function aggregateEvidence(notes: RelationshipNote[], ratings: Array<{ rating: n
  */
 function parseOpinions(): Map<string, { confidence: number; section: string }> {
   const opinions = new Map<string, { confidence: number; section: string }>();
-  const opinionsPath = join(PAI_DIR, 'PAI/USER/OPINIONS.md');
+  const opinionsPath = join(PAI_DIR, 'USER/OPINIONS.md');
 
   if (!existsSync(opinionsPath)) return opinions;
 
@@ -297,7 +298,7 @@ function updateOpinionConfidence(
   evidence: Map<string, OpinionEvidence>,
   dryRun: boolean
 ): { updated: number; majorShifts: string[] } {
-  const opinionsPath = join(PAI_DIR, 'PAI/USER/OPINIONS.md');
+  const opinionsPath = join(PAI_DIR, 'USER/OPINIONS.md');
   if (!existsSync(opinionsPath)) return { updated: 0, majorShifts: [] };
 
   let content = readFileSync(opinionsPath, 'utf-8');
@@ -361,7 +362,7 @@ function escapeRegex(str: string): string {
  */
 function checkMilestones(notes: RelationshipNote[]): string[] {
   const achieved: string[] = [];
-  const storyPath = join(PAI_DIR, 'PAI/USER/OUR_STORY.md');
+  const storyPath = join(PAI_DIR, 'USER/OUR_STORY.md');
 
   if (!existsSync(storyPath)) return achieved;
 
@@ -384,7 +385,7 @@ function checkMilestones(notes: RelationshipNote[]): string[] {
  * Add milestone to OUR_STORY.md
  */
 function addMilestone(description: string, dryRun: boolean): boolean {
-  const storyPath = join(PAI_DIR, 'PAI/USER/OUR_STORY.md');
+  const storyPath = join(PAI_DIR, 'USER/OUR_STORY.md');
   if (!existsSync(storyPath)) return false;
 
   let content = readFileSync(storyPath, 'utf-8');

--- a/Releases/v5.0.0/.claude/PAI/TOOLS/WisdomCrossFrameSynthesizer.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/WisdomCrossFrameSynthesizer.ts
@@ -17,8 +17,9 @@
 import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { join, basename } from 'path';
 import { parseArgs } from 'util';
+import { getPaiDir } from '../../hooks/lib/paths';
 
-const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
+const BASE_DIR = getPaiDir();
 const WISDOM_DIR = join(BASE_DIR, 'MEMORY', 'WISDOM');
 const FRAMES_DIR = join(WISDOM_DIR, 'FRAMES');
 const PRINCIPLES_DIR = join(WISDOM_DIR, 'PRINCIPLES');

--- a/Releases/v5.0.0/.claude/PAI/TOOLS/WisdomDomainClassifier.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/WisdomDomainClassifier.ts
@@ -16,8 +16,9 @@
 import { existsSync, readdirSync, readFileSync } from 'fs';
 import { join, basename } from 'path';
 import { parseArgs } from 'util';
+import { getPaiDir } from '../../hooks/lib/paths';
 
-const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
+const BASE_DIR = getPaiDir();
 const FRAMES_DIR = join(BASE_DIR, 'MEMORY', 'WISDOM', 'FRAMES');
 
 // ── Domain Keyword Map ──

--- a/Releases/v5.0.0/.claude/PAI/TOOLS/WisdomFrameUpdater.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/WisdomFrameUpdater.ts
@@ -18,8 +18,9 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { parseArgs } from 'util';
+import { getPaiDir } from '../../hooks/lib/paths';
 
-const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
+const BASE_DIR = getPaiDir();
 const FRAMES_DIR = join(BASE_DIR, 'MEMORY', 'WISDOM', 'FRAMES');
 
 // ── Types ──

--- a/Releases/v5.0.0/.claude/PAI/TOOLS/algorithm.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/algorithm.ts
@@ -51,14 +51,14 @@ import { resolve, basename, join, dirname } from "path";
 import { spawnSync, spawn } from "child_process";
 import { randomUUID } from "crypto";
 import { generateISATemplate } from "../../../.claude/hooks/lib/isa-template";
+import { getPaiDir, getProjectsDir } from "../../../.claude/hooks/lib/paths";
 
 // ─── Paths ───────────────────────────────────────────────────────────────────
 
-const HOME = process.env.HOME || "~";
-const BASE_DIR = process.env.PAI_DIR || join(HOME, ".claude");
+const BASE_DIR = getPaiDir();
 const ALGORITHMS_DIR = join(BASE_DIR, "MEMORY", "STATE", "algorithms");
 const SESSION_NAMES_PATH = join(BASE_DIR, "MEMORY", "STATE", "session-names.json");
-const PROJECTS_DIR = process.env.PROJECTS_DIR || join(HOME, "Projects");
+const PROJECTS_DIR = getProjectsDir();
 const VOICE_URL = "http://localhost:31337/notify";
 const VOICE_ID = "fTtv3eikoepIosk8dTZ5";
 

--- a/Releases/v5.0.0/.claude/PAI/statusline-command.sh
+++ b/Releases/v5.0.0/.claude/PAI/statusline-command.sh
@@ -11,9 +11,11 @@ set -o pipefail
 # CONFIGURATION
 # ─────────────────────────────────────────────────────────────────────────────
 
-PAI_DIR="${PAI_DIR:-$HOME/.claude/PAI}"
-CLAUDE_HOME="$HOME/.claude"
-SETTINGS_FILE="$CLAUDE_HOME/settings.json"
+# Path resolution via shared helper (mirrors hooks/lib/paths.ts contract)
+. "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/lib/paths.sh"
+CLAUDE_HOME="$(get_claude_dir)"
+PAI_DIR="$(get_pai_dir)"
+SETTINGS_FILE="$(get_settings_path)"
 RATINGS_FILE="$PAI_DIR/MEMORY/LEARNING/SIGNALS/ratings.jsonl"
 MODEL_CACHE="$PAI_DIR/MEMORY/STATE/model-cache.txt"
 QUOTE_CACHE="$PAI_DIR/.quote-cache"
@@ -59,7 +61,7 @@ PAI_VERSION="${PAI_VERSION:-—}"
 # multiple candidate paths in order, keeping the first non-empty result.
 ALGO_VERSION=""
 for _algo_path in \
-    "$PAI_DIR/ALGORITHM/LATEST" \
+    "$(pai_path ALGORITHM LATEST)" \
     "$HOME/.claude/PAI/ALGORITHM/LATEST" \
     "/Users/$(id -un 2>/dev/null)/.claude/PAI/ALGORITHM/LATEST" \
     "$(eval echo ~"$(id -un 2>/dev/null)")/.claude/PAI/ALGORITHM/LATEST"; do
@@ -73,7 +75,7 @@ done
     printf '[%s] ALGO_VERSION=%q HOME=%q PAI_DIR=%q USER=%q paths_tried:' \
         "$(date '+%H:%M:%S')" "$ALGO_VERSION" "${HOME:-UNSET}" "${PAI_DIR:-UNSET}" "${USER:-UNSET}"
     for _algo_path in \
-        "$PAI_DIR/ALGORITHM/LATEST" \
+        "$(pai_path ALGORITHM LATEST)" \
         "$HOME/.claude/PAI/ALGORITHM/LATEST" \
         "/Users/$(id -un 2>/dev/null)/.claude/PAI/ALGORITHM/LATEST"; do
         printf ' %s=%s' "$_algo_path" "$([ -f "$_algo_path" ] && echo OK || echo MISS)"
@@ -273,7 +275,7 @@ if [ "$context_pct" = "0" ] && [ "$total_input" -eq 0 ] 2>/dev/null; then
         done < <(jq -r '.loadAtStartup.files[]? // empty' "$SETTINGS_FILE" 2>/dev/null)
 
         # Project memory files (CC native memory at ~/.claude/projects/*/memory/)
-        for _f in "$HOME"/.claude/projects/*/memory/MEMORY.md; do
+        for _f in "$(get_claude_dir)"/projects/*/memory/MEMORY.md; do
             [ -f "$_f" ] && _est=$((_est + $(wc -c < "$_f") * 10 / 35))
         done
 
@@ -694,7 +696,7 @@ USAGEEOF
             if [ "$(uname -s)" = "Darwin" ]; then
                 cred_json=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null)
             else
-                cred_json=$(cat "${HOME}/.claude/.credentials.json" 2>/dev/null)
+                cred_json=$(cat "$(get_claude_dir)/.credentials.json" 2>/dev/null)
             fi
             token=$(echo "$cred_json" | jq -r '.claudeAiOauth.accessToken // empty' 2>/dev/null)
 

--- a/Releases/v5.0.0/.claude/hooks/InstructionsLoadedHandler.hook.ts
+++ b/Releases/v5.0.0/.claude/hooks/InstructionsLoadedHandler.hook.ts
@@ -25,13 +25,14 @@
 import { existsSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
+import { getPaiDir } from './lib/paths';
 
 // ========================================
 // Configuration
 // ========================================
 
 const HOME = homedir();
-const PAI_DIR = process.env.PAI_DIR || join(HOME, '.claude', 'PAI');
+const PAI_DIR = getPaiDir();
 const STATE_DIR = join(PAI_DIR, 'MEMORY', 'STATE');
 const HASHES_FILE = join(STATE_DIR, 'instruction-hashes.json');
 const INTEGRITY_LOG = join(STATE_DIR, 'instruction-integrity.jsonl');

--- a/Releases/v5.0.0/.claude/hooks/LastResponseCache.hook.ts
+++ b/Releases/v5.0.0/.claude/hooks/LastResponseCache.hook.ts
@@ -14,6 +14,7 @@
 import { readHookInput, parseTranscriptFromInput } from './lib/hook-io';
 import { writeFileSync } from 'fs';
 import { join } from 'path';
+import { getPaiDir } from './lib/paths';
 
 async function main() {
   const input = await readHookInput();
@@ -28,7 +29,7 @@ async function main() {
 
   if (lastResponse) {
     try {
-      const paiDir = process.env.PAI_DIR || join(process.env.HOME!, '.claude', 'PAI');
+      const paiDir = getPaiDir();
       const cachePath = join(paiDir, 'MEMORY', 'STATE', 'last-response.txt');
       writeFileSync(cachePath, lastResponse.slice(0, 2000), 'utf-8');
     } catch (err) {

--- a/Releases/v5.0.0/.claude/hooks/PreCompact.hook.ts
+++ b/Releases/v5.0.0/.claude/hooks/PreCompact.hook.ts
@@ -27,8 +27,9 @@
 import { existsSync, readFileSync, readdirSync } from 'fs';
 import { join, basename } from 'path';
 import { findArtifactPath } from './lib/isa-utils';
+import { getPaiDir } from './lib/paths';
 
-const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude', 'PAI');
+const BASE_DIR = getPaiDir();
 const MEMORY_DIR = join(BASE_DIR, 'MEMORY');
 const STATE_DIR = join(MEMORY_DIR, 'STATE');
 const WORK_DIR = join(MEMORY_DIR, 'WORK');

--- a/Releases/v5.0.0/.claude/hooks/PromptProcessing.hook.ts
+++ b/Releases/v5.0.0/.claude/hooks/PromptProcessing.hook.ts
@@ -31,7 +31,7 @@ import { inference } from '../PAI/TOOLS/Inference';
 import { getIdentity, getPrincipal } from './lib/identity';
 import { isValidWorkingTitle, getWorkingFallback, trimToValidTitle } from './lib/output-validators';
 import { setTabState, getSessionOneWord } from './lib/tab-setter';
-import { paiPath } from './lib/paths';
+import { paiPath, getPaiDir } from './lib/paths';
 import { updateSessionNameInWorkJson, upsertSession } from './lib/isa-utils';
 import { pushStateToTargets } from './lib/observability-transport';
 
@@ -75,7 +75,7 @@ function appendPromptProcessingTelemetry(entry: Record<string, unknown>): void {
 
 // ── Constants ──
 
-const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude', 'PAI');
+const BASE_DIR = getPaiDir();
 const SESSION_NAMES_PATH = paiPath('MEMORY', 'STATE', 'session-names.json');
 const LOCK_PATH = SESSION_NAMES_PATH + '.lock';
 const MIN_PROMPT_LENGTH = 3;

--- a/Releases/v5.0.0/.claude/hooks/SatisfactionCapture.hook.ts
+++ b/Releases/v5.0.0/.claude/hooks/SatisfactionCapture.hook.ts
@@ -31,6 +31,7 @@ import { getLearningCategory } from './lib/learning-utils';
 import { getISOTimestamp, getPSTComponents } from './lib/time';
 import { captureFailure } from '../PAI/TOOLS/FailureCapture';
 import { addRatingPulse } from './lib/isa-utils';
+import { getPaiDir } from './lib/paths';
 
 // ── Types ──
 
@@ -63,7 +64,7 @@ interface SentimentResult {
 
 // ── Constants ──
 
-const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude', 'PAI');
+const BASE_DIR = getPaiDir();
 const SIGNALS_DIR = join(BASE_DIR, 'MEMORY', 'LEARNING', 'SIGNALS');
 const RATINGS_FILE = join(SIGNALS_DIR, 'ratings.jsonl');
 const LAST_RESPONSE_CACHE = join(BASE_DIR, 'MEMORY', 'STATE', 'last-response.txt');

--- a/Releases/v5.0.0/.claude/hooks/SessionCleanup.hook.ts
+++ b/Releases/v5.0.0/.claude/hooks/SessionCleanup.hook.ts
@@ -38,8 +38,9 @@ import { join } from 'path';
 import { getISOTimestamp } from './lib/time';
 import { setTabState, cleanupKittySession } from './lib/tab-setter';
 import { readRegistry, writeRegistry, findArtifactPath } from './lib/isa-utils';
+import { getPaiDir } from './lib/paths';
 
-const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude', 'PAI');
+const BASE_DIR = getPaiDir();
 const MEMORY_DIR = join(BASE_DIR, 'MEMORY');
 const STATE_DIR = join(MEMORY_DIR, 'STATE');
 const WORK_DIR = join(MEMORY_DIR, 'WORK');

--- a/Releases/v5.0.0/.claude/hooks/WorkCompletionLearning.hook.ts
+++ b/Releases/v5.0.0/.claude/hooks/WorkCompletionLearning.hook.ts
@@ -54,8 +54,9 @@ import { join, dirname } from 'path';
 import { getISOTimestamp, getPSTDate } from './lib/time';
 import { getLearningCategory } from './lib/learning-utils';
 import { findArtifactPath } from './lib/isa-utils';
+import { getPaiDir } from './lib/paths';
 
-const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude', 'PAI');
+const BASE_DIR = getPaiDir();
 const MEMORY_DIR = join(BASE_DIR, 'MEMORY');
 const STATE_DIR = join(MEMORY_DIR, 'STATE');
 const WORK_DIR = join(MEMORY_DIR, 'WORK');

--- a/Releases/v5.0.0/.claude/hooks/handlers/UpdateCounts.ts
+++ b/Releases/v5.0.0/.claude/hooks/handlers/UpdateCounts.ts
@@ -171,7 +171,7 @@ function getCounts(paiDir: string): Counts {
     workflows: countWorkflowFiles(join(getClaudeDir(), 'skills')),
     hooks: countHooks(paiDir),
     signals: countFilesRecursive(join(paiDir, 'MEMORY/LEARNING'), '.md'),
-    files: countFilesRecursive(join(paiDir, 'PAI/USER')),
+    files: countFilesRecursive(join(paiDir, 'USER')),
     work: countSubdirs(join(paiDir, 'MEMORY/WORK')),
     sessions: countFilesRecursive(join(paiDir, 'MEMORY'), '.jsonl'),
     research: countFilesRecursive(join(paiDir, 'MEMORY/RESEARCH'), '.md') +

--- a/Releases/v5.0.0/.claude/hooks/lib/paths.sh
+++ b/Releases/v5.0.0/.claude/hooks/lib/paths.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# Centralized Path Resolution — bash mirror of hooks/lib/paths.ts
+#
+# Two root directories:
+# - Claude home (~/.claude or $CLAUDE_CONFIG_DIR) — Claude Code: settings,
+#   skills, hooks, commands, agents
+# - PAI_DIR (subpath inside Claude home, default 'PAI') — PAI data: MEMORY,
+#   Algorithm, Tools, USER
+#
+# Sourcing (single form, used everywhere — including inside hooks/):
+#   . "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/lib/paths.sh"
+# The bootstrap line IS the resolution it implements: same CLAUDE_CONFIG_DIR
+# fallback contract, so multi-account configs keep working at source time.
+#
+# Functions return paths via stdout. assert_absolute prints to stderr and
+# returns 1 on failure; callers decide whether to exit.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Idempotent sourcing guard
+[ -n "${_PAI_PATHS_SH_LOADED:-}" ] && return 0
+_PAI_PATHS_SH_LOADED=1
+
+# expand_path: expand leading $HOME / ${HOME} / ~ to actual $HOME.
+# settings.json env values are stored literally; bash callers must expand.
+expand_path() {
+    local p="$1"
+    p="${p/#\$\{HOME\}/$HOME}"
+    p="${p/#\$HOME/$HOME}"
+    p="${p/#\~/$HOME}"
+    printf '%s\n' "$p"
+}
+
+# assert_absolute: enforce that a resolved directory is absolute.
+# Mirrors paths.ts assertAbsolute(). Prints to stderr and returns 1 on fail.
+assert_absolute() {
+    local dir="$1" source="$2"
+    if [ "${dir#/}" = "${dir}" ]; then
+        printf '[paths.sh] %s resolved to a non-absolute path: "%s" (env value likely unexpanded). cwd=%s\n' \
+            "$source" "$dir" "$PWD" >&2
+        return 1
+    fi
+    printf '%s\n' "$dir"
+}
+
+# get_claude_dir: CLAUDE_CONFIG_DIR (expanded) → $HOME/.claude
+get_claude_dir() {
+    local dir
+    if [ -n "${CLAUDE_CONFIG_DIR:-}" ]; then
+        dir="$(expand_path "$CLAUDE_CONFIG_DIR")"
+    else
+        dir="$HOME/.claude"
+    fi
+    assert_absolute "$dir" "get_claude_dir"
+}
+
+# get_pai_dir: PAI_DIR is a SUBPATH relative to Claude home, never absolute.
+# join(get_claude_dir(), PAI_DIR ?? 'PAI'). Mirrors paths.ts getPaiDir().
+get_pai_dir() {
+    local sub="${PAI_DIR:-PAI}"
+    # Treat whitespace-only as default
+    [ -z "${sub// /}" ] && sub="PAI"
+    local claude_dir
+    claude_dir="$(get_claude_dir)" || return 1
+    assert_absolute "${claude_dir}/${sub}" "get_pai_dir"
+}
+
+# get_projects_dir: PROJECTS_DIR (expanded) → $HOME/Projects
+get_projects_dir() {
+    local dir
+    if [ -n "${PROJECTS_DIR:-}" ]; then
+        dir="$(expand_path "$PROJECTS_DIR")"
+    else
+        dir="$HOME/Projects"
+    fi
+    assert_absolute "$dir" "get_projects_dir"
+}
+
+# get_settings_path: settings.json lives in Claude home
+get_settings_path() {
+    local claude_dir
+    claude_dir="$(get_claude_dir)" || return 1
+    printf '%s/settings.json\n' "$claude_dir"
+}
+
+# get_env_path: authoritative .env at Claude home root
+get_env_path() {
+    local claude_dir
+    claude_dir="$(get_claude_dir)" || return 1
+    printf '%s/.env\n' "$claude_dir"
+}
+
+# pai_path: join args under PAI_DIR. pai_path "MEMORY" "STATE" → $PAI/MEMORY/STATE
+pai_path() {
+    local base
+    base="$(get_pai_dir)" || return 1
+    local out="$base"
+    local seg
+    for seg in "$@"; do
+        out="${out}/${seg}"
+    done
+    printf '%s\n' "$out"
+}
+
+# get_hooks_dir / get_skills_dir / get_memory_dir
+get_hooks_dir() {
+    local claude_dir
+    claude_dir="$(get_claude_dir)" || return 1
+    printf '%s/hooks\n' "$claude_dir"
+}
+
+get_skills_dir() {
+    local claude_dir
+    claude_dir="$(get_claude_dir)" || return 1
+    printf '%s/skills\n' "$claude_dir"
+}
+
+get_memory_dir() {
+    pai_path "MEMORY"
+}

--- a/Releases/v5.0.0/.claude/hooks/lib/paths.ts
+++ b/Releases/v5.0.0/.claude/hooks/lib/paths.ts
@@ -26,24 +26,74 @@ export function expandPath(path: string): string {
 }
 
 /**
- * Get the PAI data directory (expanded)
- * Priority: PAI_DIR env var (expanded) → ~/.claude/PAI
+ * Enforce that a resolved directory is absolute.
+ *
+ * settings.json `env` values are stored literally — Claude Code does not
+ * shell-expand them. A path-like env var such as `${HOME}/.claude/PAI` that is
+ * never expanded is non-absolute, and `path.join` silently rebases it onto
+ * `process.cwd()`, scattering writes into whatever directory the session was
+ * launched from. Fail loudly here instead of misrouting silently.
  */
-export function getPaiDir(): string {
-  const envPaiDir = process.env.PAI_DIR;
-
-  if (envPaiDir) {
-    return expandPath(envPaiDir);
+function assertAbsolute(dir: string, source: string): string {
+  if (!dir.startsWith('/')) {
+    throw new Error(
+      `[paths] ${source} resolved to a non-absolute path: "${dir}" ` +
+        `(env value likely unexpanded). cwd=${process.cwd()}`,
+    );
   }
-
-  return join(homedir(), '.claude', 'PAI');
+  return dir;
 }
 
 /**
- * Get the Claude Code home directory (~/.claude)
+ * Get the Claude Code home directory.
+ * Priority: CLAUDE_CONFIG_DIR env var (expanded) → ~/.claude
+ *
+ * `CLAUDE_CONFIG_DIR` is the official Claude Code override for the config
+ * directory (settings, credentials, session history, plugins) — e.g. for
+ * running multiple accounts side by side. Honor it; fall back to ~/.claude.
  */
 export function getClaudeDir(): string {
-  return join(homedir(), '.claude');
+  const override = process.env.CLAUDE_CONFIG_DIR;
+  const dir = override ? expandPath(override) : join(homedir(), '.claude');
+  return assertAbsolute(dir, 'getClaudeDir');
+}
+
+/**
+ * Get the PAI data directory.
+ *
+ * PAI_DIR is, by definition, a SUBPATH relative to the Claude home directory —
+ * never an absolute path. getPaiDir() ≡ join(getClaudeDir(), PAI_DIR ?? 'PAI').
+ *
+ * This makes "PAI data lives inside Claude home" a structural invariant rather
+ * than a coincidence of an env value, so a CLAUDE_CONFIG_DIR override
+ * propagates to PAI data automatically. The env var remains usable for
+ * swapping PAI dirs (e.g. PAI_DIR='experiments/PAI-v2'), always rooted in
+ * Claude home.
+ *
+ * NOTE: an absolute or ${HOME}-style PAI_DIR is NOT supported by design. Such a
+ * value joins as a literal subpath and the absolute backstop below will catch
+ * a non-absolute result only if getClaudeDir() itself is broken; a stray
+ * absolute-looking PAI_DIR instead yields an obviously-wrong visible path
+ * (not a silent cwd rebase). settings.json must set PAI_DIR='PAI' (or omit it).
+ */
+export function getPaiDir(): string {
+  // Treat empty/unset PAI_DIR as "use default" — `??` alone would let
+  // PAI_DIR='' collapse PAI data into Claude home.
+  const sub = process.env.PAI_DIR?.trim() || 'PAI';
+  const dir = join(getClaudeDir(), sub);
+  return assertAbsolute(dir, 'getPaiDir');
+}
+
+/**
+ * Get the user's projects directory (expanded)
+ * Priority: PROJECTS_DIR env var (expanded) → ~/Projects
+ *
+ * Companion to getPaiDir(): same literal-env hazard, same resolution contract.
+ */
+export function getProjectsDir(): string {
+  const env = process.env.PROJECTS_DIR;
+  const dir = env ? expandPath(env) : join(homedir(), 'Projects');
+  return assertAbsolute(dir, 'getProjectsDir');
 }
 
 /**

--- a/Releases/v5.0.0/.claude/settings.json
+++ b/Releases/v5.0.0/.claude/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "env": {
-    "PAI_DIR": "${HOME}/.claude/PAI",
+    "PAI_DIR": "PAI",
     "PROJECTS_DIR": "${HOME}/Projects",
     "BASH_DEFAULT_TIMEOUT_MS": "600000",
     "API_TIMEOUT_MS": "1800000",
@@ -1299,7 +1299,7 @@
     },
     "_httpHooks": "Pulse HTTP routes on pai:31337 (managed by Pulse process). SecurityPipeline: command hook on Bash/Write/Edit/Read (exit(2) hard-block). SkillGuard + AgentGuard: HTTP hooks via Pulse routes (fail-open).",
     "_env": {
-      "PAI_DIR": "Root directory for PAI data (~/.claude/PAI). Memory, Algorithm, Tools, USER config. Hooks and skills stay in ~/.claude.",
+      "PAI_DIR": "PAI data subdirectory relative to the Claude home dir (default 'PAI' → ~/.claude/PAI, or $CLAUDE_CONFIG_DIR/PAI). A subpath, not an absolute path. Memory, Algorithm, Tools, USER config. Hooks and skills stay in Claude home.",
       "PROJECTS_DIR": "Base directory for projects. Use ${PROJECTS_DIR}/PAI for PAI repo, ${PROJECTS_DIR}/fabric for fabric, etc.",
       "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "Maximum tokens for Claude responses. Higher values allow longer outputs but cost more.",
       "BASH_DEFAULT_TIMEOUT_MS": "Default timeout for bash commands in milliseconds."


### PR DESCRIPTION
## Description

### Summary

settings.json `env` values are applied to the process environment as **literal strings** —
Claude Code does not shell-expand them. `PAI_DIR="${HOME}/.claude/PAI"` is therefore stored
verbatim. ~33 hooks/tools read `process.env.PAI_DIR` raw with a `|| join(...)` fallback that
never fires (the literal is truthy), producing a **non-absolute** path that `path.join`
silently rebases onto `process.cwd()`. PAI memory/state/learning writes are misrouted into
whatever directory the session was launched from.

This PR routes all such consumers through the existing `hooks/lib/paths.ts` helpers
(`getPaiDir` / `getClaudeDir` / new `getProjectsDir`), makes `getClaudeDir()` honor the
official `CLAUDE_CONFIG_DIR` override, and adds a fail-fast guard so a non-absolute resolved
path throws instead of silently misrouting.

**It also redefines `PAI_DIR` as a subpath of Claude home** and changes the shipped
settings.json value `PAI_DIR=${HOME}/.claude/PAI` → `PAI_DIR=PAI`. `getPaiDir()` becomes
`join(getClaudeDir(), PAI_DIR ?? 'PAI')`. Rationale: this makes "PAI data lives inside Claude
home" a structural invariant rather than a coincidence of an env value, so the official
`CLAUDE_CONFIG_DIR` override propagates to PAI data automatically (multi-account works
end-to-end), and the maintainer's `PAI_DIR` use (swapping PAI dirs) is preserved via relative
subpaths (e.g. `PAI_DIR=experiments/PAI-v2`), always rooted in Claude home.

**This is a breaking change** (not backward compatible): the resolver change and the
settings.json change are coupled and must land together — an old absolute `PAI_DIR` value
with the new resolver produces `~/.claude/${HOME}/.claude/PAI`. Existing installs must update
`env.PAI_DIR` to `PAI` (or remove it; the default is `PAI`). This is a deliberate redesign of
the `PAI_DIR` contract; **the maintainer should weigh the precedence/migration approach and
is invited to comment** — an alternative (keep `PAI_DIR` absolute-or-expanded, accept that
`CLAUDE_CONFIG_DIR` only governs PAI data via the unset-fallback) is viable and lower-churn
but leaves multi-account incomplete for PAI data. We propose the subpath redesign as the
more-correct end state; open to the alternative if preferred.

### Reproduction (platform-independent — runnable on macOS too)

In any Claude Code session launched with PAI's shipped settings.json:

```
$ env | grep -E 'HOME=|PAI_DIR='
HOME=/Users/you                 # shell-expanded (set by the launching shell)
PAI_DIR=${HOME}/.claude/PAI     # LITERAL — Claude Code did not expand it
```

```
$ bun -e 'import {isAbsolute} from "path"; console.log(isAbsolute(process.env.PAI_DIR))'
false                           # → path.join rebases this onto process.cwd()
```

The mechanism (env-block no-expand; Node `path` POSIX semantics identical on macOS/Linux) is
platform-independent. The defect exists on macOS too; it is merely **masked** when the working
directory happens to be `~/.claude` (the misrouted relative path lands harmlessly inside
`~/.claude/${HOME}/...`). It becomes visible whenever the cwd is anything else.

### Evidence

- **Empirical:** live session env shows `HOME` expanded but `PAI_DIR` literal (above).
- **Node behavior:** `path.isAbsolute("${HOME}/...") === false`; `path.join`/`resolve` rebase
  on `process.cwd()` — documented Node `path` behavior, identical on Darwin and Linux.
- **Documentation asymmetry (not an affirmative claim that env is non-expanding — the docs
  are silent on `env`):** Claude Code documents `${VAR}`/`~` expansion as **opt-in for
  specific settings** — HTTP hook headers (`$VAR`/`${VAR}` interpolation, `hooks.md`),
  `autoMemoryDirectory` (`~/`-prefix, `settings.md`). The `env` block has no such language.
  Expansion is opt-in per-setting; `env` is not opted in. Empirically confirmed (above).
- **Regression provenance:** v4.0.3 was internally consistent (`PAI_DIR=${HOME}/.claude`,
  `MEMORY` at `~/.claude/MEMORY`, all fallbacks `~/.claude`, masked by unconditional
  `chdir(~/.claude)`). v5.0.0 moved `MEMORY` under `PAI/` and updated the env value to
  `${HOME}/.claude/PAI` but only migrated 25/33 consumer fallbacks — 8 left stale at
  `~/.claude`. This is a v5.0.0 regression from an incomplete restructure.

### How this was discovered (context — NOT part of this PR)

This surfaced via an unrelated **local** modification (not proposed here, not a dependency of
this fix): a downstream user changed their `pai.ts` launcher so that instead of always
`chdir`-ing to `~/.claude` on startup, it starts in `~/scratch-workspace` (or the current
directory when that directory has applicable write permissions in settings). That change is
sound and orthogonal — it does **not** introduce the bug. Upstream's unconditional
`process.chdir(CLAUDE_DIR)` was, in effect, **accidentally masking** this latent defect: with
cwd always pinned to `~/.claude`, the misrouted relative path resolved to
`~/.claude/${HOME}/.claude/PAI/...` — still wrong, but buried inside `~/.claude` where it
went unnoticed. The moment startup cwd is anything other than `~/.claude`, the misrouted
writes land in the working directory (e.g. an unrelated project repo), making the
pre-existing v5 regression visible.

The takeaway for review: **this PR neither contains nor requires any launcher/CWD change.**
The CWD change was merely the lens that exposed a bug already present in upstream v5.0.0. The
fix (consumer-side resolution via `paths.ts`) is correct regardless of working directory —
which is precisely the property the codebase should have and currently does not.

### Approach

All affected consumers are routed through the existing `hooks/lib/paths.ts` helpers rather
than reading `process.env.*` raw:

- `getClaudeDir()` — honors `CLAUDE_CONFIG_DIR` (official override), else `~/.claude`.
- `getPaiDir()` — `join(getClaudeDir(), PAI_DIR ?? 'PAI')`. `PAI_DIR` is **redefined as a
  subpath** of Claude home; no absolute branch. `CLAUDE_CONFIG_DIR` therefore propagates to
  PAI data automatically.
- `getProjectsDir()` — new; `PROJECTS_DIR` expanded, default `~/Projects`.
- All three hard-throw on a non-absolute resolved path (fail loud, not silent-misroute).
- `getProjectsDir`'s `PROJECTS_DIR` still uses `expandPath` (it is not redefined as a
  subpath — it points outside Claude home by nature; only `PAI_DIR` becomes a subpath).

Coupled settings.json change: `env.PAI_DIR` `${HOME}/.claude/PAI` → `PAI`. **Breaking:** the
resolver and settings change must land together; existing installs migrate `PAI_DIR` to `PAI`
(or remove it). Not retroactive without the settings change. See the diff for per-file
changes.

### Bash-side companion

Same bug class affected shell scripts that read `$PAI_DIR` raw and silently rebased onto cwd
— the visible symptom was statusline LEARNING signals going blank when sessions launch from
a working dir outside `~/.claude/`.

- New `hooks/lib/paths.sh` — sourceable bash mirror of `paths.ts`. Exports `expand_path`,
  `assert_absolute`, `get_claude_dir`, `get_pai_dir`, `get_projects_dir`, `get_settings_path`,
  `get_env_path`, `pai_path`, `get_hooks_dir`, `get_skills_dir`, `get_memory_dir`.
- Sourcing convention used everywhere including inside `hooks/`:
  `. "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/lib/paths.sh"` — the bootstrap line itself
  encodes the same fallback contract the helper implements.
- Consumers converted: `PAI/statusline-command.sh` (bootstrap, `ALGO_VERSION` first rung,
  projects glob, credentials read), `PAI/PULSE/manage.sh` (`PULSE_DIR`), and
  `PAI/PULSE/MenuBar/install.sh` (logs path).
- `assert_absolute` prints to stderr and returns 1 (caller decides exit) — matches TS
  `assertAbsolute` throw semantics but bash-idiomatic. Idempotent re-source via
  `_PAI_PATHS_SH_LOADED`.

### Out of scope (intentional)

Separate follow-ups, not bundled to keep this reviewable:
- `PAI_CONFIG_DIR` (6 consumers) contradicts `getEnvPath()`'s declared canonical `.env`
  location, plus a stale duplicate `~/.config/PAI/.env`. Different severity (credential
  resolution). Separate PR.
- 12 `CLAUDE_DIR` consts + `process.env.HOME` concat siblings are correct today but bypass
  the helper / `CLAUDE_CONFIG_DIR` — behavior-neutral consistency refactor. Separate PR.
- `PAI_DIR` → `PAI_HOME` rename (the name invites the "which dir? cwd?" confusion that
  caused the v5 mismigration). Deferred.

### Observations for maintainer consideration (not changed by this PR)

1. **CLAUDE.md path rule** ("Use `${PAI_DIR}`, `${HOME}` … never `${HOME}/.`"): the
   `${HOME}` vs `${HOME}/` trailing-slash distinction is irrelevant to `path.join`/`resolve`
   (only naive string-concat, and `//` is POSIX-harmless), and its premise (that `${HOME}`
   works in settings.json) is incorrect. Suggest restating as the real contract: env values
   are literal; resolve path env vars via `paths.ts` helpers; never read `process.env.*` raw
   for paths.
2. **Optional installer hardening:** `PAI-Install/engine/config-gen.ts` could emit
   pre-expanded absolute paths into the *generated* per-user settings.json (never the
   template) as defense-in-depth. Non-substitutive — consumer-side resolution is the fix.
3. **`skills/_PAI/` phantom (NOTE D):** `skills/_PAI/` is referenced by live code
   (`IntegrityMaintenance.ts` → `CreateUpdate.ts`, spawned via `SystemIntegrity` handler)
   and ≥3 docs/skills, but is **absent from the release tree**. The
   `IntegrityMaintenance`→`CreateUpdate` background spawn fails silently against the missing
   file. Likely a release-scrub or packaging gap rather than an intentional removal — flagged
   for the maintainer; unrelated to this PR's bug.
4. **From the bash-side companion**, two items deferred: (a) the statusline's `ALGO_VERSION`
   hardened fallback ladder hardcodes `/Users/$(id -un)/...` (macOS-only); a parallel
   `/home/` rung would extend the same broken-env hardening to Linux hosts. (b)
   `PAI_CONFIG_DIR/.env` (statusline line 107) follows the canonical-env-path question
   already covered in **Out of scope** above (`PAI_CONFIG_DIR` bullet).

### Testing

- `grep -rn 'process\.env\.PAI_DIR\s*\(\|\|\|??\)' hooks/ PAI/` → only `paths.ts:33` (the
  one correct consumer feeding `expandPath`).
- Helper smoke tests: `getPaiDir()`/`getClaudeDir()`/`getProjectsDir()` resolve absolute for
  `${HOME}`/`$HOME`/`~`/absolute input forms; throw on non-absolute.
- Live: launch from a non-`~/.claude` cwd, trigger a memory-writing hook, confirm no
  `${HOME}/` directory is created and writes land in the real PAI dir.
- Typecheck clean.
- Bash side: helper smoke tests (function exports, `expand_path` / `get_claude_dir` /
  `get_pai_dir` against `CLAUDE_CONFIG_DIR` override and `PAI_DIR=PAI`), live statusline
  render from non-`~/.claude` cwd, idempotent re-source, all four edited shell scripts
  syntax-check clean.
