### PR TITLE
fix(wiki): resolve Algorithm directory case-insensitively

### DIFF
--- a/Releases/v5.0.0/.claude/PAI/PULSE/modules/wiki.ts
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/modules/wiki.ts
@@ -41,7 +41,40 @@ const DOCUMENTATION_DIR = join(PAI_DIR, "DOCUMENTATION")
 const KNOWLEDGE_DIR = join(PAI_DIR, "MEMORY", "KNOWLEDGE")
 const BOOKMARKS_DIR = join(PAI_DIR, "MEMORY", "BOOKMARKS")
 const BOOKMARKS_CSV = join(BOOKMARKS_DIR, "bookmarks.csv")
-const ALGORITHM_DIR = join(PAI_DIR, "Algorithm")
+// Resolve the Algorithm directory case-insensitively. The v6.3.0 doctrine uses
+// `ALGORITHM/` (all-caps) while older defaults used `Algorithm/` — on Linux
+// (case-sensitive FS), a string-equality mismatch silently empties the Wiki's
+// Algorithm view. Scan PAI_DIR once at module init.
+function resolveAlgorithmDir(paiDir: string): string | null {
+  if (!existsSync(paiDir)) return null
+  const entries = readdirSync(paiDir, { withFileTypes: true })
+  const exact = entries.find(
+    (e) => e.name === "Algorithm" && (e.isDirectory() || e.isSymbolicLink()),
+  )
+  if (exact) return join(paiDir, exact.name)
+  const variants = entries.filter(
+    (e) =>
+      e.name.toLowerCase() === "algorithm" &&
+      (e.isDirectory() || e.isSymbolicLink()),
+  )
+  if (variants.length > 0) {
+    // Deterministic tie-break: prefer `ALGORITHM` (v6.3.0 doctrine spelling),
+    // else raw byte-order (locale-independent, stable across Node versions).
+    // readdirSync order is FS-implementation-defined; never trust it.
+    variants.sort((a, b) => {
+      if (a.name === "ALGORITHM") return -1
+      if (b.name === "ALGORITHM") return 1
+      return a.name < b.name ? -1 : a.name > b.name ? 1 : 0
+    })
+    return join(paiDir, variants[0].name)
+  }
+  console.warn(
+    `[wiki] PAI Algorithm directory not found in ${paiDir} — Algorithm view will be empty`,
+  )
+  return null
+}
+
+const ALGORITHM_DIR: string | null = resolveAlgorithmDir(PAI_DIR)
 const SKILLS_DIR = join(HOME, ".claude", "skills")
 const HOOKS_DIR = join(HOME, ".claude", "hooks")
 const SETTINGS_PATH = join(HOME, ".claude", "settings.json")
@@ -177,7 +210,7 @@ function systemDocMetadata(filePath: string): { slug: string; group: string } | 
     return { slug: `${group}__${bareSlug}`, group }
   }
 
