### PR TITLE
chore: pin CI actions to commit SHA, add Python gitignore entries

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,8 @@
 *.ts text eol=lf
 *.js text eol=lf
 *.sh text eol=lf
+# Python
+*.py text eol=lf
 *.md text eol=lf
 *.json text eol=lf
 *.yaml text eol=lf

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,13 +27,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@70a6e5256e9e2366a1ed5c041904a982ba3a328f # v1.0.135
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@70a6e5256e9e2366a1ed5c041904a982ba3a328f # v1.0.135
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,17 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.coverage
+.coverage.*
+coverage/
+htmlcov/
+.venv/
+venv/
+
+# Windows
+Thumbs.db
+
 # macOS
 .DS_Store
 .AppleDouble


### PR DESCRIPTION
Two small housekeeping items:

**CI supply chain hardening**
Both workflows (`claude.yml`, `claude-code-review.yml`) used floating version tags for `actions/checkout` (`@v4`) and `anthropics/claude-code-action` (`@v1`). Pinning to the specific commit SHA these tags currently resolve to prevents a tag-move supply chain attack.

- `actions/checkout@v4` → `34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1, verified against the repo tag)
- `anthropics/claude-code-action@v1` → `70a6e5256e9e2366a1ed5c041904a982ba3a328f` (v1.0.135, verified against the repo tag)

Comments show the semantic version for human reference, but the action resolves by SHA.

**.gitignore + .gitattributes**
The repo contains Python files across PACKs and tooling. Added `__pycache__`, `.coverage`, `.venv`, `*.pyc`, and related build/cache patterns to `.gitignore`, plus `Thumbs.db`. Added `*.py text eol=lf` to `.gitattributes`.