### PR TITLE
fix(RepeatDetection): use stdout+exit 0 to inject warning as additionalContext

### DIFF
--- a/Releases/v5.0.0/.claude/hooks/RepeatDetection.hook.ts
+++ b/Releases/v5.0.0/.claude/hooks/RepeatDetection.hook.ts
@@ -106,15 +106,17 @@ function main(): void {
 
   // Threshold: 0.6 (60%) similarity triggers warning
   if (similarity >= 0.6) {
-    // Output warning to stderr — this gets injected into model context
-    process.stderr.write(
+    // UserPromptSubmit hook contract: stdout + exit 0 injects the text as
+    // additionalContext into the model's context (the desired behavior).
+    // stderr + exit 2 blocks the prompt and surfaces the warning to the
+    // user instead of injecting it for the model — wrong direction.
+    process.stdout.write(
       `⚠️ REPEAT DETECTION: This message is ${Math.round(similarity * 100)}% similar to the previous message. ` +
       `The user is likely REPEATING a request you missed. ` +
       `STOP. Re-read their message carefully. Do NOT proceed with what you were doing before. ` +
       `Address their ACTUAL request this time.`,
     );
-    // Exit 2 = blocking error, stderr fed to Claude
-    process.exit(2);
+    process.exit(0);
   }
 
   process.exit(0);


### PR DESCRIPTION
## Summary

`RepeatDetection.hook.ts` (UserPromptSubmit hook) writes its warning to **stderr** and exits with **code 2**, which is the Claude Code hook **block** pattern — it prevents the user's prompt from being processed and surfaces the warning text to the user.

The desired behavior, per the hook's own docstring ("injects a high-priority WARNING into the model's context"), is the **additionalContext** pattern: write to **stdout** and exit with **code 0**. That signals Claude Code to inject the text into the model's context for the next turn, while letting the prompt proceed.

## Bug observed

When the hook triggered on a repeated prompt:

1. The user's repeated prompt was **blocked** (the user is the one repeating, so blocking them doesn't help).
2. The "⚠️ REPEAT DETECTION" warning surfaced **to the user** instead of to the model.
3. The model never received the signal it was supposed to use to re-read the message.

## Fix

Two-line change in `Releases/v5.0.0/.claude/hooks/RepeatDetection.hook.ts`:

- `process.stderr.write(...)` → `process.stdout.write(...)`
- `process.exit(2)` → `process.exit(0)`

Comments updated to reflect the corrected semantics. No other behavior changed; the detection logic, threshold (0.6 jaccard similarity), and warning text are unchanged.

## Reference

Claude Code UserPromptSubmit hook contract: stdout + exit 0 = `additionalContext` injected for the model; stderr + exit 2 = block + surface to user. The latter is intended for security/policy violations where the prompt should not proceed.