### PR TITLE
fix: resolve PROJECTS.md to correct USER/PROJECTS/ path in Telos dashboard

### DIFF
--- a/Releases/v2.5/.claude/skills/Telos/DashboardTemplate/App/api/file/save/route.ts
+++ b/Releases/v2.5/.claude/skills/Telos/DashboardTemplate/App/api/file/save/route.ts
@@ -3,7 +3,13 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 
-const TELOS_DIR = path.join(os.homedir(), '.claude/skills/life/telos')
+const TELOS_DIR = path.join(os.homedir(), '.claude/skills/PAI/USER/TELOS')
+const PROJECTS_FILE = path.join(os.homedir(), '.claude/skills/PAI/USER/PROJECTS/PROJECTS.md')
+
+function resolveTelosFilePath(filename: string): string {
+  if (filename === 'PROJECTS.md') return PROJECTS_FILE
+  return path.join(TELOS_DIR, filename)
+}
 
 export async function POST(request: Request) {
   try {
@@ -24,7 +30,7 @@ export async function POST(request: Request) {
       const csvDir = path.join(TELOS_DIR, 'data')
       filePath = path.join(csvDir, filename)
     } else {
-      filePath = path.join(TELOS_DIR, filename)
+      filePath = resolveTelosFilePath(filename)
     }
 
     // Verify file exists before overwriting

--- a/Releases/v2.5/.claude/skills/Telos/DashboardTemplate/Lib/telos-data.ts
+++ b/Releases/v2.5/.claude/skills/Telos/DashboardTemplate/Lib/telos-data.ts
@@ -10,6 +10,13 @@ export interface TelosFile {
 }
 
 const TELOS_DIR = path.join(os.homedir(), '.claude/skills/PAI/USER/TELOS')
+// PROJECTS.md lives alongside other USER dirs, not inside TELOS
+const PROJECTS_FILE = path.join(os.homedir(), '.claude/skills/PAI/USER/PROJECTS/PROJECTS.md')
+
+function resolveTelosFilePath(filename: string): string {
+  if (filename === 'PROJECTS.md') return PROJECTS_FILE
+  return path.join(TELOS_DIR, filename)
+}
 
 export function getAllTelosData(): TelosFile[] {
   const files: TelosFile[] = []
@@ -22,7 +29,7 @@ export function getAllTelosData(): TelosFile[] {
       for (const filename of dirFiles) {
         if (filename.endsWith('.md') && !filename.startsWith('.')) {
           try {
-            const filePath = path.join(TELOS_DIR, filename)
+            const filePath = resolveTelosFilePath(filename)
             const stats = fs.statSync(filePath)
 
             if (stats.isFile()) {


### PR DESCRIPTION
## Problem

`PROJECTS.md` lives at `PAI/USER/PROJECTS/PROJECTS.md`, not inside `PAI/USER/TELOS/`. Both `getAllTelosData()` in `telos-data.ts` and the save route in `api/file/save/route.ts` were resolving it through `TELOS_DIR`, so clicking a project card in the Telos dashboard returned an empty/missing file.

## Fix

Add a `resolveTelosFilePath()` helper in both files that routes `PROJECTS.md` requests to `USER/PROJECTS/PROJECTS.md` and all other files through `TELOS_DIR` as before.

Also aligns the `TELOS_DIR` constant in `save/route.ts` with `telos-data.ts` — it was still pointing to the old `life/telos` path.

## Files changed

- `Releases/v2.5/.claude/skills/Telos/DashboardTemplate/Lib/telos-data.ts`
- `Releases/v2.5/.claude/skills/Telos/DashboardTemplate/App/api/file/save/route.ts`