### PR TITLE
fix(CostTracker): don't classify package.json SDK deps as BYPASS call sites

### DIFF
--- a/Releases/v5.0.0/.claude/PAI/TOOLS/CostTracker.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/CostTracker.ts
@@ -191,6 +191,12 @@ function classifyCallSite(file: string, reason: string): { classification: "bypa
   if (file.endsWith(".md")) {
     return { classification: "legit", note: "markdown (docs/template) — no runtime billing risk" };
   }
+  // Dependency manifests / lockfiles declare packages — they don't execute, so an
+  // SDK name appearing here is a declaration, not a billing call site.
+  if (file.endsWith("package.json") || file.endsWith("package-lock.json") ||
+      file.endsWith("bun.lock") || file.endsWith("bun.lockb") || file.endsWith("yarn.lock")) {
+    return { classification: "legit", note: "dependency manifest — declaration, not a runtime call" };
+  }
   for (const [hint, note] of Object.entries(LEGIT_HINTS)) {
     if (file.includes(hint)) return { classification: "legit", note };
   }


### PR DESCRIPTION
## Problem

`classifyCallSite()` in `CostTracker.ts` special-cases `.md` files as non-executable, but never handled **dependency manifests**. When a `package.json` under a scan root (e.g. `PULSE/`, `skills/`) lists `@anthropic-ai/*` as a dependency, the `@anthropic-ai/...` `RISK_PATTERN` matches the manifest text; the file isn't `.md`, isn't in `LEGIT_HINTS`, and has no `ANTHROPIC_API_KEY`-delete guard, so it falls through to the `"SDK"` branch and is misclassified as a **`bypass`** call site.

Result: a phantom *"N call site(s) classified as BYPASS — review and patch"* cost alert — even though a dependency **declaration** never executes and never bills. The real runtime callers (e.g. `PULSE/modules/telegram.ts`, `imessage.ts`) are already correctly classified `legit` via the `delete process.env.ANTHROPIC_API_KEY` guard.

## Reproduce

With `@anthropic-ai/claude-agent-sdk` declared in `PULSE/package.json`:

```
$ bun CostTracker.ts scan
🔴 ~/.claude/PAI/PULSE/package.json:3
   SDK call without ANTHROPIC_API_KEY-delete guard — will bill API if key present in env
```

That line is a manifest dependency, not a call site → false positive (and it fires the BYPASS alert).

## Fix

Mirror the existing `.md` rule for dependency manifests / lockfiles (`package.json`, `package-lock.json`, `bun.lock`, `bun.lockb`, `yarn.lock`): they declare packages, they don't execute, so an SDK name appearing in them is a declaration, not a billing call site.

After the fix: `package.json` classifies `legit`, `bypass: 0`, `alert-check` → no alerts. Genuine executable risk patterns (SDK usage in `.ts` without the guard, `claude --bare`, raw `x-api-key` HTTP) still fire as before.

## Note

In this repo `CostTracker.ts` currently lives only at `Releases/v5.0.0/.claude/PAI/TOOLS/CostTracker.ts`, so the fix is applied there. Happy to retarget if there's a canonical source location elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
