### PR TITLE
feat(skills/AppleMail): macOS Mail.app integration with hard approval gate

### DIFF
--- a/Releases/v5.0.0/.claude/PAI/TOOLS/apple-mail.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/apple-mail.ts
@@ -1,0 +1,1098 @@
+#!/usr/bin/env bun
+// Apple Mail CLI — wraps macOS Mail.app via AppleScript (osascript).
+//
+// Read commands (autonomous, no approval gate):
+//   apple-mail accounts
+//   apple-mail mailboxes [--account NAME]
+//   apple-mail unread [--account NAME] [--limit N=20]
+//   apple-mail list <mailbox> [--account NAME] [--limit N=50]
+//   apple-mail search "<query>" [--account NAME] [--limit N=20]
+//   apple-mail fetch <id> [--full]
+//   apple-mail count <mailbox> [--account NAME] [--unread-only]
+//   apple-mail drafts [--limit N=20]
+//   apple-mail status
+//
+// Write commands (gated through Arthur policy apple_mail_send):
+//   apple-mail draft --to ADDR --subject "..." (--body-file PATH | --body-stdin)
+//                    [--cc ADDR] [--bcc ADDR] [--account NAME] [--html]
+//   apple-mail send  ... [--approval-token TOK]
+//   apple-mail reply <id> (--body-file PATH | --body-stdin) [--reply-all] [--approval-token TOK]
+//   apple-mail forward <id> --to ADDR (--body-file PATH | --body-stdin) [--approval-token TOK]
+//   apple-mail mark-read <id>[,<id>...]
+//   apple-mail mark-unread <id>[,<id>...]
+//   apple-mail move <id> --to-mailbox NAME [--account NAME]
+//
+// Approval flow for send/reply/forward:
+//   1. Without --approval-token: tool calls Arthur.evaluate(), receives CONFIRM,
+//      writes a pending-draft file, prints draft preview, pings Pulse + Telegram,
+//      exits 2.
+//   2. Approval token can be activated from any channel:
+//        - In Claude:  re-run with --approval-token TOK
+//        - In Pulse:   click pending notification (writes outcome file)
+//        - Telegram:   /approve-mail TOK (handler writes outcome file)
+//   3. Re-run with --approval-token TOK: tool reads pending+outcome files and
+//      ships the mail iff decision === "approve". Token expires after 30 min.
+//
+// No --force flag, no in-tool override. The gate is the tool.
+
+import { audit, evaluate } from "./Arthur.ts";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { randomBytes } from "node:crypto";
+
+// ─────────────────────────────── Platform guard ───────────────────────────────
+
+if (process.platform !== "darwin") {
+  process.stderr.write(
+    JSON.stringify({ error: "apple-mail requires macOS", code: "unsupported_platform" }) + "\n",
+  );
+  process.exit(2);
+}
+
+// ─────────────────────────────── Constants ───────────────────────────────
+
+const PAI_DIR = process.env.PAI_DIR ?? join(homedir(), ".claude", "PAI");
+const PENDING_DIR = join(PAI_DIR, "MEMORY", "STATE", "apple-mail-pending");
+const TOKEN_TTL_MS = 30 * 60 * 1000;
+const TELEGRAM_TOKEN = process.env.PAI_TELEGRAM_BOT_TOKEN;
+const TELEGRAM_CHAT = process.env.PAI_TELEGRAM_CHAT_ID;
+const PULSE_URL = "http://localhost:31337/notify";
+
+// Mailboxes excluded by default from cross-mailbox iteration (currently only `search`).
+// Override per-call with --include-junk, or globally via PAI_APPLE_MAIL_INCLUDE_MAILBOXES (comma list).
+const SKIP_MAILBOXES_DEFAULT: readonly string[] = [
+  // Junk / Spam / iCloud Mail Categories (macOS 26+)
+  "Junk", "Junk-E-Mail", "Junk E-mail", "Junk Email",
+  "Spam", "Bulk Mail",
+  "Sonstiges", "Werbung", "Newsletter", "Transaktionen", "Updates",
+  // Trash
+  "Trash", "Bin", "Deleted Items", "Deleted Messages",
+  "Papierkorb", "Gelöschte Nachrichten", "Gelöschte Objekte",
+  // Outbound / own mail
+  "Sent", "Sent Items", "Sent Messages",
+  "Gesendet", "Gesendete Nachrichten", "Gesendete Objekte",
+  "Drafts", "Entwürfe",
+];
+
+function getSkipMailboxes(): readonly string[] {
+  const env = process.env.PAI_APPLE_MAIL_INCLUDE_MAILBOXES;
+  if (!env) return SKIP_MAILBOXES_DEFAULT;
+  const include = new Set(env.split(",").map((s) => s.trim()).filter(Boolean));
+  return SKIP_MAILBOXES_DEFAULT.filter((m) => !include.has(m));
+}
+
+function asListLiteral(names: readonly string[]): string {
+  return "{" + names.map((n) => `"${escapeAS(n)}"`).join(", ") + "}";
+}
+
+if (!existsSync(PENDING_DIR)) mkdirSync(PENDING_DIR, { recursive: true, mode: 0o700 });
+
+const TOKEN_RE = /^[0-9a-f]{32}$/;
+
+function assertValidToken(token: string): void {
+  if (!TOKEN_RE.test(token)) {
+    audit({ event_type: "apple_mail_token_malformed", token_excerpt: token.slice(0, 8) });
+    process.stderr.write(
+      JSON.stringify({ error: "malformed approval token", code: "token_malformed" }) + "\n",
+    );
+    process.exit(2);
+  }
+}
+
+// ─────────────────────────────── Types ───────────────────────────────
+
+type Envelope = {
+  kind: "send" | "reply" | "forward";
+  to?: string;
+  cc?: string;
+  bcc?: string;
+  subject?: string;
+  body: string;
+  html?: boolean;
+  account?: string;
+  replyToId?: string;
+  replyAll?: boolean;
+  forwardId?: string;
+};
+
+type Pending = {
+  token: string;
+  envelope: Envelope;
+  created: string;
+  expires: string;
+};
+
+type Outcome = {
+  decision: "approve" | "reject";
+  approver: string;
+  decided: string;
+};
+
+// ─────────────────────────────── osascript wrapper ───────────────────────────────
+
+function osa(script: string): string {
+  const result = Bun.spawnSync(["osascript", "-e", script]);
+  const stderr = new TextDecoder().decode(result.stderr).trim();
+  const stdout = new TextDecoder().decode(result.stdout);
+  if (result.exitCode !== 0) {
+    throw new Error(`osascript failed (exit ${result.exitCode}): ${stderr || stdout}`);
+  }
+  return stdout;
+}
+
+function escapeAS(s: string): string {
+  // AppleScript string escaping: backslash + double-quote.
+  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function ensureMailRunning(): void {
+  try {
+    osa('tell application "System Events" to (name of processes) contains "Mail"');
+  } catch {
+    // ignore
+  }
+  osa('tell application "Mail" to activate');
+}
+
+// ─────────────────────────────── Pending state ───────────────────────────────
+
+function cleanupStaleTokens(): void {
+  if (!existsSync(PENDING_DIR)) return;
+  const now = Date.now();
+  for (const f of readdirSync(PENDING_DIR)) {
+    const p = join(PENDING_DIR, f);
+    try {
+      const age = now - statSync(p).mtimeMs;
+      if (age > TOKEN_TTL_MS + 60_000) {
+        unlinkSync(p);
+      }
+    } catch {
+      // ignore
+    }
+  }
+}
+
+function writePending(p: Pending): void {
+  const file = join(PENDING_DIR, `${p.token}.json`);
+  writeFileSync(file, JSON.stringify(p, null, 2), { mode: 0o600 });
+}
+
+function readPending(token: string): Pending | null {
+  const file = join(PENDING_DIR, `${token}.json`);
+  if (!existsSync(file)) return null;
+  return JSON.parse(readFileSync(file, "utf8")) as Pending;
+}
+
+function readOutcome(token: string): Outcome | null {
+  const file = join(PENDING_DIR, `${token}.outcome.json`);
+  if (!existsSync(file)) return null;
+  return JSON.parse(readFileSync(file, "utf8")) as Outcome;
+}
+
+function clearPending(token: string): void {
+  for (const suffix of [".json", ".outcome.json"]) {
+    const file = join(PENDING_DIR, `${token}${suffix}`);
+    if (existsSync(file)) unlinkSync(file);
+  }
+}
+
+// ─────────────────────────────── Notify channels ───────────────────────────────
+
+async function notifyPulse(message: string): Promise<void> {
+  try {
+    await fetch(PULSE_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message, voice_enabled: false, voice_id: "fTtv3eikoepIosk8dTZ5" }),
+    });
+  } catch (e) {
+    process.stderr.write(`[apple-mail] Pulse notify failed: ${(e as Error).message}\n`);
+  }
+}
+
+async function notifyTelegram(message: string): Promise<boolean> {
+  if (!TELEGRAM_TOKEN || !TELEGRAM_CHAT) {
+    process.stderr.write(
+      "[apple-mail] Telegram approval channel not configured (set PAI_TELEGRAM_BOT_TOKEN + PAI_TELEGRAM_CHAT_ID); using session + Pulse only\n",
+    );
+    return false;
+  }
+  try {
+    const r = await fetch(`https://api.telegram.org/bot${TELEGRAM_TOKEN}/sendMessage`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ chat_id: TELEGRAM_CHAT, text: message }),
+    });
+    return r.ok;
+  } catch (e) {
+    process.stderr.write(`[apple-mail] Telegram notify failed: ${(e as Error).message}\n`);
+    return false;
+  }
+}
+
+// ─────────────────────────────── AppleScript generators ───────────────────────────────
+
+function scriptAccounts(): string {
+  return `tell application "Mail"
+  set out to ""
+  repeat with a in accounts
+    try
+      set addr to (item 1 of email addresses of a)
+    on error
+      set addr to ""
+    end try
+    set out to out & (name of a) & "|" & addr & linefeed
+  end repeat
+  return out
+end tell`;
+}
+
+function scriptMailboxes(account: string | undefined): string {
+  if (account) {
+    return `tell application "Mail"
+  set out to ""
+  set acc to first account whose name is "${escapeAS(account)}"
+  repeat with mb in mailboxes of acc
+    set out to out & (name of acc) & "|" & (name of mb) & "|" & (unread count of mb) & "|" & (count of messages of mb) & linefeed
+  end repeat
+  return out
+end tell`;
+  }
+  return `tell application "Mail"
+  set out to ""
+  repeat with acc in accounts
+    repeat with mb in mailboxes of acc
+      set out to out & (name of acc) & "|" & (name of mb) & "|" & (unread count of mb) & "|" & (count of messages of mb) & linefeed
+    end repeat
+  end repeat
+  return out
+end tell`;
+}
+
+function scriptUnread(account: string | undefined, limit: number): string {
+  const acctFilter = account
+    ? `set msgs to messages of (first mailbox of (first account whose name is "${escapeAS(account)}") whose name is "INBOX") whose read status is false`
+    : `set msgs to {}
+  repeat with acc in accounts
+    try
+      set inb to first mailbox of acc whose name is "INBOX"
+      set msgs to msgs & (messages of inb whose read status is false)
+    on error
+      try
+        set inb to first mailbox of acc whose name is "Inbox"
+        set msgs to msgs & (messages of inb whose read status is false)
+      end try
+    end try
+  end repeat`;
+  return `tell application "Mail"
+  set out to ""
+  set i to 0
+  ${acctFilter}
+  repeat with m in msgs
+    if i >= ${limit} then exit repeat
+    try
+      set snip to (content of m)
+      if length of snip > 200 then set snip to (text 1 thru 200 of snip)
+      set snip to my cleanLines(snip)
+      set acctName to (name of (mailbox of m)'s account)
+      set out to out & (id of m) & "|" & acctName & "|" & (name of mailbox of m) & "|" & (sender of m) & "|" & (subject of m) & "|" & ((date received of m) as string) & "|" & snip & linefeed
+      set i to i + 1
+    end try
+  end repeat
+  return out
+end tell
+
+on cleanLines(s)
+  set AppleScript's text item delimiters to {return, linefeed, tab}
+  set parts to text items of s
+  set AppleScript's text item delimiters to " "
+  set joined to parts as string
+  set AppleScript's text item delimiters to ""
+  return joined
+end cleanLines`;
+}
+
+function scriptList(mailbox: string, account: string | undefined, limit: number): string {
+  const acctScope = account
+    ? `set acc to first account whose name is "${escapeAS(account)}"
+  set mb to first mailbox of acc whose name is "${escapeAS(mailbox)}"
+  set acctName to name of acc`
+    : `set mb to first mailbox whose name is "${escapeAS(mailbox)}"
+  set acctName to "(any)"`;
+  return `tell application "Mail"
+  set out to ""
+  set i to 0
+  ${acctScope}
+  repeat with m in messages of mb
+    if i >= ${limit} then exit repeat
+    try
+      set snip to (content of m)
+      if length of snip > 200 then set snip to (text 1 thru 200 of snip)
+      set snip to my cleanLines(snip)
+      set out to out & (id of m) & "|" & acctName & "|" & (name of mb) & "|" & (sender of m) & "|" & (subject of m) & "|" & ((date received of m) as string) & "|" & snip & linefeed
+      set i to i + 1
+    end try
+  end repeat
+  return out
+end tell
+
+on cleanLines(s)
+  set AppleScript's text item delimiters to {return, linefeed, tab}
+  set parts to text items of s
+  set AppleScript's text item delimiters to " "
+  set joined to parts as string
+  set AppleScript's text item delimiters to ""
+  return joined
+end cleanLines`;
+}
+
+function scriptSearch(
+  query: string,
+  account: string | undefined,
+  limit: number,
+  includeJunk: boolean,
+): string {
+  const skipList = includeJunk ? null : asListLiteral(getSkipMailboxes());
+  const skipOpen = skipList ? `if (name of mb) is not in ${skipList} then` : "";
+  const skipClose = skipList ? "end if" : "";
+  const acctScope = account
+    ? `set acc to first account whose name is "${escapeAS(account)}"
+  set msgs to {}
+  repeat with mb in mailboxes of acc
+    ${skipOpen}
+    try
+      set msgs to msgs & (messages of mb whose content contains "${escapeAS(query)}")
+    end try
+    ${skipClose}
+  end repeat`
+    : `set msgs to {}
+  repeat with acc in accounts
+    repeat with mb in mailboxes of acc
+      ${skipOpen}
+      try
+        set msgs to msgs & (messages of mb whose content contains "${escapeAS(query)}")
+      end try
+      ${skipClose}
+    end repeat
+  end repeat`;
+  return `tell application "Mail"
+  set out to ""
+  set i to 0
+  ${acctScope}
+  repeat with m in msgs
+    if i >= ${limit} then exit repeat
+    try
+      set snip to (content of m)
+      if length of snip > 200 then set snip to (text 1 thru 200 of snip)
+      set snip to my cleanLines(snip)
+      set acctName to (name of (mailbox of m)'s account)
+      set out to out & (id of m) & "|" & acctName & "|" & (name of mailbox of m) & "|" & (sender of m) & "|" & (subject of m) & "|" & ((date received of m) as string) & "|" & snip & linefeed
+      set i to i + 1
+    end try
+  end repeat
+  return out
+end tell
+
+on cleanLines(s)
+  set AppleScript's text item delimiters to {return, linefeed, tab}
+  set parts to text items of s
+  set AppleScript's text item delimiters to " "
+  set joined to parts as string
+  set AppleScript's text item delimiters to ""
+  return joined
+end cleanLines`;
+}
+
+function scriptFetch(id: string, full: boolean): string {
+  const bodyClause = full
+    ? `set bd to content of m
+  set out to out & "---BODY---" & linefeed & bd & linefeed`
+    : "";
+  return `tell application "Mail"
+  set out to ""
+  set m to first message of inbox whose id is ${parseInt(id, 10)}
+  set out to "ID: " & (id of m) & linefeed
+  set out to out & "FROM: " & (sender of m) & linefeed
+  try
+    set out to out & "TO: " & (address of (to recipient 1 of m)) & linefeed
+  end try
+  set out to out & "SUBJECT: " & (subject of m) & linefeed
+  set out to out & "DATE: " & ((date received of m) as string) & linefeed
+  set out to out & "ACCOUNT: " & (name of (mailbox of m)'s account) & linefeed
+  set out to out & "MAILBOX: " & (name of mailbox of m) & linefeed
+  ${bodyClause}
+  return out
+end tell`;
+}
+
+function scriptCount(mailbox: string, account: string | undefined, unreadOnly: boolean): string {
+  const acctScope = account
+    ? `set mb to first mailbox of (first account whose name is "${escapeAS(account)}") whose name is "${escapeAS(mailbox)}"`
+    : `set mb to first mailbox whose name is "${escapeAS(mailbox)}"`;
+  const countExpr = unreadOnly ? "unread count of mb" : "count of messages of mb";
+  return `tell application "Mail"
+  ${acctScope}
+  return ${countExpr}
+end tell`;
+}
+
+function scriptStatus(): string {
+  return `tell application "System Events"
+  set isRunning to (name of processes) contains "Mail"
+end tell
+if isRunning then
+  tell application "Mail"
+    set acctN to count of accounts
+    set tot to 0
+    repeat with acc in accounts
+      repeat with mb in mailboxes of acc
+        try
+          set tot to tot + (unread count of mb)
+        end try
+      end repeat
+    end repeat
+    return "running|" & acctN & "|" & tot
+  end tell
+else
+  return "stopped|0|0"
+end if`;
+}
+
+function scriptSend(env: Envelope, finalAction: "send" | "save"): string {
+  const subject = escapeAS(env.subject ?? "");
+  const content = escapeAS(env.body);
+  const html = env.html ? "true" : "false";
+  const accountClause = env.account
+    ? `set sender of newMsg to "${escapeAS(env.account)}"`
+    : "";
+  const recipientsClause = (env.to ?? "")
+    .split(",")
+    .map((a) => a.trim())
+    .filter(Boolean)
+    .map((a) => `make new to recipient at end of to recipients with properties {address:"${escapeAS(a)}"}`)
+    .join("\n    ");
+  const ccClause = (env.cc ?? "")
+    .split(",")
+    .map((a) => a.trim())
+    .filter(Boolean)
+    .map((a) => `make new cc recipient at end of cc recipients with properties {address:"${escapeAS(a)}"}`)
+    .join("\n    ");
+  const bccClause = (env.bcc ?? "")
+    .split(",")
+    .map((a) => a.trim())
+    .filter(Boolean)
+    .map((a) => `make new bcc recipient at end of bcc recipients with properties {address:"${escapeAS(a)}"}`)
+    .join("\n    ");
+  return `tell application "Mail"
+  set newMsg to make new outgoing message with properties {subject:"${subject}", content:"${content}", visible:false}
+  set html content of newMsg to ${html}
+  tell newMsg
+    ${recipientsClause}
+    ${ccClause}
+    ${bccClause}
+  end tell
+  ${accountClause}
+  ${finalAction === "send" ? "send newMsg" : "save newMsg"}
+  return (id of newMsg) as string
+end tell`;
+}
+
+function scriptReply(id: string, body: string, replyAll: boolean): string {
+  const action = replyAll ? "reply to" : "reply to";
+  return `tell application "Mail"
+  set orig to first message of inbox whose id is ${parseInt(id, 10)}
+  set rep to ${action} orig with opening window
+  delay 0.4
+  tell rep
+    set content to "${escapeAS(body)}" & linefeed & content
+    send
+  end tell
+  return "replied"
+end tell`;
+}
+
+function scriptForward(id: string, to: string, body: string): string {
+  return `tell application "Mail"
+  set orig to first message of inbox whose id is ${parseInt(id, 10)}
+  set fwd to forward orig with opening window
+  delay 0.4
+  tell fwd
+    make new to recipient at end of to recipients with properties {address:"${escapeAS(to)}"}
+    set content to "${escapeAS(body)}" & linefeed & content
+    send
+  end tell
+  return "forwarded"
+end tell`;
+}
+
+function scriptMarkRead(ids: string[], read: boolean): string {
+  const list = ids.map((i) => parseInt(i, 10)).filter((n) => !Number.isNaN(n));
+  return `tell application "Mail"
+  repeat with mid in {${list.join(", ")}}
+    try
+      set m to first message of inbox whose id is mid
+      set read status of m to ${read ? "true" : "false"}
+    end try
+  end repeat
+  return "ok"
+end tell`;
+}
+
+function scriptMove(id: string, mailbox: string, account: string | undefined): string {
+  const target = account
+    ? `first mailbox of (first account whose name is "${escapeAS(account)}") whose name is "${escapeAS(mailbox)}"`
+    : `first mailbox whose name is "${escapeAS(mailbox)}"`;
+  return `tell application "Mail"
+  set m to first message of inbox whose id is ${parseInt(id, 10)}
+  set targetMb to ${target}
+  move m to targetMb
+  return "moved"
+end tell`;
+}
+
+// ─────────────────────────────── Argv parser ───────────────────────────────
+
+function parseFlags(argv: string[]): Record<string, string | boolean> {
+  const out: Record<string, string | boolean> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith("--")) continue;
+    const key = a.slice(2);
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith("--")) {
+      out[key] = true;
+    } else {
+      out[key] = next;
+      i++;
+    }
+  }
+  return out;
+}
+
+function readBody(flags: Record<string, string | boolean>): string {
+  if (typeof flags["body-file"] === "string") {
+    return readFileSync(flags["body-file"] as string, "utf8");
+  }
+  if (flags["body-stdin"]) {
+    return readFileSync(0, "utf8");
+  }
+  throw new Error("body required: pass --body-file PATH or --body-stdin");
+}
+
+// ─────────────────────────────── Output parsers ───────────────────────────────
+
+function parsePipes(s: string, fields: string[]): Record<string, string>[] {
+  return s
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .map((l) => {
+      const parts = l.split("|");
+      const obj: Record<string, string> = {};
+      fields.forEach((f, i) => (obj[f] = parts[i] ?? ""));
+      return obj;
+    });
+}
+
+// ─────────────────────────────── Approval gate ───────────────────────────────
+
+async function gateAndStage(envelope: Envelope): Promise<never> {
+  // Defense-in-depth: any Arthur load/eval failure (e.g. policies.yaml missing on a
+  // fresh PAI install) MUST fail closed → treat as CONFIRM so the token gate runs.
+  // We never let an Arthur exception bypass the gate.
+  let decision: { verdict: "ALLOW" | "DENY" | "CONFIRM"; reason: string; rule: string };
+  try {
+    decision = evaluate({
+      key: "apple_mail_send",
+      caller: "apple-mail.ts",
+      purpose: "send mail",
+      session_id: process.env.CLAUDE_SESSION_ID,
+    });
+  } catch (e) {
+    audit({
+      event_type: "apple_mail_arthur_unavailable",
+      to: envelope.to,
+      subject: envelope.subject,
+      error: (e as Error).message,
+      hint: "Arthur unreachable; failing closed to CONFIRM",
+    });
+    decision = { verdict: "CONFIRM", reason: "Arthur unavailable; fail-closed", rule: "fail_closed" };
+  }
+
+  if (decision.verdict === "DENY") {
+    audit({
+      event_type: "apple_mail_denied",
+      to: envelope.to,
+      subject: envelope.subject,
+      reason: decision.reason,
+      rule: decision.rule,
+    });
+    process.stderr.write(JSON.stringify({ error: decision.reason, code: "denied" }) + "\n");
+    process.exit(2);
+  }
+
+  // Defense-in-depth: Arthur's default-allow path (rule === "default") fires when no
+  // explicit policy exists for the key. For mail send/reply/forward we ALWAYS want
+  // human confirmation — treat missing policy as if it had require_confirmation:true
+  // so a fresh PAI install can't accidentally ship mail before the user wires up
+  // ~/.claude/PAI/USER/ARTHUR/policies.yaml (see skills/AppleMail/policies-sample.yaml).
+  if (decision.verdict === "ALLOW" && decision.rule !== "default") {
+    // Explicit policy match with no confirmation required — ship immediately.
+    await actuallySend(envelope, "(policy-allow)");
+    process.exit(0);
+  }
+  if (decision.verdict === "ALLOW" && decision.rule === "default") {
+    audit({
+      event_type: "apple_mail_default_gate_engaged",
+      to: envelope.to,
+      subject: envelope.subject,
+      hint: "no explicit apple_mail_send policy; defaulting to CONFIRM",
+    });
+    // Fall through to CONFIRM staging below.
+  }
+
+  // CONFIRM (or default-allow promoted to CONFIRM) — stage the draft.
+  const token = randomBytes(16).toString("hex");
+  const now = new Date();
+  const expires = new Date(now.getTime() + TOKEN_TTL_MS);
+  const pending: Pending = {
+    token,
+    envelope,
+    created: now.toISOString(),
+    expires: expires.toISOString(),
+  };
+  writePending(pending);
+
+  const bodyPreview = envelope.body.slice(0, 800);
+  const cc = envelope.cc ? `Cc: ${envelope.cc}\n` : "";
+  const bcc = envelope.bcc ? `Bcc: ${envelope.bcc}\n` : "";
+  const preview = `━━━ MAIL DRAFT — APPROVAL REQUIRED ━━━
+To: ${envelope.to ?? "(reply target)"}
+${cc}${bcc}Subject: ${envelope.subject ?? "(reply)"}
+───
+${bodyPreview}${envelope.body.length > 800 ? "\n[…body truncated]" : ""}
+───
+Approval token: ${token}
+Approve from any channel:
+  - In Claude:  apple-mail send --approval-token ${token}
+  - In Pulse:   click the pending notification
+  - Telegram:   /approve-mail ${token}
+Expires: ${expires.toLocaleString()}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━`;
+  process.stdout.write(preview + "\n");
+
+  await notifyPulse(
+    `Mail draft pending approval (token ${token}): To ${envelope.to ?? "(reply)"} — "${envelope.subject ?? ""}"`,
+  );
+  const telegramOk = await notifyTelegram(
+    `📧 Mail draft pending approval\nTo: ${envelope.to ?? "(reply)"}\nSubject: ${envelope.subject ?? ""}\n\nApprove: /approve-mail ${token}\nReject: /reject-mail ${token}\n\nExpires in 30 min`,
+  );
+
+  audit({
+    event_type: "apple_mail_send_requested",
+    token,
+    to: envelope.to,
+    cc: envelope.cc,
+    bcc: envelope.bcc,
+    subject: envelope.subject,
+    kind: envelope.kind,
+    channels: telegramOk ? ["session", "pulse", "telegram"] : ["session", "pulse"],
+  });
+
+  const channels = telegramOk ? ["session", "pulse", "telegram"] : ["session", "pulse"];
+  process.stdout.write(
+    JSON.stringify({ status: "awaiting_approval", token, channels }, null, 2) + "\n",
+  );
+  process.exit(2);
+}
+
+async function consumeApprovalToken(token: string): Promise<never> {
+  assertValidToken(token);
+  const pending = readPending(token);
+  if (!pending) {
+    audit({ event_type: "apple_mail_token_unknown", token });
+    process.stderr.write(JSON.stringify({ error: "unknown approval token", code: "token_unknown" }) + "\n");
+    process.exit(2);
+  }
+  if (new Date(pending.expires).getTime() < Date.now()) {
+    audit({
+      event_type: "apple_mail_token_expired",
+      token,
+      to: pending.envelope.to,
+      subject: pending.envelope.subject,
+    });
+    clearPending(token);
+    process.stderr.write(JSON.stringify({ error: "approval token expired", code: "token_expired" }) + "\n");
+    process.exit(2);
+  }
+  const outcome = readOutcome(token);
+  if (!outcome) {
+    process.stdout.write(
+      JSON.stringify({ status: "awaiting_approval", token, hint: "no outcome file yet" }, null, 2) + "\n",
+    );
+    process.exit(2);
+  }
+  if (outcome.decision !== "approve") {
+    audit({
+      event_type: "apple_mail_rejected",
+      token,
+      to: pending.envelope.to,
+      subject: pending.envelope.subject,
+      approver: outcome.approver,
+    });
+    clearPending(token);
+    process.stderr.write(
+      JSON.stringify({ error: "draft rejected by approver", code: "rejected" }) + "\n",
+    );
+    process.exit(2);
+  }
+  await actuallySend(pending.envelope, outcome.approver);
+  clearPending(token);
+  process.exit(0);
+}
+
+async function actuallySend(env: Envelope, approver: string): Promise<void> {
+  ensureMailRunning();
+  let messageId = "";
+  if (env.kind === "reply" && env.replyToId) {
+    messageId = osa(scriptReply(env.replyToId, env.body, env.replyAll === true)).trim();
+  } else if (env.kind === "forward" && env.forwardId) {
+    messageId = osa(scriptForward(env.forwardId, env.to ?? "", env.body)).trim();
+  } else {
+    messageId = osa(scriptSend(env, "send")).trim();
+  }
+  audit({
+    event_type: "apple_mail_sent",
+    to: env.to,
+    subject: env.subject,
+    kind: env.kind,
+    approver,
+    messageId,
+  });
+  process.stdout.write(JSON.stringify({ sent: true, messageId, approver }, null, 2) + "\n");
+}
+
+// ─────────────────────────────── Help ───────────────────────────────
+
+function printHelp(): void {
+  process.stdout.write(
+    `apple-mail — macOS Mail.app CLI wrapper
+
+Read:
+  accounts                                       list configured accounts
+  mailboxes [--account NAME]                     list mailboxes
+  unread [--account NAME] [--limit N]            unread messages (JSON)
+  list <mailbox> [--account NAME] [--limit N]    list messages in mailbox
+  search "<query>" [--account NAME] [--limit N] [--include-junk]
+                                                 full-text search across mailboxes;
+                                                 by default skips Junk/Sonstiges/Werbung/Spam,
+                                                 Trash/Papierkorb/Deleted, Sent/Gesendet/Drafts/Entwürfe.
+                                                 --include-junk searches all mailboxes.
+  fetch <id> [--full]                            single message; --full = body
+  count <mailbox> [--account NAME] [--unread-only]
+  drafts [--limit N]                             list drafts
+  filters                                        show active mailbox skip-list
+  status                                         is Mail running + total unread
+
+Write (Arthur-gated for send/reply/forward):
+  draft   --to ADDR --subject "..." (--body-file P|--body-stdin) [--cc] [--bcc] [--account] [--html]
+  send    --to ADDR --subject "..." (--body-file P|--body-stdin) [--cc] [--bcc] [--account] [--html] [--approval-token TOK]
+  reply   <id> (--body-file P|--body-stdin) [--reply-all] [--approval-token TOK]
+  forward <id> --to ADDR (--body-file P|--body-stdin) [--approval-token TOK]
+  mark-read   <id>[,id...]
+  mark-unread <id>[,id...]
+  move <id> --to-mailbox NAME [--account NAME]
+`,
+  );
+}
+
+// ─────────────────────────────── Main ───────────────────────────────
+
+async function main(): Promise<void> {
+  cleanupStaleTokens();
+
+  const argv = process.argv.slice(2);
+  const cmd = argv[0];
+  if (!cmd || cmd === "--help" || cmd === "-h") {
+    printHelp();
+    return;
+  }
+  const rest = argv.slice(1);
+  const flags = parseFlags(rest);
+  const positional = rest.filter((a) => !a.startsWith("--") && rest[rest.indexOf(a) - 1]?.startsWith("--") !== true);
+
+  // Re-derive positional more reliably:
+  const positionals: string[] = [];
+  for (let i = 0; i < rest.length; i++) {
+    const a = rest[i];
+    if (a.startsWith("--")) {
+      const next = rest[i + 1];
+      if (next !== undefined && !next.startsWith("--")) i++;
+      continue;
+    }
+    positionals.push(a);
+  }
+
+  switch (cmd) {
+    case "accounts": {
+      const raw = osa(scriptAccounts());
+      const data = parsePipes(raw, ["name", "email"]);
+      process.stdout.write(JSON.stringify(data, null, 2) + "\n");
+      return;
+    }
+    case "mailboxes": {
+      const raw = osa(scriptMailboxes(flags.account as string | undefined));
+      const data = parsePipes(raw, ["account", "name", "unreadCount", "totalCount"]).map((r) => ({
+        ...r,
+        unreadCount: Number(r.unreadCount),
+        totalCount: Number(r.totalCount),
+      }));
+      process.stdout.write(JSON.stringify(data, null, 2) + "\n");
+      return;
+    }
+    case "unread": {
+      const limit = Number(flags.limit ?? 20);
+      const raw = osa(scriptUnread(flags.account as string | undefined, limit));
+      const data = parsePipes(raw, [
+        "id",
+        "account",
+        "mailbox",
+        "from",
+        "subject",
+        "dateReceived",
+        "snippet",
+      ]);
+      process.stdout.write(JSON.stringify(data, null, 2) + "\n");
+      return;
+    }
+    case "list": {
+      const mailbox = positionals[0];
+      if (!mailbox) throw new Error("list requires <mailbox>");
+      const limit = Number(flags.limit ?? 50);
+      const raw = osa(scriptList(mailbox, flags.account as string | undefined, limit));
+      const data = parsePipes(raw, [
+        "id",
+        "account",
+        "mailbox",
+        "from",
+        "subject",
+        "dateReceived",
+        "snippet",
+      ]);
+      process.stdout.write(JSON.stringify(data, null, 2) + "\n");
+      return;
+    }
+    case "search": {
+      const query = positionals[0];
+      if (!query) throw new Error('search requires "<query>"');
+      const limit = Number(flags.limit ?? 20);
+      const includeJunk = flags["include-junk"] === true;
+      const raw = osa(scriptSearch(query, flags.account as string | undefined, limit, includeJunk));
+      const data = parsePipes(raw, [
+        "id",
+        "account",
+        "mailbox",
+        "from",
+        "subject",
+        "dateReceived",
+        "snippet",
+      ]);
+      process.stdout.write(JSON.stringify(data, null, 2) + "\n");
+      return;
+    }
+    case "filters": {
+      process.stdout.write(
+        JSON.stringify(
+          {
+            skip_mailboxes: getSkipMailboxes(),
+            override_env: "PAI_APPLE_MAIL_INCLUDE_MAILBOXES",
+            override_flag: "--include-junk",
+            applies_to: ["search"],
+            note: "unread already restricted to INBOX/Inbox; list/count/fetch operate on explicit mailbox names",
+          },
+          null,
+          2,
+        ) + "\n",
+      );
+      return;
+    }
+    case "fetch": {
+      const id = positionals[0];
+      if (!id) throw new Error("fetch requires <id>");
+      const raw = osa(scriptFetch(id, flags.full === true));
+      const obj: Record<string, string> = {};
+      let body = "";
+      let inBody = false;
+      for (const line of raw.split(/\r?\n/)) {
+        if (line === "---BODY---") {
+          inBody = true;
+          continue;
+        }
+        if (inBody) {
+          body += line + "\n";
+          continue;
+        }
+        const m = line.match(/^([A-Z]+): (.*)$/);
+        if (m) obj[m[1].toLowerCase()] = m[2];
+      }
+      if (flags.full === true) obj.body = body.trim();
+      process.stdout.write(JSON.stringify(obj, null, 2) + "\n");
+      return;
+    }
+    case "count": {
+      const mailbox = positionals[0];
+      if (!mailbox) throw new Error("count requires <mailbox>");
+      const raw = osa(
+        scriptCount(mailbox, flags.account as string | undefined, flags["unread-only"] === true),
+      );
+      process.stdout.write(
+        JSON.stringify({ mailbox, account: flags.account ?? null, count: Number(raw.trim()) }, null, 2) +
+          "\n",
+      );
+      return;
+    }
+    case "drafts": {
+      const limit = Number(flags.limit ?? 20);
+      // Drafts mailbox exists per-account; list across all accounts.
+      const raw = osa(scriptList("Drafts", undefined, limit));
+      const data = parsePipes(raw, [
+        "id",
+        "account",
+        "mailbox",
+        "from",
+        "subject",
+        "dateReceived",
+        "snippet",
+      ]);
+      process.stdout.write(JSON.stringify(data, null, 2) + "\n");
+      return;
+    }
+    case "status": {
+      let running = false;
+      let accountCount = 0;
+      let totalUnread = 0;
+      try {
+        const raw = osa(scriptStatus()).trim();
+        const [state, acctN, tot] = raw.split("|");
+        running = state === "running";
+        accountCount = Number(acctN);
+        totalUnread = Number(tot);
+      } catch {
+        running = false;
+      }
+      process.stdout.write(JSON.stringify({ running, accountCount, totalUnread }, null, 2) + "\n");
+      return;
+    }
+    case "draft": {
+      ensureMailRunning();
+      const env: Envelope = {
+        kind: "send",
+        to: flags.to as string,
+        cc: flags.cc as string | undefined,
+        bcc: flags.bcc as string | undefined,
+        subject: flags.subject as string,
+        body: readBody(flags),
+        html: flags.html === true,
+        account: flags.account as string | undefined,
+      };
+      const draftId = osa(scriptSend(env, "save")).trim();
+      audit({ event_type: "apple_mail_drafted", to: env.to, subject: env.subject, draftId });
+      process.stdout.write(JSON.stringify({ draftId, status: "drafted" }, null, 2) + "\n");
+      return;
+    }
+    case "send": {
+      if (typeof flags["approval-token"] === "string") {
+        await consumeApprovalToken(flags["approval-token"] as string);
+        return;
+      }
+      const env: Envelope = {
+        kind: "send",
+        to: flags.to as string,
+        cc: flags.cc as string | undefined,
+        bcc: flags.bcc as string | undefined,
+        subject: flags.subject as string,
+        body: readBody(flags),
+        html: flags.html === true,
+        account: flags.account as string | undefined,
+      };
+      if (!env.to || !env.subject) {
+        throw new Error("send requires --to and --subject (or use --approval-token TOK to resume)");
+      }
+      await gateAndStage(env);
+      return;
+    }
+    case "reply": {
+      if (typeof flags["approval-token"] === "string") {
+        await consumeApprovalToken(flags["approval-token"] as string);
+        return;
+      }
+      const replyId = positionals[0];
+      if (!replyId) throw new Error("reply requires <id>");
+      const env: Envelope = {
+        kind: "reply",
+        body: readBody(flags),
+        replyToId: replyId,
+        replyAll: flags["reply-all"] === true,
+      };
+      await gateAndStage(env);
+      return;
+    }
+    case "forward": {
+      if (typeof flags["approval-token"] === "string") {
+        await consumeApprovalToken(flags["approval-token"] as string);
+        return;
+      }
+      const fwdId = positionals[0];
+      if (!fwdId) throw new Error("forward requires <id>");
+      const env: Envelope = {
+        kind: "forward",
+        to: flags.to as string,
+        body: readBody(flags),
+        forwardId: fwdId,
+      };
+      if (!env.to) throw new Error("forward requires --to");
+      await gateAndStage(env);
+      return;
+    }
+    case "mark-read":
+    case "mark-unread": {
+      ensureMailRunning();
+      const ids = (positionals[0] ?? "").split(",").map((s) => s.trim()).filter(Boolean);
+      if (ids.length === 0) throw new Error(`${cmd} requires <id>[,<id>...]`);
+      const read = cmd === "mark-read";
+      osa(scriptMarkRead(ids, read));
+      audit({ event_type: `apple_mail_${cmd}`, ids });
+      process.stdout.write(JSON.stringify({ status: "ok", ids, read }, null, 2) + "\n");
+      return;
+    }
+    case "move": {
+      ensureMailRunning();
+      const id = positionals[0];
+      const targetMailbox = flags["to-mailbox"] as string;
+      if (!id || !targetMailbox) throw new Error("move requires <id> and --to-mailbox NAME");
+      osa(scriptMove(id, targetMailbox, flags.account as string | undefined));
+      audit({ event_type: "apple_mail_moved", id, targetMailbox, account: flags.account });
+      process.stdout.write(JSON.stringify({ status: "moved", id, targetMailbox }, null, 2) + "\n");
+      return;
+    }
+    default: {
+      process.stderr.write(`Unknown command: ${cmd}\n`);
+      printHelp();
+      process.exit(2);
+    }
+  }
+}
+
+main().catch((e) => {
+  process.stderr.write(JSON.stringify({ error: (e as Error).message, code: "runtime_error" }) + "\n");
+  process.exit(1);
+});

