### PR TITLE
feat(PAIUpgrade): mandatory cross-recommendation interference analysis (Step 6b)

### DIFF
--- a/Releases/v5.0.0/.claude/skills/PAIUpgrade/References/ExampleReport.md
+++ b/Releases/v5.0.0/.claude/skills/PAIUpgrade/References/ExampleReport.md
@@ -84,6 +84,12 @@ echo "Session: ${CLAUDE_SESSION_ID}"
 
 ---
 
+## ⚠️ Interactions & Sequencing
+
+interference: none found across 2 recommendations (≤10 — full matrix not required; see Workflows/Upgrade.md Step 6b)
+
+---
+
 ## 📊 Summary
 
 | # | Technique | Source | Priority | PAI Component | Effort |

--- a/Releases/v5.0.0/.claude/skills/PAIUpgrade/References/OutputFormat.md
+++ b/Releases/v5.0.0/.claude/skills/PAIUpgrade/References/OutputFormat.md
@@ -7,10 +7,11 @@
 1. **✨ Discoveries** — what was found, ranked by interestingness
 2. **🔥 Recommendations** — what to do, ranked by priority tier
 3. **🎯 Technique Details** — full extraction with code/quotes
-4. **🪞 Internal Reflections** — upgrade candidates from algorithm reflections (Thread 3)
-5. **📊 Summary** — one-line totals
-6. **⏭️ Skipped Content** — already-done / rejected with file:line evidence
-7. **🔍 Sources Processed** — count footer
+4. **⚠️ Interactions & Sequencing** — cross-recommendation interference matrix (MANDATORY when >10 recommendations; see Workflows/Upgrade.md Step 6b)
+5. **🪞 Internal Reflections** — upgrade candidates from algorithm reflections (Thread 3)
+6. **📊 Summary** — one-line totals
+7. **⏭️ Skipped Content** — already-done / rejected with file:line evidence
+8. **🔍 Sources Processed** — count footer
 
 **Print only non-empty tiers** in Recommendations. If no CRITICAL items, omit that header entirely.
 
@@ -111,6 +112,29 @@ Numbered to match Recommendations. One block per technique.
 
 ---
 
