### PR TITLE
fix(pulse): create ~/Library/LaunchAgents before writing launchd plist

### DIFF
--- a/Releases/v5.0.0/.claude/PAI/PULSE/manage.sh
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/manage.sh
@@ -84,7 +84,7 @@ case "$1" in
     ;;
 
   install)
-    mkdir -p "$PULSE_DIR/state" "$PULSE_DIR/logs"
+    mkdir -p "$PULSE_DIR/state" "$PULSE_DIR/logs" "$HOME/Library/LaunchAgents"
 
     # Cleanup any prior pulse before installing fresh — prevents the stale-PID
     # / unbound-port half-dead state where a previous launchd-managed pulse is


### PR DESCRIPTION
## Problem

`PULSE/manage.sh install` writes the launchd plist to `$HOME/Library/LaunchAgents/`:

```sh
PLIST_DST="$HOME/Library/LaunchAgents/$PLIST_NAME.plist"
...
sed -e "s|__HOME__|$HOME|g" -e "s|__BUN_PATH__|$BUN_PATH|g" "$PLIST_SRC" > "$PLIST_DST"
```

…but the `install)` case only creates `state/` and `logs/`:

```sh
mkdir -p "$PULSE_DIR/state" "$PULSE_DIR/logs"
```

On a fresh macOS user account, `~/Library/LaunchAgents/` does not exist until something
creates it. When it's missing, the `> "$PLIST_DST"` redirect fails with
`No such file or directory`, the install aborts, and the user sees a confusing
`port 31337 did not bind` error with no obvious cause.

## Fix

Add `"$HOME/Library/LaunchAgents"` to the existing `mkdir -p`. One-line, idempotent,
no behavior change on accounts where the directory already exists.

```diff
-    mkdir -p "$PULSE_DIR/state" "$PULSE_DIR/logs"
+    mkdir -p "$PULSE_DIR/state" "$PULSE_DIR/logs" "$HOME/Library/LaunchAgents"
```

Hit this on a fresh-account PAI 5 install; this exact patch has been running locally
since. Related to the opaque-install-failure reports.
