### PR TITLE
fix(pulse): disable assistant-* cron jobs until Assistant module ships (fixes #1180)

### DIFF
--- a/Releases/v5.0.0/.claude/PAI/PULSE/PULSE.toml
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/PULSE.toml
@@ -103,7 +103,9 @@ schedule = "*/30 * * * *"
 type = "script"
 command = "bun run Assistant/checks/heartbeat.ts"
 output = "voice"
-enabled = true
+# Disabled in v5.0.0: Assistant/checks/heartbeat.ts is not shipped — see #1180.
+# Re-enable once the Assistant module lands.
+enabled = false
 
 [[job]]
 name = "assistant-tasks"
@@ -111,7 +113,9 @@ schedule = "* * * * *"
 type = "script"
 command = "bun run Assistant/checks/tasks.ts"
 output = "voice"
-enabled = true
+# Disabled in v5.0.0: Assistant/checks/tasks.ts is not shipped — see #1180.
+# Re-enable once the Assistant module lands.
+enabled = false
 
 [[job]]
 name = "assistant-diary"
@@ -119,7 +123,9 @@ schedule = "0 23 * * *"
 type = "script"
 command = "bun run Assistant/checks/diary.ts"
 output = "log"
-enabled = true
+# Disabled in v5.0.0: Assistant/checks/diary.ts is not shipped — see #1180.
+# Re-enable once the Assistant module lands.
+enabled = false
 
 [[job]]
 name = "assistant-growth"
@@ -127,7 +133,9 @@ schedule = "0 4 * * 0"
 type = "script"
 command = "bun run Assistant/checks/growth.ts"
 output = "log"
-enabled = true
+# Disabled in v5.0.0: Assistant/checks/growth.ts is not shipped — see #1180.
+# Re-enable once the Assistant module lands.
+enabled = false
 
 # ── Life Dashboard (Phase 0) ──
 


### PR DESCRIPTION
## What

Disables the four `assistant-*` cron jobs in `Releases/v5.0.0/.claude/PAI/PULSE/PULSE.toml` (`assistant-heartbeat`, `assistant-tasks`, `assistant-diary`, `assistant-growth`) so they stop firing on fresh PAI 5.0.0 installs.

Closes #1180.

## Why

PAI 5.0.0 ships `PULSE.toml` with four cron jobs whose commands point at `Assistant/checks/{heartbeat,tasks,diary,growth}.ts`, but the `Assistant/` directory was never committed to the v5.0.0 release. On every fresh install, the cron loop produces:

```
{"level":"error","msg":"assistant-tasks failed",
 "error":"Error: Script exited 1: error: Module not found \"Assistant/checks/tasks.ts\"\n"}
```

`assistant-tasks` is on a `* * * * *` schedule — one failure every minute — and `/api/pulse/health` permanently shows the four jobs as failing. This was reported in #1180 (and overlaps with #1130, #1173).

## How

Single-file edit: flip `enabled = true` -> `enabled = false` on the four `assistant-*` job blocks and add a one-line comment pointing at this issue.

```diff
 name = "assistant-heartbeat"
 ...
 output = "voice"
-enabled = true
+# Disabled in v5.0.0: Assistant/checks/heartbeat.ts is not shipped — see #1180.
+# Re-enable once the Assistant module lands.
+enabled = false
```

(Same shape for `assistant-tasks`, `assistant-diary`, `assistant-growth`.)

## Scope kept narrow

- **Does NOT** touch the section-level `[da] enabled = true` toggle — that controls the module loader / dashboard endpoints reported in #1173 and should ship in its own PR.
- **Does NOT** delete the job blocks. Schedules, names and `command` strings are preserved so a single `enabled = false` -> `true` re-arms each job once the Assistant module lands.

## Verification

**Before** (fresh PAI 5.0.0 install, macOS Darwin 25.5):

```
$ curl -s http://localhost:31337/api/pulse/health | jq '.subsystems.cron.jobs[] | select(.result=="error")'
{ "name": "assistant-tasks",     "result": "error", "failures": 3 }
{ "name": "assistant-heartbeat", "result": "error", "failures": 3 }
{ "name": "assistant-diary",    "result": "error", "failures": 1 }
$ tail Pulse/logs/pulse-stderr.log | grep assistant
... assistant-tasks failed ... Module not found "Assistant/checks/tasks.ts" ...
```

**After** (same patch applied locally and Pulse restarted): the four `assistant-*` entries leave the failing-job list and `pulse-stderr.log` stops spamming the missing-module trace. The four `[[job]]` blocks remain in the file, just with `enabled = false`, so the cron loader skips them.

## Future-work (intentionally out of scope)

- #1173 — implement the actual Assistant module (`PULSE/Assistant/module.ts` + `PULSE/Assistant/checks/*.ts`) so these jobs can be re-armed.
- #1240 — clear stale cron failure metadata for jobs that are subsequently disabled in `PULSE.toml`.
- #1130 — `manage.sh` install timeout is a separate path.