+## ⚠️ Interactions & Sequencing
+
+Mandatory when the report carries more than 10 recommendations (Step 6b in Upgrade.md); at ≤10, the section reduces to a single line: "interference: none found across N recs".
+
+```markdown
+Pairwise interference analysis across R1-RN, adversarially verified by a second agent (different model family when available).
+
+| # | Pair | Mechanism | Guard |
+|---|------|-----------|-------|
+| C1 | Rx↔Ry | [how they interfere — confound / same-file / dependency / bundling] | [sequencing rule, design guard, or precondition] |
+
+**Wave sequence:** W0 [conflict-free now] → W1 [deadline-ordered] → … → Wn [independent anytime].
+
+**Synergies:** [pairs that reinforce each other, worth implementing together]
+```
+
+**Hard sub-rules:**
+- Every conflict row has a non-empty Guard cell — a conflict without a resolution blocks the report.
+- The matrix must survive an adversarial pass by a second agent; disputes resolve by probing ground truth, not by model preference.
+- Recommendation rows involved in any conflict are tagged so readers hit the warning before implementing.
+
+---
+
 ## 🪞 Internal Reflections (Thread 3)
 
 ```markdown
@@ -166,3 +190,4 @@ One-line digest of source counts and routing.
 8. **Skip boldly.** Content with no extractable technique → Skipped, not diluted.
 9. **Numbered cross-references** are consistent across Discoveries, Recommendations, and Technique Details.
 10. **Print only non-empty tiers.** Empty tier headers are noise.
+11. **Interference gate.** >10 recommendations → the Interactions & Sequencing section is mandatory, adversarially verified, and every conflict pair carries a guard. Prior-Status gates against the past; this gates against each other.

--- a/Releases/v5.0.0/.claude/skills/PAIUpgrade/SKILL.md
+++ b/Releases/v5.0.0/.claude/skills/PAIUpgrade/SKILL.md
@@ -57,7 +57,7 @@ The skill runs **four parallel agent threads** that converge into personalized r
 
 **Canonical spec:** `References/OutputFormat.md` — single source of truth for section order, Prior Status legend, table columns, and hard rules. Both this skill and `Workflows/Upgrade.md` reference that file rather than inlining their own copies.
 
-Section order: Discoveries → Recommendations → Technique Details → Internal Reflections → Summary → Skipped → Sources Processed.
+Section order: Discoveries → Recommendations → Technique Details → Interactions & Sequencing (mandatory >10 recs) → Internal Reflections → Summary → Skipped → Sources Processed.
 
 **Print only non-empty Recommendation tiers** (no empty `🟡 MEDIUM` headers).
 
@@ -69,6 +69,7 @@ Section order: Discoveries → Recommendations → Technique Details → Interna
 2. **Quote or code-block the actual content** — show exactly what was said/written.
 3. **Map to PAI components** — every technique connects to a specific file, skill, workflow, or system component.
 4. **Verify Prior State (Thread 0 gate)** — Before emitting ANY recommendation, confirm against Thread 0 inventory: is it already in Algorithm / PATTERNS.yaml / hooks / SKILL files / KNOWLEDGE / prior ISAs? Assign a Prior Status emoji and cite evidence. Items that are ✅ DONE go to Skipped, not Recommendations.
+   - **Cross-reference recommendations against EACH OTHER (Step 6b gate)** — when the report exceeds 10 recommendations, run the interference analysis (measurement confounds, same-file collisions, input dependencies, doctrine bundling), adversarially verified by a second agent, and emit the Interactions & Sequencing section. Prior Status gates against the past; this gates against the set itself.
 5. **Two mandatory description fields, ≤2 sentences each, concrete and specific:**
    - **What It Is:** the technique itself — what it does, how it works, what capability it provides
    - **How It Helps PAI:** the specific benefit — which component improves, what gap it fills
@@ -147,6 +148,7 @@ These output patterns are **FAILURES**:
 
 ## Gotchas
 
+- **A large recommendation set is itself a system — analyze it as one.** A 44-recommendation report once shipped with every row Prior-Status-gated but zero pairwise analysis; the retrofit found two high-severity measurement confounds (a fallback setting and a safety-routing behavior each silently swapping the model under an A/B eval) plus six same-file collisions. Step 6b (interference matrix + adversarial pass) is mandatory at >10 recs.
 - **Check ALL sources in parallel** — Anthropic blog, changelog, YouTube channels, GitHub releases. Don't check sequentially.
 - **Upgrades must not break existing skills or workflows.** Verify backward compatibility before applying.
 - **Full upgrade check can take 5-7 minutes.** Use `run_in_background: true` for the outer agent.

--- a/Releases/v5.0.0/.claude/skills/PAIUpgrade/Workflows/Upgrade.md
+++ b/Releases/v5.0.0/.claude/skills/PAIUpgrade/Workflows/Upgrade.md
@@ -171,11 +171,34 @@ Sort by priority and tier:
 
 Each recommendation: short action name, PAI Relevance (primary framing — WHY it matters), effort (Low/Med/High), files affected.
 
+### Step 6b: Cross-Recommendation Interference Analysis (MANDATORY when >10 recommendations)
+
+Prior-Status gating checks each recommendation against the PAST; this step checks them against EACH OTHER. Skipping it on a large report invites measurement confounds, same-file collisions, and broken sequencing that surface only at implementation time.
+
+**Gate:** runs whenever the recommendation count exceeds 10 — roughly where a reliable mental pairwise sweep ends (10 recommendations ≈ 45 pairs). At ≤10, the section reduces to a single line — "interference: none found across N recs" — so quick modes stay fast.
+
+**1. Build the matrix.** Sweep all recommendation pairs for four interference classes:
+
+| Class | What to look for | Example failure |
+|-------|------------------|-----------------|
+| **Measurement confound** | One rec changes the thing another rec measures (model substitution, effort/token recalibration, fallback routing, safety routing) | A fallback setting silently swaps the model under an A/B eval |
+| **Same-file/surface collision** | Two recs edit the same file, hook, or invocation path | Two recs independently rewrite the same Stop hook |
+| **Resource/input dependency** | One rec consumes or evicts what another rec reads | A memory-eviction rec archives the entries a mandatory-consult rec greps |
+| **Doctrine/version bundling** | Multiple recs edit a single-versioned artifact (Algorithm doctrine, canonical spec) | Eight piecemeal edits to one doctrine file = eight version bumps |
+
+**2. Adversarial verification (REQUIRED).** Hand the draft matrix plus the recommendation list to a second agent — ideally a different model family than the one that drafted it — instructed to (a) find missed pairs, (b) refute listed conflicts, (c) attack the sequencing. Resolve disputes by probing ground truth (read the actual source file), never by deferring to either model. If no second model family is available, run the pass with a fresh-context instance of the same model — adversarial framing still catches drafting blind spots — and note which reviewer ran.
+
+**3. Every conflict gets a guard.** No identified pair ships without a named resolution: a sequencing rule, a design guard, a bundling instruction, or an explicit precondition. Conflicts without guards block the report.
+
+**4. Emit the section.** Output as `⚠️ Interactions & Sequencing` per `../References/OutputFormat.md`: conflict table (Pair | Mechanism | Guard) + wave-ordered execution sequence + synergies worth exploiting. Tag affected recommendation rows so readers see interference before implementing.
+
+> Origin: a 44-recommendation report shipped with every row Prior-Status-gated but zero pairwise analysis; the retrofit found two high-severity measurement confounds (a fallback setting and a safety-routing behavior each silently swapping the model under an A/B eval) plus six same-file collisions.
+
 ### Step 7: Output Report
 
 **Canonical output format:** `../References/OutputFormat.md`. Reference example: `../References/ExampleReport.md`.
 
-Section order: Discoveries → Recommendations → Technique Details → Internal Reflections → Summary → Skipped → Sources Processed.
+Section order: Discoveries → Recommendations → Technique Details → Interactions & Sequencing (when Step 6b ran) → Internal Reflections → Summary → Skipped → Sources Processed.
 
 **Print only non-empty Recommendation tiers.** Empty tier headers are noise.
 


### PR DESCRIPTION
## Problem

PAIUpgrade's synthesis gates every recommendation against **prior work** (Thread 0 → Prior Status), but nothing checks recommendations against **each other**. On large reports, that lets four classes of problems ship undetected until implementation time: measurement confounds (one rec changes the thing another rec measures), same-file collisions, input dependencies (one rec evicts what another reads), and doctrine/version bundling (several recs editing one versioned artifact).

## What this adds

Four files under `Releases/v5.0.0/.claude/skills/PAIUpgrade/`:

- **`Workflows/Upgrade.md`** — new **Step 6b**: a four-class interference matrix plus a mandatory adversarial verification pass by a second agent (different model family when available; fresh-context same-model fallback otherwise — disputes resolve by probing ground truth, never by model preference). Gated at **>10 recommendations** (~45 pairs — roughly where a reliable mental pairwise sweep ends); at ≤10 the section reduces to a single line so quick modes stay fast. Every identified conflict must carry a guard or the report is blocked.
- **`References/OutputFormat.md`** — `⚠️ Interactions & Sequencing` joins the canonical section order (position 4), with the section spec and hard rule 11: *Prior-Status gates against the past; this gates against each other.*
- **`SKILL.md`** — extraction sub-rule under rule 4, updated section-order summary, and a Gotchas entry.
- **`References/ExampleReport.md`** — the worked example now demonstrates the ≤10 one-liner form, staying consistent with the spec it illustrates.

## Origin

Found in practice: a 44-recommendation report shipped fully Prior-Status-gated with zero pairwise analysis; the retrofit interference pass found two high-severity measurement confounds (a fallback setting and a safety-routing behavior each silently swapping the model under an A/B eval) plus six same-file collisions. The patch itself was hardened through the same adversarial-review loop it mandates.

## Scope notes

- Targets the `Releases/v5.0.0` tree (the shipped runtime). Happy to also port to `Packs/Utilities/src/PAIUpgrade` if that's the preferred source of truth — that copy currently reflects an earlier generation of the workflow.
- `Workflows/AlgorithmUpgrade.md` (a sibling recommendation-emitting workflow) is intentionally not gated here to keep the change minimal; happy to follow up if useful.
