### PR TITLE
Align Packs/ source PAI/Tools → PAI/TOOLS to match shipped v5 runtime dir (case-sensitive Linux)

### DIFF
--- a/Packs/Media/src/Art/Workflows/Essay.md
+++ b/Packs/Media/src/Art/Workflows/Essay.md
@@ -513,10 +513,10 @@ For non-blog images that only need transparency, or to remove backgrounds after 
 
 ```bash
 # Use the Images Skill for background removal
-bun ~/.claude/PAI/Tools/RemoveBg.ts /path/to/output.png
+bun ~/.claude/PAI/TOOLS/RemoveBg.ts /path/to/output.png
 
 # Or batch process multiple images
-bun ~/.claude/PAI/Tools/RemoveBg.ts image1.png image2.png image3.png
+bun ~/.claude/PAI/TOOLS/RemoveBg.ts image1.png image2.png image3.png
 ```
 
 **See:** `~/.claude/skills/Images/Workflows/BackgroundRemoval.md` for full documentation.

--- a/Packs/Media/src/Art/Workflows/Mermaid.md
+++ b/Packs/Media/src/Art/Workflows/Mermaid.md
@@ -669,7 +669,7 @@ GOING INTO BLOG/WEBSITE: Remove background for transparency
 **For blog/website use** — use the **Images skill** for background removal:
 
 ```bash
-bun ~/.claude/PAI/Tools/RemoveBg.ts /path/to/mermaid-diagram.png
+bun ~/.claude/PAI/TOOLS/RemoveBg.ts /path/to/mermaid-diagram.png
 ```
 
 **See:** `~/.claude/skills/Images/Workflows/BackgroundRemoval.md` for full documentation.

--- a/Packs/Media/src/Art/Workflows/Visualize.md
+++ b/Packs/Media/src/Art/Workflows/Visualize.md
@@ -98,7 +98,7 @@ TRANSPARENT: Use Images skill to remove background for overlay use
 **For transparent background** — use the **Images skill** for background removal:
 
 ```bash
-bun ~/.claude/PAI/Tools/RemoveBg.ts /path/to/visualization.png
+bun ~/.claude/PAI/TOOLS/RemoveBg.ts /path/to/visualization.png
 ```
 
 **See:** `~/.claude/skills/Images/Workflows/BackgroundRemoval.md` for full documentation.

