### PR TITLE
fix(TOOLS): frontmatter parser drops block-list tags/related — KnowledgeGraph edges silently dead

### DIFF
--- a/Releases/v5.0.0/.claude/PAI/TOOLS/KnowledgeGraph.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/KnowledgeGraph.ts
@@ -80,20 +80,44 @@ function parseFrontmatter(content: string): Record<string, any> {
   const match = content.match(/^---\n([\s\S]*?)\n---/);
   if (!match) return {};
   const result: Record<string, any> = {};
-  for (const line of match[1].split("\n")) {
+  const lines = match[1].split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.startsWith("  ") || line.startsWith("\t")) continue;
     const colonIdx = line.indexOf(":");
     if (colonIdx > 0) {
       const key = line.substring(0, colonIdx).trim();
-      // Skip indented lines (YAML nested content handled separately)
-      if (line.startsWith("  ") || line.startsWith("\t")) continue;
       let value: any = line.substring(colonIdx + 1).trim();
-      if (value.startsWith("[") && value.endsWith("]")) {
+      if (value.length === 0) {
+        const items: string[] = [];
+        let j = i + 1;
+        while (j < lines.length && (lines[j].startsWith("  ") || lines[j].startsWith("\t"))) {
+          const itemLine = lines[j].trim();
+          if (itemLine.startsWith("-")) {
+            let item = itemLine.replace(/^-\s*/, "");
+            const quotedItem = item.match(/^\s*(["'])([\s\S]*)\1\s*$/);
+            if (quotedItem) {
+              item = quotedItem[2];
+            }
+            item = item.trim();
+            if (item.length > 0) {
+              items.push(item);
+            }
+          }
+          j++;
+        }
+        if (items.length > 0) {
+          value = items;
+          i = j - 1;
+        }
+      }
+      if (typeof value === "string" && value.startsWith("[") && value.endsWith("]")) {
         value = value
           .slice(1, -1)
           .split(",")
           .map((s: string) => s.trim().replace(/['"]/g, ""))
           .filter((s: string) => s.length > 0);
-      } else if (value.startsWith('"') && value.endsWith('"')) {
+      } else if (typeof value === "string" && value.startsWith('"') && value.endsWith('"')) {
         value = value.slice(1, -1);
       }
       result[key] = value;
@@ -127,6 +151,41 @@ function extractRelated(content: string): Array<{ slug: string; type: string }> 
   const lines = fmMatch[1].split("\n");
   let inRelated = false;
   let currentSlug: string | null = null;
+  let currentType = "related";
+
+  function normalizeSlug(value: string): string {
+    let slug = value.trim();
+    const quoted = slug.match(/^(['"])([\s\S]*)\1$/);
+    if (quoted) {
+      slug = quoted[2];
+    }
+    slug = slug.trim();
+    if (slug.startsWith("[[") && slug.endsWith("]]")) {
+      slug = slug.slice(2, -2).trim();
+    }
+    if (slug.includes("|")) {
+      slug = slug.split("|")[0].trim();
+    }
+    if (slug.includes("/")) {
+      slug = slug.split("/").pop()!.trim();
+    }
+    slug = slug.replace(/^\[+/, "").replace(/\]+$/, "").trim();
+    const requoted = slug.match(/^(['"])([\s\S]*)\1$/);
+    if (requoted) {
+      slug = requoted[2].trim();
+    }
+    return slug;
+  }
+
+  function pushCurrent(): void {
+    if (!currentSlug) return;
+    const slug = normalizeSlug(currentSlug);
+    if (slug.length > 0) {
+      related.push({ slug, type: currentType || "related" });
+    }
+    currentSlug = null;
+    currentType = "related";
+  }
 
   for (const line of lines) {
     if (line.match(/^related\s*:/)) {
@@ -136,37 +195,41 @@ function extractRelated(content: string): Array<{ slug: string; type: string }> 
     if (inRelated) {
       // End of related block: non-indented, non-empty line that isn't a list item
       if (!line.startsWith("  ") && !line.startsWith("\t") && !line.startsWith("-") && line.trim().length > 0) {
+        pushCurrent();
         inRelated = false;
         continue;
       }
-      // New list item
-      if (line.trim().startsWith("- slug:") || line.trim().startsWith("slug:")) {
+      const trimmed = line.trim();
+      if (trimmed.length === 0) continue;
+      // New structured list item
+      if (trimmed.startsWith("- slug:") || trimmed.startsWith("slug:")) {
+        pushCurrent();
         const slugMatch = line.match(/slug:\s*(.+)/);
         if (slugMatch) {
-          // Push previous entry if exists
-          if (currentSlug) {
-            related.push({ slug: currentSlug, type: "related" });
-          }
-          currentSlug = slugMatch[1].trim().replace(/['"]/g, "");
+          currentSlug = slugMatch[1].trim();
+          currentType = "related";
+        }
+        continue;
+      }
+      // Simple list item
+      if (trimmed.startsWith("-")) {
+        pushCurrent();
+        const slug = normalizeSlug(trimmed.replace(/^-\s*/, ""));
+        if (slug.length > 0) {
+          related.push({ slug, type: "related" });
         }
         continue;
       }
       // Type line for current slug
       const typeMatch = line.match(/type:\s*(.+)/);
       if (typeMatch && currentSlug) {
-        related.push({
-          slug: currentSlug,
-          type: typeMatch[1].trim().replace(/['"]/g, ""),
-        });
-        currentSlug = null;
+        currentType = typeMatch[1].trim().replace(/['"]/g, "");
+        pushCurrent();
         continue;
       }
     }
   }
-  // Push trailing slug without type
-  if (currentSlug) {
-    related.push({ slug: currentSlug, type: "related" });
-  }
+  pushCurrent();
 
   return related;
 }

--- a/Releases/v5.0.0/.claude/PAI/TOOLS/MemoryRetriever.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/MemoryRetriever.ts
@@ -93,15 +93,29 @@ function parseFrontmatter(content: string): { frontmatter: Frontmatter; body: st
   if (!match) return { frontmatter: {}, body: content };
 
   const result: Frontmatter = {};
+  let blockKey: string | null = null; // top-level key currently collecting a YAML block-list
   for (const line of match[1].split("\n")) {
+    // Block-list item: an indented "- item" belongs to the preceding empty-valued key.
+    const listItem = line.match(/^\s+-\s+(.*)$/);
+    if (blockKey && listItem) {
+      const item = listItem[1].trim().replace(/^['"]|['"]$/g, "");
+      if (item.length > 0) {
+        if (!Array.isArray(result[blockKey])) result[blockKey] = [];
+        (result[blockKey] as string[]).push(item);
+      }
+      continue;
+    }
+    if (line.startsWith(" ") || line.startsWith("\t")) continue; // skip other nested lines
     const colonIdx = line.indexOf(":");
     if (colonIdx > 0) {
       const key = line.substring(0, colonIdx).trim();
       let value: string | string[] = line.substring(colonIdx + 1).trim();
+      if (value === "") { blockKey = key; continue; } // maybe a YAML block-list parent
       if (typeof value === "string" && value.startsWith("[") && value.endsWith("]")) {
-        value = value.slice(1, -1).split(",").map((s: string) => s.trim().replace(/['"]/g, ""));
+        value = value.slice(1, -1).split(",").map((s: string) => s.trim().replace(/['"]/g, "")).filter((s: string) => s.length > 0);
       }
       result[key] = value;
+      blockKey = null;
     }
   }
 


### PR DESCRIPTION
# fix(TOOLS): frontmatter parser drops YAML block-list `tags:`/`related:` → KnowledgeGraph tag & related edges are silently dead

## TL;DR
On any real knowledge archive, `KnowledgeGraph.ts` reports **`tag: 0` and `related: 0` edges** — only body `[[wikilinks]]` ever connect. Root cause: the hand-rolled frontmatter parser **skips indented lines**, so the YAML *block-list* form of `tags:` and `related:` (which is what the Knowledge skill actually writes) is never parsed. The same defect kills `MemoryRetriever.ts`'s tag-match bonus. Two-function fix per file; weights, BFS, and CLI behavior untouched.

## Reproduction (v5.0.0, before)
```
$ bun .claude/PAI/TOOLS/KnowledgeGraph.ts stats
  Nodes: 120
  Edges: 304 (tag: 0, wikilink: 304, related: 0)   ← tag & related edge classes empty
  Isolated nodes: 16
```
A note whose frontmatter is the standard block-list form:
```yaml
tags:
  - area/healthcare
  - role/physician
related:
  - "[[albert-einstein-hospital]]"
```
shows `Tags: []` and **"No direct connections found"** in `related <slug>` — its weight-5 `related` edges and weight-1 tag edges never form.

## Root cause
1. **`parseFrontmatter()`** (`KnowledgeGraph.ts` ~L88, `MemoryRetriever.ts` ~L98) does `if (line.startsWith("  ") || line.startsWith("\t")) continue;`. The indented `  - item` lines of a block list are skipped, so `tags:`/`related:` resolve to empty → `node.tags = []` → **zero tag co-occurrence edges**, and notes render `type: unknown`.
2. **`extractRelated()`** (`KnowledgeGraph.ts`) only recognizes the *structured* `- slug:` / `type:` form. Real notes use wikilink list items (`- "[[slug]]"`), so **zero `related` edges** form.

Net: of the three documented edge classes (related=5, wikilink=3, tag=1), only wikilink (body-scanned) works. The graph layer is effectively non-functional for the note format the Knowledge skill itself produces.

## The fix (scope-contained — only the two parser functions)
- **`parseFrontmatter()`**: parse YAML block-list values (`key:` followed by indented `- item` lines) into a `string[]`, stripping `- ` and matched quotes; inline `[a, b]` arrays and quoted scalars still parse; no lowercasing (callers handle it).
- **`extractRelated()`**: a `normalizeSlug()` helper extracts the target from all four item forms — `- "[[slug]]"`, `- [[slug]]`, `- "slug"`, `- slug` — unwrapping `[[…]]`, dropping `|alias`, keeping the last `/` segment; the legacy `- slug:`/`type:` structured form still works.
- `buildGraph`, BFS/`traverse`, edge weights (5/3/1), `TAG_GROUP_CAP`, and every CLI verb are **unchanged**.

## Testing evidence (after)
```
$ bun .claude/PAI/TOOLS/KnowledgeGraph.ts stats
  Nodes: 120
  Edges: 10672 (tag: 9936, wikilink: 304, related: 432)   ← both classes live; wikilink unchanged
  Isolated nodes: 2
```
- `related <slug>` now resolves the note's real typed `related:` links and its tags.
- **`MemoryRetriever.ts`**: a query whose term appears *only* in a note's `tags:` (absent from the body) now retrieves it at `score: 5.0` (= `TAG_MATCH_WEIGHT`) — impossible before (tags parsed to `[]`).
- Correctness checks: a note *without* a `tags:` field still shows `Tags: []` (no over-match / contamination); top tag clusters are real facets, not parser artifacts; `git diff` hunks are confined to `parseFrontmatter` + `extractRelated`; all CLI verbs exit 0; node count unchanged (skip-files honored).

## Impact
Affects every PAI user who lets the Knowledge skill write notes (the default block-list frontmatter). Before this, `KnowledgeGraph traverse/related/hubs/find` and `MemoryRetriever`'s tag bonus operate on empty tag/related data; the "edges > nodes" health expectation is unreachable. After, the graph and tag-aware retrieval work as documented.

## Optional follow-up (not in this PR)
`KnowledgeGraph.ts` and `MemoryRetriever.ts` carry **two independent hand-rolled frontmatter parsers** — the divergence is what let this bug live in one place. A future cleanup could extract a single shared `parseFrontmatter` so the next fix touches one implementation.

## Provenance
Found while building a 2,000+ note domain knowledge cluster, where the dead tag/related edges made graph traversal useless — the parser fix was the precondition for the graph layer to function at all. Patches: `KnowledgeGraph.patch`, `MemoryRetriever.patch` (apply cleanly to `Releases/v5.0.0/.claude/PAI/TOOLS/`, verified via `git apply --check`).
