### PR TITLE
fix(telos): align dashboard engineer cap to 16 (was split 10/16)

### DIFF
--- a/Releases/v5.0.0/.claude/skills/Telos/SKILL.md
+++ b/Releases/v5.0.0/.claude/skills/Telos/SKILL.md
@@ -70,7 +70,7 @@ User: "analyze ~/Projects/MyApp with TELOS"
 **Example 3: Build project dashboard**
 ```
 User: "build a dashboard for TELOSAPP"
---> Launches up to 10 parallel engineers
+--> Launches up to 16 parallel engineers
 --> Creates Next.js dashboard with shadcn/ui + Aceternity
 --> Returns interactive dashboard with dependency graphs, metrics cards, progress tables
 ```
@@ -380,7 +380,7 @@ Engineer 10: Integration and testing
 2. **Auto-Detection** - Determines context from user question
 3. **Flexible Discovery** - Finds files regardless of structure
 4. **TELOS Methodology** - Applies relationships, dependencies, goals, narratives
-5. **Parallel Execution** - Up to 10 engineers for dashboard builds
+5. **Parallel Execution** - Up to 16 engineers for dashboard builds
 6. **Visual Excellence** - Beautiful outputs with shadcn/ui + Aceternity
 7. **Privacy-Aware** - Respects sensitive data
 8. **Integrated** - Works with development, research, and other skills


### PR DESCRIPTION
`Releases/v5.0.0/.claude/skills/Telos/SKILL.md` named two different caps for the dashboard-build engineer fan-out, and each one appeared twice:

- [L3](https://github.com/danielmiessler/Personal_AI_Infrastructure/blob/2fde1bbe9e8f280cd4998e244b53e3c66f3dc8b9/Releases/v5.0.0/.claude/skills/Telos/SKILL.md#L3) (`description`): "up to **16** parallel engineers"
- [L265](https://github.com/danielmiessler/Personal_AI_Infrastructure/blob/2fde1bbe9e8f280cd4998e244b53e3c66f3dc8b9/Releases/v5.0.0/.claude/skills/Telos/SKILL.md#L265) (`CRITICAL` build instruction): "up to **16** parallel engineers"
- [L73](https://github.com/danielmiessler/Personal_AI_Infrastructure/blob/2fde1bbe9e8f280cd4998e244b53e3c66f3dc8b9/Releases/v5.0.0/.claude/skills/Telos/SKILL.md#L73) (routing comment): "up to **10** parallel engineers"
- [L383](https://github.com/danielmiessler/Personal_AI_Infrastructure/blob/2fde1bbe9e8f280cd4998e244b53e3c66f3dc8b9/Releases/v5.0.0/.claude/skills/Telos/SKILL.md#L383) (Parallel Execution summary): "Up to **10** engineers for dashboard builds"

The `CRITICAL` directive on L265 is the line that drives build-time behavior, and it says 16, with the description agreeing. I assume 16 as the cap you meant and lines 73/383 as leftovers from an earlier number, so this raises those two to 16. All four references now agree.

If 10 was the ceiling you want here, I can flip it the other way.
