### PR TITLE
Fix CrossVendorAudit codex invocation: non-git PAI dirs and OpenAI env overrides

### DIFF
--- a/Releases/v5.0.0/.claude/PAI/TOOLS/CrossVendorAudit.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/CrossVendorAudit.ts
@@ -189,10 +189,24 @@ function assembleBundle(isa: string, artifacts: string, toolTail: string, adviso
 
 function invokeCodex(bundle: string): Promise<{ stdout: string; stderr: string; code: number | null }> {
   return new Promise((resolvePromise) => {
+    // --skip-git-repo-check: the PAI directory is not always a git repository
+    // (some installs persist it by other means), and codex exec refuses to run
+    // from a non-git working directory without this flag.
+    // Env scrub: codex's auth precedence puts OPENAI_API_KEY / OPENAI_BASE_URL
+    // above ~/.codex/auth.json and config.toml, so a stray key in the parent
+    // shell silently flips the audit from the user's configured codex auth
+    // (e.g. ChatGPT subscription) to direct API billing. Only scrub when a
+    // configured auth file exists — users who authenticate codex solely via
+    // OPENAI_API_KEY keep working unchanged.
+    const env = { ...process.env };
+    if (existsSync(join(HOME, ".codex", "auth.json"))) {
+      delete env.OPENAI_API_KEY;
+      delete env.OPENAI_BASE_URL;
+    }
     const proc = spawn(
       CODEX_BIN,
-      ["exec", "--sandbox", "read-only", "--model", "gpt-5.4", "-"],
-      { stdio: ["pipe", "pipe", "pipe"] }
+      ["exec", "--sandbox", "read-only", "--skip-git-repo-check", "--model", "gpt-5.4", "-"],
+      { stdio: ["pipe", "pipe", "pipe"], env }
     );
     let stdout = "";
     let stderr = "";


### PR DESCRIPTION
## Problem

`CrossVendorAudit.ts` (the Cato cross-vendor audit harness) has two failure modes in `invokeCodex()`:

1. **Audit always skips on non-git PAI installs.** `codex exec` refuses to run when the working directory is not a git repository (`Not inside a trusted directory`), so on installs that persist the PAI directory by means other than git, every audit returns `skipped: codex exit 1` and the cross-vendor audit never actually fires.

2. **Silent auth flip.** The spawned codex process inherits the parent environment, and codex's auth precedence puts `OPENAI_API_KEY` / `OPENAI_BASE_URL` above `~/.codex/auth.json` and `config.toml`. A stray key in the parent shell silently moves the audit from the user's configured codex auth (e.g. ChatGPT subscription) to direct API billing, with no signal that it happened.

## Fix

- Pass `--skip-git-repo-check` to `codex exec` (the read-only sandbox is still enforced by `--sandbox read-only`).
- Copy the env and delete `OPENAI_API_KEY` / `OPENAI_BASE_URL` before spawn — **only when `~/.codex/auth.json` exists**, so users who authenticate codex solely via the env var keep working unchanged; users with configured auth stop being silently overridden by stray shell keys.

## Testing

Verified live on a non-git PAI install: the audit runs end-to-end and persists a structured verdict to `cato-findings.jsonl` where it previously logged `skipped: codex exit 1`. `bun build` passes on the patched file.

## Note for maintainers

The change targets `Releases/v5.0.0/` because a tree-wide search shows it is the only place this file ships — happy to retarget if release snapshots are frozen and there's a development home for it.