### PR TITLE
fix(installer): surface manage.sh stderr when Pulse install fails

### DIFF
--- a/Releases/v5.0.0/.claude/PAI/PAI-Install/engine/actions.ts
+++ b/Releases/v5.0.0/.claude/PAI/PAI-Install/engine/actions.ts
@@ -1588,18 +1588,24 @@ async function installPulse(paiDir: string, emit: EngineEventHandler): Promise<b
   await emit({ event: "progress", step: "voice", percent: 20, detail: "Installing Pulse (voice + dashboard + observability)..." });
 
   try {
+    // Capture manage.sh stderr so a failed install reports the actual cause
+    // (e.g. missing ~/Library/LaunchAgents, sed/launchctl errors) instead of a
+    // generic message that sends users hunting blind.
+    let installStderr = "";
     const installOk = await new Promise<boolean>((resolve) => {
       const child = spawn("bash", [manageScript, "install"], {
         cwd: pulseDir,
         stdio: ["ignore", "pipe", "pipe"],
       });
+      child.stderr?.on("data", (chunk) => { installStderr += chunk.toString(); });
       const timer = setTimeout(() => { child.kill(); resolve(false); }, 30000);
       child.on("close", (code) => { clearTimeout(timer); resolve(code === 0); });
       child.on("error", () => { clearTimeout(timer); resolve(false); });
     });
 
     if (!installOk) {
-      await emit({ event: "message", content: "Pulse install command failed. Voice notifications will not be available." });
+      const tail = installStderr.trim().split("\n").slice(-20).join("\n");
+      await emit({ event: "message", content: "Pulse install command failed. Voice notifications will not be available." + (tail ? "\nmanage.sh stderr (last lines):\n" + tail : "") });
       return false;
     }
 


### PR DESCRIPTION
## Problem

When Pulse fails to install, `installPulse()` reports a generic message and discards the
real cause. It spawns `manage.sh install` with stderr piped, but never reads the pipe:

```ts
const installOk = await new Promise<boolean>((resolve) => {
  const child = spawn("bash", [manageScript, "install"], {
    cwd: pulseDir,
    stdio: ["ignore", "pipe", "pipe"],   // stderr piped...
  });
  const timer = setTimeout(() => { child.kill(); resolve(false); }, 30000);
  child.on("close", (code) => { clearTimeout(timer); resolve(code === 0); });  // ...but never read
  child.on("error", () => { clearTimeout(timer); resolve(false); });
});

if (!installOk) {
  await emit({ event: "message", content: "Pulse install command failed. Voice notifications will not be available." });
  return false;
}
```

So a real failure inside `manage.sh` (missing `~/Library/LaunchAgents`, a `sed`/`launchctl`
error, etc.) is swallowed — the installer prints "install command failed" with no detail
and the user is left guessing.

## Fix

Accumulate the already-piped stderr and include its tail in the failure message. No new
process behavior, no extra spawn — just stop throwing away output we're already capturing.

```ts
let installStderr = "";
// ...
child.stderr?.on("data", (chunk) => { installStderr += chunk.toString(); });
// ...
if (!installOk) {
  const tail = installStderr.trim().split("\n").slice(-20).join("\n");
  await emit({ event: "message", content: "Pulse install command failed. Voice notifications will not be available." + (tail ? "\nmanage.sh stderr (last lines):\n" + tail : "") });
  return false;
}
```

Pairs with #1310 — that fixes one common cause of the silent failure; this makes any
remaining cause visible instead of opaque.
