### PR TITLE
feat: Add Claude Fable 5 model pricing and display name to Performance dashboard

### DIFF
--- a/Releases/v5.0.0/.claude/PAI/PULSE/Observability/src/app/performance/page.tsx
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/Observability/src/app/performance/page.tsx
@@ -102,6 +102,7 @@ function formatTokens(n: number): string {
 }
 
 function shortModel(m: string): string {
+  if (m.includes("fable")) return "Fable";
   if (m.includes("opus")) return "Opus";
   if (m.includes("haiku")) return "Haiku";
   if (m.includes("sonnet")) return "Sonnet";

--- a/Releases/v5.0.0/.claude/PAI/PULSE/Performance/cost-aggregator.ts
+++ b/Releases/v5.0.0/.claude/PAI/PULSE/Performance/cost-aggregator.ts
@@ -21,6 +21,8 @@ const STATE_FILE = join(PAI_DIR, "PULSE", "Performance", "aggregator-state.json"
 
 // Model pricing per million tokens (as of 2026-04)
 const MODEL_PRICING: Record<string, { input: number; output: number; cacheWrite: number; cacheRead: number }> = {
+  // Fable 5
+  "claude-fable-5": { input: 10, output: 50, cacheWrite: 12.50, cacheRead: 1.00 },
   // Opus 4 / 4.6
   "claude-opus-4-20250514": { input: 15, output: 75, cacheWrite: 18.75, cacheRead: 1.50 },
   "claude-opus-4-6": { input: 15, output: 75, cacheWrite: 18.75, cacheRead: 1.50 },
@@ -35,8 +37,10 @@ const MODEL_PRICING: Record<string, { input: number; output: number; cacheWrite:
 function getPricing(model: string): { input: number; output: number; cacheWrite: number; cacheRead: number } {
   // Exact match
   if (MODEL_PRICING[model]) return MODEL_PRICING[model]
-  // Fuzzy match: opus, sonnet, haiku
+  // Fuzzy match: fable, opus, sonnet, haiku — transcripts can carry suffixed
+  // ids (e.g. "claude-fable-5[1m]") that won't exact-match the table
   const lower = model.toLowerCase()
+  if (lower.includes("fable")) return MODEL_PRICING["claude-fable-5"]
   if (lower.includes("opus")) return MODEL_PRICING["claude-opus-4-6"]
   if (lower.includes("haiku")) return MODEL_PRICING["claude-haiku-4-5-20251001"]
   if (lower.includes("sonnet")) return MODEL_PRICING["claude-sonnet-4-6"]


### PR DESCRIPTION
Fixes #1341

Fable 5 sessions were getting costed at Sonnet rates and showing up as a raw model id. Three small changes:

- `MODEL_PRICING`: add `claude-fable-5` ($10/$50; cache write 12.50, cache read 1.00 — same ratios as the rest of the table)
- `getPricing()`: add a `fable` fuzzy-match branch so suffixed ids like `claude-fable-5[1m]` price right instead of falling through to Sonnet
- `shortModel()`: show "Fable" on the dashboard

Testing: ran it on macOS (Bun) against a sandboxed fresh HOME with a synthetic Fable transcript. Exit 0, no errors, and the costs match hand math exactly — 1M input → $10.00, 100K output → $5.00, 200K cache write → $2.50, 4M cache read → $4.00. The dashboard maps the id to "Fable".

6 added lines across two files in the v5.0.0 bundle. Nothing platform-specific.