-  if (filePath.startsWith(ALGORITHM_DIR)) {
+  if (ALGORITHM_DIR != null && filePath.startsWith(ALGORITHM_DIR)) {
     const filename = basename(filePath)
     return {
       slug: `Algorithm__${stripMarkdownExtension(filename)}`,
@@ -528,7 +561,7 @@ function indexSystemDocs(): void {
     indexSystemDoc(filePath)
   }
 
-  if (!existsSync(ALGORITHM_DIR)) return
+  if (ALGORITHM_DIR == null || !existsSync(ALGORITHM_DIR)) return
 
   try {
     const algorithmFiles = readdirSync(ALGORITHM_DIR, { withFileTypes: true })


### PR DESCRIPTION
# fix(wiki): resolve Algorithm directory case-insensitively

## Problem

`Releases/v5.0.0/.claude/PAI/PULSE/modules/wiki.ts` hard-codes the Algorithm directory path at module load time:

```ts
// wiki.ts:44
const ALGORITHM_DIR = join(PAI_DIR, "Algorithm")
```

On case-insensitive file systems (macOS HFS+/APFS) this works for any case variant. On case-sensitive file systems (Linux ext4/xfs/zfs — all production servers, all VMs, all containerized installs) this fails when the real directory is `ALGORITHM/` — which is what the PAI v6.3.0 Algorithm doctrine specifies throughout (`PAI/ALGORITHM/LATEST`, `PAI/ALGORITHM/v{VERSION}.md`).

**Symptom:** the existence gate at `wiki.ts:531` (`if (!existsSync(ALGORITHM_DIR)) return`) returns false on Linux installs that follow current doctrine, and Pulse silently drops Algorithm documentation from the Wiki view. No error, no warning — just a missing section.

**Reproduction on Linux:**

```bash
# Fresh install, doctrine-spelled directory
mkdir -p ~/.claude/PAI/ALGORITHM
echo "# v6.3.0" > ~/.claude/PAI/ALGORITHM/v6.3.0.md
# Start Pulse and open http://localhost:31337/wiki
# Expected: Algorithm view shows the doc
# Actual:   Algorithm view is empty
```

The defect was masked on the surfacing user's host by an out-of-band workaround symlink (`~/.claude/PAI/Algorithm -> ALGORITHM`), which is exactly the kind of brittle thing this PR removes the need for.

## Fix

Replace the single hard-coded constant with a small `resolveAlgorithmDir` function that scans `PAI_DIR` once at module init:

- **Prefer exact `Algorithm/`** match if present — this preserves macOS users' case and yields byte-identical behavior to the pre-patch code for them.
- **Fall back to any case-variant** of `algorithm` if the exact match is missing — handles `ALGORITHM/` (current doctrine) and any future case drift.
- **Emit a clear `console.warn`** if no variant is present, naming `PAI_DIR` for debuggability. Does NOT throw — preserves the existing "Algorithm docs are optional when PAI is partially installed" graceful-degrade.

`ALGORITHM_DIR`'s type becomes `string | null` to reflect the not-found path explicitly. The two call sites that consumed it as `string` gain null-safety:

- `wiki.ts:180` — `if (filePath.startsWith(ALGORITHM_DIR))` becomes `if (ALGORITHM_DIR != null && filePath.startsWith(ALGORITHM_DIR))`
- `wiki.ts:531` — `if (!existsSync(ALGORITHM_DIR)) return` becomes `if (ALGORITHM_DIR == null || !existsSync(ALGORITHM_DIR)) return`

The rest of the file is unchanged.

## Design rationale

1. **Resolve once at module init, not per-call.** wiki.ts loads at process start; the resolver does its FS scan exactly once. Per-call resolution would multiply syscall cost on every Wiki API request.
2. **No `realpathSync`.** Some users already work around the defect with symlinks (e.g., `Algorithm -> ALGORITHM`). `realpathSync` would collapse those silently. Name-based comparison via `readdirSync` is symlink-safe.
3. **No new dependencies.** Uses only `readdirSync`, `existsSync`, and `join` — all already imported.
4. **Minimal diff.** +26 / -3 lines, confined to the resolution surface. Route handlers, MiniSearch indexing, file-watcher logic, slug generation: all untouched.
5. **TypeScript strict-mode clean.** No `// @ts-ignore`, no `as any`, explicit type annotations.

## Test evidence

Verified via a 9-assertion synthetic harness covering the case matrix:

| Scenario | Real directory | Expected | Pass |
|---|---|---|---|
| macOS conventional | `Algorithm/` only      | `<dir>/Algorithm`              | ✓ |
| v6.3.0 doctrine    | `ALGORITHM/` only      | `<dir>/ALGORITHM`              | ✓ |
| Edge case          | `algorithm/` only      | `<dir>/algorithm`              | ✓ |
| Tie-break primary  | `ALGORITHM/` + `algorithm/` (no `Algorithm/`) | `<dir>/ALGORITHM` (doctrine wins) | ✓ |
| Tie-break fallback | `AlGoRiThM/` + `algorithm/` (no exact, no all-caps) | `<dir>/AlGoRiThM` (byte-order: uppercase first) | ✓ |
| Not present        | (no algorithm-named)   | `null` + `console.warn`        | ✓ |
| PAI_DIR missing    | (no PAI_DIR itself)    | `null` (no warn — early return) | ✓ |

Harness output: `9 passed, 0 failed`. The harness file is the resolver code copied verbatim (so the test exercises the same logic the patch introduces).

### Deterministic tie-break

When multiple case-variants exist with no exact `Algorithm/`, the resolver:
1. Prefers `ALGORITHM/` (matches the v6.3.0 doctrine spelling).
2. Otherwise falls back to byte-order comparison (locale-independent, stable across Node versions). Uppercase letters sort before lowercase by ASCII, so `AlGoRiThM/` wins over `algorithm/` deterministically.

This avoids depending on `readdirSync` order (which is FS-implementation-defined) or `localeCompare` (which is locale-dependent and can vary across Node versions / `LANG` settings).

## Backwards compatibility

- **macOS users with `Algorithm/`** — zero behavior change. The exact-match branch returns `Algorithm/` byte-identically to the pre-patch code.
- **macOS users with `ALGORITHM/`** — case-folded FS already handled this; resolver now resolves it explicitly. No regression.
- **Linux users with `Algorithm/`** — zero behavior change.
- **Linux users with `ALGORITHM/`** — defect is fixed; Algorithm view populates.
- **Linux users with `algorithm/`** — edge case now handled; Algorithm view populates.
- **Anyone with no Algorithm directory** — gets a clear `console.warn` at startup instead of silent emptiness. Detectability is doctrine.

## Notes

- No related upstream issue exists at time of submission. The defect was surfaced during a Linux evaluation of v5.0.0; rather than file an issue and then a PR, the PR itself documents the case matrix.
- Diff is `Releases/v5.0.0/.claude/PAI/PULSE/modules/wiki.ts` only; nothing else touched.
- Branch base: tag `v5.0.0`.