--- a/Packs/Telos/src/DashboardTemplate/App/api/chat/route.ts
+++ b/Packs/Telos/src/DashboardTemplate/App/api/chat/route.ts
@@ -30,7 +30,7 @@ When answering questions:
     // Use Inference tool instead of direct API
     const inferenceResult = await new Promise<{ success: boolean; output?: string; error?: string }>((resolve) => {
       const homeDir = process.env.HOME || ''
-      const proc = spawn('bun', ['run', `${homeDir}/.claude/PAI/Tools/Inference.ts`, '--level', 'fast', systemPrompt, message], {
+      const proc = spawn('bun', ['run', `${homeDir}/.claude/PAI/TOOLS/Inference.ts`, '--level', 'fast', systemPrompt, message], {
         stdio: ['ignore', 'pipe', 'pipe'],
       })
 

--- a/Packs/Utilities/src/Evals/Graders/ModelBased/LLMRubric.ts
+++ b/Packs/Utilities/src/Evals/Graders/ModelBased/LLMRubric.ts
@@ -5,7 +5,7 @@
 
 import { BaseGrader, registerGrader, type GraderContext } from '../Base.ts';
 import type { GraderConfig, GraderResult, LLMRubricParams } from '../../Types/index.ts';
-import { inference, type InferenceLevel } from '../../../PAI/Tools/Inference';
+import { inference, type InferenceLevel } from '../../../PAI/TOOLS/Inference';
 import { readFileSync, existsSync } from 'fs';
 
 export class LLMRubricGrader extends BaseGrader {

--- a/Packs/Utilities/src/Evals/Graders/ModelBased/NaturalLanguageAssert.ts
+++ b/Packs/Utilities/src/Evals/Graders/ModelBased/NaturalLanguageAssert.ts
@@ -5,7 +5,7 @@
 
 import { BaseGrader, registerGrader, type GraderContext } from '../Base.ts';
 import type { GraderConfig, GraderResult, NaturalLanguageAssertParams } from '../../Types/index.ts';
-import { inference, type InferenceLevel } from '../../../PAI/Tools/Inference';
+import { inference, type InferenceLevel } from '../../../PAI/TOOLS/Inference';
 
 export class NaturalLanguageAssertGrader extends BaseGrader {
   type = 'natural_language_assert' as const;

--- a/Packs/Utilities/src/Evals/Graders/ModelBased/PairwiseComparison.ts
+++ b/Packs/Utilities/src/Evals/Graders/ModelBased/PairwiseComparison.ts
@@ -5,7 +5,7 @@
 
 import { BaseGrader, registerGrader, type GraderContext } from '../Base.ts';
 import type { GraderConfig, GraderResult, PairwiseComparisonParams } from '../../Types/index.ts';
-import { inference, type InferenceLevel } from '../../../PAI/Tools/Inference';
+import { inference, type InferenceLevel } from '../../../PAI/TOOLS/Inference';
 import { readFileSync, existsSync } from 'fs';
 
 export class PairwiseComparisonGrader extends BaseGrader {

--- a/Packs/Utilities/src/Fabric/SKILL.md
+++ b/Packs/Utilities/src/Fabric/SKILL.md
@@ -179,7 +179,7 @@ Each pattern's `system.md` contains the full prompt that defines:
 ## Changelog
 
 ### 2026-01-18
-- Initial skill creation (extracted from PAI/Tools/fabric)
+- Initial skill creation (extracted from PAI/TOOLS/fabric)
 - Native pattern execution (no CLI dependency for most patterns)
 - Two workflows: ExecutePattern, UpdatePatterns
 - 240+ patterns organized by category

--- a/Packs/Utilities/src/PAIUpgrade/Workflows/AlgorithmUpgrade.md
+++ b/Packs/Utilities/src/PAIUpgrade/Workflows/AlgorithmUpgrade.md
@@ -225,7 +225,7 @@ Ideas that require fundamental changes, not just spec edits:
 - [ ] Review proposals
 - [ ] Apply approved changes to Algorithm spec
 - [ ] Bump version if warranted
-- [ ] Run `bun PAI/Tools/RebuildPAI.ts` to rebuild
+- [ ] Run `bun PAI/TOOLS/RebuildPAI.ts` to rebuild
 ```
 
 ---

--- a/Packs/Utilities/src/PAIUpgrade/Workflows/Upgrade.md
+++ b/Packs/Utilities/src/PAIUpgrade/Workflows/Upgrade.md
@@ -143,7 +143,7 @@ Agent 2 - YouTube Channels:
 "Check configured YouTube channels for new content and EXTRACT GRANULAR TECHNIQUES:
 
 1. Load channel config:
-   bun ~/.claude/PAI/Tools/LoadSkillConfig.ts ../youtube-channels.json
+   bun ~/.claude/PAI/TOOLS/LoadSkillConfig.ts ../youtube-channels.json
 
 2. For each channel, check recent videos:
    yt-dlp --flat-playlist --dump-json 'https://www.youtube.com/@channelhandle/videos' 2>/dev/null | head -5
@@ -152,7 +152,7 @@ Agent 2 - YouTube Channels:
    cat ../State/youtube-videos.json
 
 4. For NEW videos, extract transcripts:
-   bun ~/.claude/PAI/Tools/GetTranscript.ts '<video-url>'
+   bun ~/.claude/PAI/TOOLS/GetTranscript.ts '<video-url>'
 
 5. CRITICAL - For each transcript, extract SPECIFIC TECHNIQUES:
    - Look for code patterns, configurations, command examples


### PR DESCRIPTION
## Summary

Rewrites the **10 remaining `Packs/` source files** that still reference the runtime tools directory with the legacy lowercase `PAI/Tools/` so they match the canonical all-caps `PAI/TOOLS/` used everywhere else in v5. This is the **source-side half of #1324**.

## Root cause (corrects the issue framing)

I investigated #1324 and the shipped release is **not** actually broken on Linux today:

- The installed artifact is **not** a `/usr/local/bin/pai` shim — it's a single `alias pai='bun .../PAI/TOOLS/pai.ts'` line, and the v5 installer already emits the correct **`TOOLS`** casing (and strips stale aliases on reinstall).
- The entire `Releases/v5.0.0/` tree is self-consistent on `PAI/TOOLS/` (zero lowercase `PAI/Tools/` references inside it). The shipped graders import `../../../../PAI/TOOLS/Inference.ts` and the Telos chat route spawns `~/.claude/PAI/TOOLS/Inference.ts`.

The real defect is a **source/release divergence**: the casing convention changed v4 (`PAI/Tools`) → v5 (`PAI/TOOLS`), the release builder rewrites `Tools`→`TOOLS` on packaging (so shipped output is correct), but **10 upstream `Packs/` source files were never back-ported**. On case-insensitive macOS/APFS every path resolves to the one physical dir, masking it; on case-sensitive Linux/ext4 (incl. WSL2) the lowercase references fail to resolve when the source is run directly.

## Changes (12 references, 10 files — all `PAI/Tools/` → `PAI/TOOLS/`)

- **Executable** (would break at runtime on Linux): `Packs/Telos/.../api/chat/route.ts` (spawns `Inference.ts`); 3 Evals model-graders import `PAI/TOOLS/Inference` (`LLMRubric`, `NaturalLanguageAssert`, `PairwiseComparison`).
- **Copy-paste commands** (break on Linux paste): `PAIUpgrade/Workflows/{Upgrade,AlgorithmUpgrade}.md`, `Media/.../Art/Workflows/{Essay,Mermaid,Visualize}.md`.
- **Doc/changelog consistency**: `Utilities/src/Fabric/SKILL.md`.

## Scope / safety

- Only the literal **`PAI/Tools/`** runtime-tools token is rewritten. The three legitimately capital-T `Tools/` families — skill-level `<Skill>/Tools/`, `PAI/DOCUMENTATION/Tools/`, and the repo-root `Tools/` — are **intentionally untouched**.
- **No directory rename / `git mv`** needed: the physical dir is already `TOOLS`. Verified case-exact via `git ls-files` against `Releases/v5.0.0/` (immune to the macOS case-insensitivity that hides this bug). After the change, `grep -rn 'PAI/Tools/' Packs/` is empty.
- Result resolves correctly on **both** case-insensitive macOS and case-sensitive Linux, since canonical `TOOLS` already matches the physical dir.

## Suggested follow-ups (intentionally not bundled here, to keep this PR focused)

1. **CI grep-guard**: fail the build if `grep -rn 'PAI/Tools/' Packs/ Releases/$LATEST/` is non-empty, to stop the source/release divergence from silently reappearing.
2. **Durable upstream fix**: the private release-builder (`skills/_PAI/Tools/ShadowRelease.ts`, not in this public tree) currently relies on a build-time `Tools`→`TOOLS` rewrite; back-porting these `Packs/` edits makes the source canonical so the build no longer has to paper over it.
3. `.pai-protected.json` could add a `Releases/*/.claude/PAI/TOOLS/*.ts` glob (the v5 runtime tools dir is currently unprotected by name).

Refs #1324