### PR TITLE
fix(hooks): RepeatDetection injects warning via stdout, not stderr+exit 2

### DIFF
--- a/Releases/v5.0.0/.claude/hooks/RepeatDetection.hook.ts
+++ b/Releases/v5.0.0/.claude/hooks/RepeatDetection.hook.ts
@@ -106,15 +106,18 @@ function main(): void {
 
   // Threshold: 0.6 (60%) similarity triggers warning
   if (similarity >= 0.6) {
-    // Output warning to stderr — this gets injected into model context
-    process.stderr.write(
+    // Inject the warning into the model's context WITHOUT blocking the prompt.
+    // On a UserPromptSubmit hook, exit 0 + stdout is appended to the model's
+    // context and the user's message still goes through. Exit 2 would instead
+    // ERASE the prompt and route stderr to the user only — the model would
+    // never see the message, which defeats the purpose of this hook.
+    process.stdout.write(
       `⚠️ REPEAT DETECTION: This message is ${Math.round(similarity * 100)}% similar to the previous message. ` +
       `The user is likely REPEATING a request you missed. ` +
       `STOP. Re-read their message carefully. Do NOT proceed with what you were doing before. ` +
       `Address their ACTUAL request this time.`,
     );
-    // Exit 2 = blocking error, stderr fed to Claude
-    process.exit(2);
+    process.exit(0);
   }
 
   process.exit(0);


### PR DESCRIPTION
## Problem

`RepeatDetection.hook.ts` is a `UserPromptSubmit` hook. On a >=60% similarity match it calls `process.stderr.write(...)` then `process.exit(2)`.

For `UserPromptSubmit` hooks, exit code 2 **blocks and erases the prompt**, and routes stderr **to the user only** -- the model never receives the message. Two consequences:

1. The repeat-detection warning the hook is designed to inject into the model's context never arrives there.
2. The user's resent message is silently dropped -- the model never sees it.

The file header comment states the hook "injects a high-priority WARNING into the model's context forcing re-reading of the user's message." The implementation does the opposite of that intent.

## Fix

The correct channel for `UserPromptSubmit` context injection is **exit 0 with the text on stdout** -- stdout from a `UserPromptSubmit` hook is appended to the model's context, and the prompt proceeds normally.

This swaps `process.stderr.write` -> `process.stdout.write` and `process.exit(2)` -> `process.exit(0)` in the trigger branch. Detection logic (the 0.6 threshold, tokenizer, and trigram similarity) is unchanged. 7 insertions, 4 deletions, one file.

## Testing

- `bun build` on the hook: clean.
- Behavioral: with the fix, a >=60%-similar follow-up arrives intact with the warning prepended as context -- verified via synthetic `UserPromptSubmit` stdin and live in a Claude Code session. Before the fix, the same message was erased before reaching the model.

## Reference

Claude Code hooks documentation, `UserPromptSubmit` exit-code semantics: exit 2 blocks/erases the prompt with stderr shown to the user only; exit 0 stdout is added to the model's context.
