### PR TITLE
fix(tools): apply #1175 casing fix to residual TOOLS/ call sites

### DIFF
--- a/Releases/v5.0.0/.claude/PAI/TOOLS/DASchedule.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/DASchedule.ts
@@ -15,7 +15,7 @@ import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync } fr
 
 const HOME = process.env.HOME ?? "~"
 const PAI_DIR = join(HOME, ".claude", "PAI")
-const TASKS_DIR = join(PAI_DIR, "Pulse", "state", "da")
+const TASKS_DIR = join(PAI_DIR, "PULSE", "state", "da")
 const TASKS_PATH = join(TASKS_DIR, "scheduled-tasks.jsonl")
 
 // ── Types ──

--- a/Releases/v5.0.0/.claude/PAI/TOOLS/MemoryRetriever.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/MemoryRetriever.ts
@@ -283,7 +283,7 @@ function extractExcerpt(note: KnowledgeNote, queryTerms: string[]): string {
 // ============================================================================
 
 function compress(text: string, budget: number): string {
-  const inferPath = path.join(PAI_DIR, "Tools", "Inference.ts");
+  const inferPath = path.join(PAI_DIR, "TOOLS", "Inference.ts");
 
   if (!fs.existsSync(inferPath)) {
     // Fallback: truncate to approximate token count

--- a/Releases/v5.0.0/.claude/PAI/TOOLS/pai.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/pai.ts
@@ -31,7 +31,7 @@ import { join, basename } from "path";
 const CLAUDE_DIR = join(homedir(), ".claude");
 const MCP_DIR = join(CLAUDE_DIR, "MCPs");
 const ACTIVE_MCP = join(CLAUDE_DIR, ".mcp.json");
-const BANNER_SCRIPT = join(homedir(), ".claude", "PAI", "Tools", "Banner.ts");
+const BANNER_SCRIPT = join(homedir(), ".claude", "PAI", "TOOLS", "Banner.ts");
 const VOICE_SERVER = "http://localhost:31337/notify/personality";
 const WALLPAPER_DIR = join(homedir(), "Projects", "Wallpaper");
 // Note: RAW archiving removed - Claude Code handles its own cleanup (30-day retention in projects/)


### PR DESCRIPTION
## Summary

Follow-up to #1175 / #1259 / #1267 / #1273. Audit of `Releases/v5.0.0/.claude/PAI/` for residual TitleCase directory names in path-construction calls found three more sites — all in `TOOLS/`. Same root cause, same fix shape, same risk profile as the prior PRs.

On macOS HFS+/APFS (case-insensitive default), TitleCase and UPPERCASE resolve to the same directory — bug is invisible. On Linux ext4/btrfs (case-sensitive), each `join()` resolves to a non-existent path and the affected feature silently fails.

## Confirmed canonical casing in v5.0.0

```
ALGORITHM/  DOCUMENTATION/  MEMORY/  PULSE/  TOOLS/  USER/  TEMPLATES/  PAI-Install/  bin/
```

All top-level dirs except `PAI-Install` and `bin` are UPPERCASE.

## Fix table

| File | Line | Was | Now |
|---|---|---|---|
| `TOOLS/DASchedule.ts` | 18 | `join(PAI_DIR, "Pulse", "state", "da")` | `"PULSE"` |
| `TOOLS/MemoryRetriever.ts` | 286 | `path.join(PAI_DIR, "Tools", "Inference.ts")` | `"TOOLS"` |
| `TOOLS/pai.ts` | 34 | `join(homedir(), ".claude", "PAI", "Tools", "Banner.ts")` | `"TOOLS"` |

Total: **3 string changes across 3 files.**

User-visible Linux failures pre-patch:

- `TOOLS/pai.ts:34` — `BANNER_SCRIPT` points at non-existent `Tools/Banner.ts`; banner load fails silently when the `pai` CLI runs.
- `TOOLS/DASchedule.ts:18` — DA scheduled-task state directory not found; scheduling state cannot be read/written.
- `TOOLS/MemoryRetriever.ts:286` — `Inference.ts` fallback path missing; compression takes the substring-truncation degraded path instead of the LLM compression path.

## Reproduction (against the release tree)

```bash
$ ls -d Releases/v5.0.0/.claude/PAI/Pulse 2>&1
ls: cannot access 'Releases/v5.0.0/.claude/PAI/Pulse': No such file or directory

$ ls -d Releases/v5.0.0/.claude/PAI/Tools 2>&1
ls: cannot access 'Releases/v5.0.0/.claude/PAI/Tools': No such file or directory

$ ls -d Releases/v5.0.0/.claude/PAI/PULSE Releases/v5.0.0/.claude/PAI/TOOLS
Releases/v5.0.0/.claude/PAI/PULSE
Releases/v5.0.0/.claude/PAI/TOOLS
```

Each `join(PAI_DIR, "Pulse"|"Tools", …)` resolves to one of those ENOENT paths on Linux.

## Audit method

```bash
cd Releases/v5.0.0/.claude/PAI
grep -rn --include='*.ts' -E '"(Pulse|Memory|Skills|Tools|Algorithm|Documentation|User)"' . \
  | grep -E 'join|path\.|resolve|readFile|existsSync|readdirSync'
```

Six hits on current `main` after the prior PRs landed. Three were false positives and are NOT touched here:

- `PULSE/pulse-old.ts:49` — dead code (zero references anywhere in repo).
- `PAI-Install/engine/actions.ts:1405` — per-skill `Tools/` subdir convention (TitleCase), distinct from top-level `TOOLS/`.
- `TOOLS/ArchitectureSummaryGenerator.ts:27` — `DOCUMENTATION/Memory/` is the legitimate TitleCase subdir of `DOCUMENTATION/`.

The remaining three are this PR.

## Risk

Very low — identical risk profile to #1175.

- **Linux:** affected call sites previously silently broken → now work (intended fix).
- **macOS:** behavior unchanged — case-insensitive HFS+/APFS already resolved TitleCase to the canonical UPPERCASE directory, so the same paths resolved fine before and after.
- **No semantic changes** — only path-string casing.
- **No public API touched. No config schema changes.**

## Optional follow-up — CI lint

This is the fifth PR in the same bug class (after #1175 / #1259 / #1267 / #1273). A CI lint that fails the build when `"Pulse"|"Memory"|"Algorithm"|"Tools"` (TitleCase) appears inside `join()` / `path.*` / `resolve()` calls would prevent the next round. Out of scope here.