--- a/Releases/v5.0.0/.claude/skills/AppleMail/SKILL.md
+++ b/Releases/v5.0.0/.claude/skills/AppleMail/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: AppleMail
+description: macOS Mail.app integration for PAI/Timmy. Read inbox autonomously (accounts, mailboxes, unread, list, search, fetch, drafts, count, status) via the apple-mail CLI which wraps Mail.app through AppleScript. Write paths (send, reply, forward) are HARD-GATED through Arthur's apple_mail_send policy — no mail leaves the machine without an explicit approval token activated from one of three channels (in-session, Pulse notification, Telegram /approve-mail command). drafts and read-state mutations (mark-read, move) run silently with audit log. Three workflows ship: Read.md (browsing), Draft.md (compose + save to Drafts folder), SendWithApproval.md (the gated outbound flow with token + multi-channel notify). USE WHEN check my mail, what's in my inbox, unread from X, search inbox for Y, draft a reply to Z, forward this to W, mark this read, move to archive, what mail accounts do I have, Apple Mail, Mail.app. NOT FOR Gmail (use PAI/TOOLS/gmail.ts directly), iMessage (Pulse iMessage module), calendar (separate skill), or anything that must run on Linux/Windows (Mac-only). NOT FOR bulk send or mailing lists — the approval gate fires per send and that's intentional.
+metadata:
+  type: skill
+  platform: darwin-only
+  safety: approval-gate-required
+---
+
+# AppleMail — macOS Mail.app for PAI
+
+> Companion to `gmail.ts` for the accounts Jan keeps in Apple Mail (FWU, personal, anything not in Google Workspace). Single Bun CLI + Arthur policy + this skill.
+
+## Activation
+
+Trigger this skill when the conversation references reading or writing mail that's in **Apple Mail (Mail.app)**, not Gmail. Phrases that should fire:
+
+- "check my mail / inbox"
+- "any unread from <person/domain>?"
+- "search inbox for <topic>"
+- "what's in my drafts"
+- "draft a reply to <message>"
+- "send <person> an email about <X>"
+- "forward this to <person>"
+- "mark this read / archive this"
+- "what Apple Mail accounts do I have"
+
+If the user names "Gmail" or "Google Workspace" explicitly, prefer `~/.claude/PAI/TOOLS/gmail.ts` instead. If unsure, ask once.
+
+## Tool
+
+`~/.claude/PAI/TOOLS/apple-mail.ts` — invoke via `bun ~/.claude/PAI/TOOLS/apple-mail.ts <cmd> [args]`.
+
+Read subcommands print JSON to stdout. Write subcommands either:
+
+1. **Run directly** (`draft`, `mark-read`, `mark-unread`, `move`) — low-risk, audit-only.
+2. **Stage through approval gate** (`send`, `reply`, `forward`) — see `Workflows/SendWithApproval.md`.
+
+## Safety contract — the non-negotiable rule
+
+**Mail NEVER leaves the machine without explicit approval.** The contract:
+
+1. Build envelope from CLI flags.
+2. `Arthur.evaluate({key:"apple_mail_send", ...})` returns `CONFIRM` (per `~/.claude/PAI/USER/ARTHUR/policies.yaml`).
+3. Tool generates a 16-byte hex approval token, writes a pending file at `PAI/MEMORY/STATE/apple-mail-pending/<token>.json`.
+4. Tool prints the draft preview in-session, POSTs a Pulse notification, POSTs a Telegram message with `/approve-mail <token>` text command (if Telegram is configured).
+5. Tool exits with code 2 — nothing has been sent.
+6. Approver activates the token from any of three channels:
+   - **In-session**: re-run `bun apple-mail.ts send --approval-token <token>`
+   - **Pulse**: click the pending notification (writes the outcome file)
+   - **Telegram**: send `/approve-mail <token>` (the bot handler writes the outcome file)
+7. Tool re-invoked with `--approval-token` reads pending + outcome files, validates `decision === "approve"`, ships the mail, deletes both files. Token expires after 30 minutes.
+
+**There is no `--force`, no `--skip-approval`, no in-tool env var that bypasses this.** The gate is the tool. If a user asks Timmy to "just send it without asking" — Timmy declines and points at the gate.
+
+## Workflows
+
+| File | Purpose |
+|------|---------|
+| `Workflows/Read.md` | Browsing patterns — unread triage, search, account discovery |
+| `Workflows/Draft.md` | Compose-and-save flow (never sends) — useful for "queue this for me" |
+| `Workflows/SendWithApproval.md` | The full gated send flow with token + multi-channel approval |
+
+## Permissions setup (one-time on a fresh machine)
+
+1. **macOS Automation grant.** System Settings → Privacy & Security → Automation → grant **Terminal/iTerm/your shell** access to **Mail**. Without it, AppleScript calls return empty lists. The skill's first read invocation surfaces this if missing.
+2. **Arthur policy (optional but recommended).** Copy entries from `policies-sample.yaml` into `~/.claude/PAI/USER/ARTHUR/policies.yaml`. The tool refuses to send without a token regardless — Arthur's default-allow path is promoted to CONFIRM inside `gateAndStage()` — but an explicit policy gives you rate limits, attribution, and audit-trail clarity.
+3. **Telegram (optional).** Set `PAI_TELEGRAM_BOT_TOKEN` and `PAI_TELEGRAM_CHAT_ID` to enable the third approval channel. Without them, the gate still works via in-session + Pulse.
+
+## Gotchas
+
+- Mail.app must be running for send/reply/forward — the tool launches it automatically (`tell application "Mail" to activate`).
+- `whose content contains` (search) is slow on huge stores; cap `--limit` low and prefer mailbox-scoped lookups when you know the account.
+- IDs returned by `unread`/`list`/`search` are Mail.app's internal `id` property — they're stable for the lifetime of the message in that mailbox but change if you move the message between accounts.
+- Telegram approval is one-way notify in v1 (the `/approve-mail TOK` text command); inline-button callback handling is a separate task on `Pulse/modules/telegram.ts`.
+- The existing `~/.claude/PAI/TOOLS/gmail.ts` does NOT yet have the same approval gate — that's a known gap on a separate retrofit task.
+
+## OpenClaw lineage
+
+This skill borrows three ideas from how OpenClaw structures messaging-channel work:
+
+1. **Always spawn, never redirect** — Timmy invokes the tool directly; user is never told "go open Mail.app and do it manually."
+2. **Multi-channel approval surfaces** — like OpenClaw's session/AGENTS.md/UI tiers, this skill exposes three independent approval channels (session, Pulse, Telegram). The user approves from whichever is nearest.
+3. **Channel discrimination at the gate** — the Arthur policy is the single decision point regardless of which channel originated the request.

--- a/Releases/v5.0.0/.claude/skills/AppleMail/Workflows/Draft.md
+++ b/Releases/v5.0.0/.claude/skills/AppleMail/Workflows/Draft.md
@@ -1,0 +1,67 @@
+# Workflow — Draft (Apple Mail)
+
+> `apple-mail draft` saves an outgoing message to the **Drafts** folder. It NEVER sends. Use this when the user says "draft <X>", "queue a message to <Y>", "let me look at it before sending" — and especially when Timmy is working autonomously in the background and shouldn't even attempt the approval flow.
+
+## Basic draft
+
+```bash
+bun ~/.claude/PAI/TOOLS/apple-mail.ts draft \
+  --to "kollege@fwu.de" \
+  --subject "AIS.chat Rollout — Status für Q3" \
+  --body-stdin <<'EOF'
+Hi,
+
+kurzer Stand zum Rollout in den Schulen…
+
+Beste Grüße,
+Jan
+EOF
+```
+
+Output: `{"draftId": "...", "status": "drafted"}`. The draft now sits in the relevant account's Drafts folder, ready for the user to review in Mail.app and either send manually or feed back into `apple-mail send` with the approval gate.
+
+## With a body file
+
+```bash
+bun ~/.claude/PAI/TOOLS/apple-mail.ts draft \
+  --to "team@german-uds.de" \
+  --cc "leitung@german-uds.de" \
+  --subject "Bewerbungs-Pipeline — Vorschlag" \
+  --body-file /tmp/draft-pitch.md
+```
+
+## HTML drafts
+
+Add `--html` and the body is treated as HTML (uses Mail.app's HTML content slot):
+
+```bash
+bun ~/.claude/PAI/TOOLS/apple-mail.ts draft \
+  --to "press@example.com" \
+  --subject "Pressemitteilung Q4" \
+  --html \
+  --body-file /tmp/press-release.html
+```
+
+## Choosing the sender account
+
+```bash
+bun ~/.claude/PAI/TOOLS/apple-mail.ts draft \
+  --account "FWU" \
+  --to "..." --subject "..." --body-stdin <<< "..."
+```
+
+Pass the email address of the sending identity, not the account display name (AppleScript's `sender` property expects the address, e.g. `jan.renz@fwu.de`).
+
+## Why drafts matter for safety
+
+Drafts are the **escape hatch** when the approval flow would be too heavy:
+
+- Timmy is mid-conversation drafting many candidates and only ONE will ship — write all candidates as drafts, gate only the chosen one through `send`.
+- A scheduled/cron task assembles a daily summary email but Jan reviews it before sending — write the draft from the cron, send it manually or via approval-token re-run.
+- Jan wants to dictate the body, then tweak in Mail.app's UI before sending — `draft` puts the body exactly where Mail.app expects it.
+
+## What `draft` does NOT do
+
+- It does **not** call Arthur or write a pending file. There's no token. There's no notify ping. It's a pure local action.
+- It does **not** prevent the user from manually clicking Send in Mail.app afterwards — that's the user's hand, not the tool's.
+- It does **not** support attachments yet — for attachments, compose in Mail.app's UI or use `osascript` directly. Future work.

--- a/Releases/v5.0.0/.claude/skills/AppleMail/Workflows/Read.md
+++ b/Releases/v5.0.0/.claude/skills/AppleMail/Workflows/Read.md
@@ -1,0 +1,88 @@
+# Workflow — Read (Apple Mail)
+
+> Use the `apple-mail` CLI to inspect mail without sending anything. All read commands print JSON to stdout — pipe to `jq` for slicing.
+
+## Discovering accounts
+
+```bash
+bun ~/.claude/PAI/TOOLS/apple-mail.ts accounts
+```
+
+Returns `[{name, email}]`. Note the `name` value — most other commands accept `--account NAME` to scope.
+
+## Quick triage — what's unread right now?
+
+```bash
+bun ~/.claude/PAI/TOOLS/apple-mail.ts unread --limit 10
+```
+
+Returns up to 10 unread messages across all accounts: `{id, account, mailbox, from, subject, dateReceived, snippet}`. Scope to one account:
+
+```bash
+bun ~/.claude/PAI/TOOLS/apple-mail.ts unread --account "FWU" --limit 20
+```
+
+## Listing a specific mailbox
+
+```bash
+bun ~/.claude/PAI/TOOLS/apple-mail.ts list "INBOX" --account "FWU" --limit 30
+bun ~/.claude/PAI/TOOLS/apple-mail.ts list "Archive" --account "Personal"
+```
+
+Common mailbox names: `INBOX`, `Sent Messages`, `Drafts`, `Archive`, `Junk`. Mailbox names are case-sensitive and per-account.
+
+## Search
+
+```bash
+bun ~/.claude/PAI/TOOLS/apple-mail.ts search "kindergarten" --limit 10
+bun ~/.claude/PAI/TOOLS/apple-mail.ts search "AIS.chat" --account "FWU" --limit 5
+```
+
+Searches message body (`whose content contains`). Slow on large stores — keep `--limit` low. Quote the query; use single quotes around the whole command if the query contains shell metacharacters.
+
+## Reading a single message
+
+```bash
+# Just headers + snippet
+bun ~/.claude/PAI/TOOLS/apple-mail.ts fetch 12345
+
+# Full body
+bun ~/.claude/PAI/TOOLS/apple-mail.ts fetch 12345 --full
+```
+
+## Counts
+
+```bash
+bun ~/.claude/PAI/TOOLS/apple-mail.ts count "INBOX" --unread-only
+bun ~/.claude/PAI/TOOLS/apple-mail.ts count "INBOX" --account "FWU"
+```
+
+## Status check (am I even connected?)
+
+```bash
+bun ~/.claude/PAI/TOOLS/apple-mail.ts status
+```
+
+Returns `{running, accountCount, totalUnread}`. Use this at the top of any longer-running flow to verify Mail.app is alive.
+
+## Composing JSON pipelines
+
+```bash
+# Unread from any FWU domain sender today
+bun ~/.claude/PAI/TOOLS/apple-mail.ts unread --limit 50 \
+  | jq '[.[] | select(.from | contains("fwu.de"))]'
+
+# Just the IDs and subjects
+bun ~/.claude/PAI/TOOLS/apple-mail.ts unread --limit 50 \
+  | jq '.[] | {id, subject}'
+```
+
+## When Timmy uses Read
+
+If the user asks "any new mail from <X>?" Timmy:
+
+1. Runs `apple-mail unread --limit 20` (or scoped to the account if obvious).
+2. Filters the JSON locally (jq or just summarizes).
+3. Reports a short prose summary, optionally pulls full body via `fetch <id> --full` if the user wants depth.
+
+Timmy NEVER runs read commands and stops there — always synthesizes into a useful answer in voice.

--- a/Releases/v5.0.0/.claude/skills/AppleMail/Workflows/SendWithApproval.md
+++ b/Releases/v5.0.0/.claude/skills/AppleMail/Workflows/SendWithApproval.md
@@ -1,0 +1,142 @@
+# Workflow — Send with Approval (Apple Mail)
+
+> The gated outbound flow. **No mail leaves the machine without explicit Jan approval.** This is the contract for `send`, `reply`, and `forward` — three subcommands, one gate.
+
+## The flow
+
+```
+Timmy builds envelope ──► apple-mail send ──► Arthur.evaluate("apple_mail_send")
+                                                       │
+                                                       │ verdict = CONFIRM
+                                                       ▼
+                                    Token generated (16 random bytes hex)
+                                    Pending file: STATE/apple-mail-pending/<tok>.json
+                                                       │
+                  ┌────────────────────────┬───────────┴────────────┐
+                  ▼                        ▼                        ▼
+            In-Claude session         Pulse notification      Telegram message
+            (preview printed)         (visual ping)           (/approve-mail TOK)
+                  │                        │                        │
+                  └────────────┬───────────┴────────────┬───────────┘
+                               ▼                        ▼
+                Jan reads draft, decides   Jan taps approve in Pulse
+                Re-runs: send              OR sends /approve-mail TOK in Telegram
+                  --approval-token TOK     (writes outcome.json with decision:approve)
+                               │                        │
+                               ▼                        ▼
+                       Pending + outcome files validated
+                       AppleScript ships the mail
+                       Both files deleted
+                       audit log: apple_mail_sent
+```
+
+## Issuing a send
+
+```bash
+bun ~/.claude/PAI/TOOLS/apple-mail.ts send \
+  --to "team@fwu.de" \
+  --subject "Roadmap-Update" \
+  --body-stdin <<'EOF'
+Hi team,
+
+…body…
+EOF
+```
+
+The tool prints a preview block:
+
+```
+━━━ MAIL DRAFT — APPROVAL REQUIRED ━━━
+To: team@fwu.de
+Subject: Roadmap-Update
+───
+Hi team,
+
+…body…
+───
+Approval token: a3f9e1c2…
+Approve from any channel:
+  - In Claude:  apple-mail send --approval-token a3f9e1c2…
+  - In Pulse:   click the pending notification
+  - Telegram:   /approve-mail a3f9e1c2…
+Expires: 2026-05-17 23:50:00
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+…and exits with code 2 + a JSON status line: `{"status":"awaiting_approval","token":"a3f9e1c2…","channels":["session","pulse","telegram"]}`. Nothing has been sent.
+
+## Approving — three equivalent paths
+
+**Path 1: In Claude session.** Jan types `approve <tok>` or just "ship it"; Timmy runs:
+
+```bash
+bun ~/.claude/PAI/TOOLS/apple-mail.ts send --approval-token a3f9e1c2…
+```
+
+But this still requires the outcome file. Timmy creates it inline:
+
+```bash
+echo '{"decision":"approve","approver":"jan@session","decided":"'$(date -Iseconds)'"}' \
+  > ~/.claude/PAI/MEMORY/STATE/apple-mail-pending/a3f9e1c2…outcome.json
+bun ~/.claude/PAI/TOOLS/apple-mail.ts send --approval-token a3f9e1c2…
+```
+
+(The outcome file is the source-of-truth signal — same shape for all three channels.)
+
+**Path 2: Pulse.** The Pulse notification handler writes the outcome file when Jan clicks ✅. Then Pulse runs the same `apple-mail send --approval-token` command. (Phase-2 work: Pulse needs an approval-panel UI; for v1, Pulse only displays the pending message — Jan still completes the approve via session or Telegram.)
+
+**Path 3: Telegram.** Jan replies in the Telegram chat with the bot:
+
+```
+/approve-mail a3f9e1c2…
+```
+
+The bot-command handler (separate task in `Pulse/modules/telegram.ts`) writes:
+
+```json
+{"decision": "approve", "approver": "telegram:<chat_id>", "decided": "2026-05-17T23:51:00Z"}
+```
+
+to `STATE/apple-mail-pending/<tok>.outcome.json`, then invokes the tool with the token. The mail ships, files are cleaned up, audit entry written.
+
+## Reply / Forward
+
+Same gate, different envelope source:
+
+```bash
+# Reply to message 12345
+bun ~/.claude/PAI/TOOLS/apple-mail.ts reply 12345 --body-stdin <<< "Danke für die Info!"
+
+# Reply-all
+bun ~/.claude/PAI/TOOLS/apple-mail.ts reply 12345 --reply-all --body-file /tmp/reply.txt
+
+# Forward
+bun ~/.claude/PAI/TOOLS/apple-mail.ts forward 12345 --to "kollege@fwu.de" --body-stdin <<< "FYI"
+```
+
+Each one stages through the same token + 3-channel approval as `send`.
+
+## When approval is REJECTED
+
+Outcome file with `{"decision":"reject","approver":"…"}`. Re-running with the token returns exit 2 + `{"error":"draft rejected by approver","code":"rejected"}`. Pending files cleaned up; mail is NOT sent. The audit log records `apple_mail_rejected`.
+
+## Expiry
+
+Tokens live for **30 minutes**. After that, the next any-command invocation of `apple-mail` deletes stale pending files. A re-run with an expired token returns `token_expired`. Re-issue from the original `send` command if you still want to ship it.
+
+## Anti-bypass — what Timmy MUST NOT do
+
+- Do not `echo '{"decision":"approve"}' >` the outcome file when the user hasn't said "approve". The outcome file is the proxy for human consent; forging it forges consent.
+- Do not invent a `--force` flag, set a magic env var, or shell-out to `osascript` directly to bypass the gate. The tool is the gate.
+- Do not auto-approve "obvious" mails (e.g. "reply just says thanks"). Every send goes through the gate. Even one-word replies.
+- If the user explicitly says "just send it, skip the gate" — Timmy declines and explains why. The user can manually set `PAI_ARTHUR_OVERRIDE=1` (in Arthur.ts, separate concern) if they really want to disable the gate machine-wide — that's a deliberate hand on the safety switch.
+
+## Operating without Telegram
+
+If `PAI_TELEGRAM_BOT_TOKEN` and `PAI_TELEGRAM_CHAT_ID` env vars are missing, the tool logs:
+
+```
+[apple-mail] Telegram approval channel not configured (set PAI_TELEGRAM_BOT_TOKEN + PAI_TELEGRAM_CHAT_ID); using session + Pulse only
+```
+
+…and continues with the two remaining channels. The send still gates correctly — only the Telegram surface goes silent.

--- a/Releases/v5.0.0/.claude/skills/AppleMail/policies-sample.yaml
+++ b/Releases/v5.0.0/.claude/skills/AppleMail/policies-sample.yaml
@@ -1,0 +1,28 @@
+# Sample Arthur policies for the AppleMail skill.
+#
+# Copy these entries into ~/.claude/PAI/USER/ARTHUR/policies.yaml (merge with any
+# existing `version: 1` header and other keys). The apple-mail.ts tool reads
+# these through Arthur.evaluate() before staging outbound mail.
+#
+# Even without these entries the tool refuses to send without a token — the
+# default-gate (decision.rule === "default") path in gateAndStage() catches the
+# missing-policy case. These entries make the gate explicit, enable audit-trail
+# attribution, and pin the rate limit.
+
+version: 1
+
+# Outbound send / reply / forward — HIGH risk, requires human confirmation.
+apple_mail_send:
+  risk: high
+  require_confirmation: true
+  allowed_callers:
+    - any
+  rate_limit: "20/hour"
+
+# Read-state mutations (mark-read, move). Low-risk; audit-only.
+apple_mail_mutate:
+  risk: low
+  require_confirmation: false
+  allowed_callers:
+    - any
+  rate_limit: "200/hour"


### PR DESCRIPTION
## What

Adds an **AppleMail** skill + `apple-mail.ts` CLI for macOS Mail.app on PAI v5.0.0, modeled on the existing `gmail.ts` pattern but with a much stricter outbound contract: **no mail leaves the machine without an explicit, regex-validated approval token activated by a human.**

| File | Purpose |
|------|---------|
| `Releases/v5.0.0/.claude/PAI/TOOLS/apple-mail.ts` | Single-file Bun CLI (~1100 lines), AppleScript wrapper, Arthur-gated writes |
| `Releases/v5.0.0/.claude/skills/AppleMail/SKILL.md` | Activation triggers, safety contract, gotchas, setup notes |
| `…/Workflows/Read.md` | Browsing patterns + jq pipelines |
| `…/Workflows/Draft.md` | Compose-and-save (never sends) — the escape hatch for autonomous flows |
| `…/Workflows/SendWithApproval.md` | The full token + 3-channel approval flow + anti-bypass rules |
| `…/policies-sample.yaml` | Drop-in entries for `~/.claude/PAI/USER/ARTHUR/policies.yaml` |

Purely additive — no existing PAI files are modified.

## Why

PAI shipped Gmail (`PAI/TOOLS/gmail.ts`) but had no Apple Mail integration for accounts that aren't in Google Workspace. The same gap that's worth filling is also the right moment to upgrade the safety story: `gmail.ts send` currently has no Arthur gate; reproducing that pattern for Apple Mail would multiply the exposure. This PR introduces the gate pattern on the new tool first so it can be retrofitted to gmail.ts in a follow-up.

## Read surface (autonomous, no gate)

```
apple-mail accounts | mailboxes | unread | list <mailbox> | search "<q>"
           | fetch <id> [--full] | count <mailbox> | drafts | status
```

All return JSON. Pipe to `jq` freely.

## Write surface — the load-bearing contract

`send`, `reply`, `forward` flow:

```
build envelope ──► Arthur.evaluate("apple_mail_send")
                      │
                      ├── ALLOW (explicit, non-default rule) ──► send
                      ├── DENY ──► exit 2, audit
                      └── CONFIRM (or fail-closed) ──► STAGE
                                                       │
                          • 16-byte hex token (regex-validated)
                          • pending file at MEMORY/STATE/apple-mail-pending/<tok>.json
                            (file 0600, dir 0700)
                          • in-session preview block printed to stdout
                          • POST Pulse :31337/notify
                          • POST Telegram bot API (if env vars set) with
                            /approve-mail TOK and /reject-mail TOK hints
                          • exit 2 with awaiting_approval JSON
                          • NOTHING SHIPS
```

Approval comes from any of three channels writing the same outcome file:

```json
{"decision":"approve","approver":"<channel:id>","decided":"<iso>"}
```

Re-invocation with `--approval-token TOK` reads pending + outcome, validates `decision === "approve"`, ships via AppleScript, deletes both files, writes `audit({event_type:"apple_mail_sent", …})`.

## Defense-in-depth: there is no path that sends without explicit consent

- **Token regex validation** before any FS path-join → `--approval-token ../../etc/passwd` returns `token_malformed`, never traverses
- **Arthur unavailable / `policies.yaml` missing** → `gateAndStage()` catches the exception, forces decision to CONFIRM, fail-closed
- **Arthur default-allow (rule === "default", policy not yet wired)** → promoted to CONFIRM via the token gate, audit event `apple_mail_default_gate_engaged`
- **No `--force` / `--skip-approval` / `--no-confirm`** flag exists; `grep -E 'force|skip-approval|no-confirm|bypass' apple-mail.ts` returns only the comment declaring this invariant
- **30-minute token expiry**, swept idempotently at every invocation
- **Pending file mode 0600 in dir 0700**
- **Mark-read/move audit-only**: low-risk read-state mutations bypass CONFIRM but are still audited via `Arthur.audit()`

## Verified

| Probe | Expected | Result |
|-------|----------|--------|
| `apple-mail status` | exit 0, valid JSON | ✓ `{"running":false,"accountCount":0,…}` |
| `send --to X --subject Y --body-stdin <<<Z` | exit 2, `awaiting_approval`, pending file 0600 | ✓ |
| `send --approval-token <unknown 32hex>` | exit 2, `token_unknown` | ✓ |
| `send --approval-token ../../etc/passwd` | exit 2, `token_malformed` (no FS access) | ✓ |
| `send --approval-token <valid, no outcome>` | exit 2, `awaiting_approval` | ✓ |
| Delete `policies.yaml`, retry send | exit 2, `awaiting_approval` (fail-closed) | ✓ |
| Write outcome `decision:approve`, retry send | AppleScript send, exit 0, audit `apple_mail_sent` | ✓ |
| `grep -E 'force\|skip-approval\|no-confirm\|bypass'` on source | 0 functional matches | ✓ (only the declaring comment) |

## Out of scope (follow-up PRs)

1. **Telegram `/approve-mail TOK` and `/reject-mail TOK` chat commands.** Local Pulse module has these wired against a `ThreadStore` architecture; upstream `telegram.ts` is still on `ConversationStore` and has no command handlers. Belongs in a separate PR after (or alongside) the threading refactor.

2. **Retrofit `gmail.ts` with the same Arthur gate.** Same pattern, ~50-line diff, separate additive PR.

3. **Make `Arthur.ts` resilient to missing `policies.yaml`** (currently throws ENOENT; consumers each have to fail-closed at their boundary). Library-level fix; not blocking this PR because `apple-mail.ts` already does the right thing at its boundary.

## Platform

macOS only. `process.platform !== 'darwin'` returns `{error:"apple-mail requires macOS",code:"unsupported_platform"}` and exits 2. Mail.app launches on demand via `osascript activate`.

## Setup (for installers)

1. `bun install` (no new deps beyond what PAI already requires)
2. (optional) Add the entries from `skills/AppleMail/policies-sample.yaml` to `USER/ARTHUR/policies.yaml` for explicit rate limits and audit attribution. The gate still runs without them.
3. (optional) `PAI_TELEGRAM_BOT_TOKEN` + `PAI_TELEGRAM_CHAT_ID` env vars enable the Telegram notify channel. Without them the gate falls back to session + Pulse.
4. macOS: Settings → Privacy & Security → Automation → grant your shell access to Mail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
