### PR TITLE
feat(Inference): disable extended-thinking budget for fast/snap-judgment calls

### DIFF
--- a/Releases/v5.0.0/.claude/PAI/TOOLS/Inference.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/Inference.ts
@@ -25,9 +25,10 @@
  *   --auto-state                   v3.24 P5: Auto-synthesize state from current ISA + recent activity (advisor mode only, 2 positional args: task, question)
  *   --json                         Expect and parse JSON response
  *   --timeout <ms>                 Custom timeout (default varies by level)
+ *   --no-thinking                  Disable the extended-thinking budget (snap-judgment latency); implied by --level fast
  *
  * DEFAULTS BY LEVEL:
- *   fast:     model=haiku,   timeout=15s
+ *   fast:     model=haiku,   timeout=15s,  thinking=off
  *   standard: model=sonnet,  timeout=30s
  *   smart:    model=opus,    timeout=90s
  *   advisor:  model=opus,    timeout=120s
@@ -71,6 +72,12 @@ export interface InferenceOptions {
    * are prepended to the user prompt as @-references so Claude reads them as
    * image attachments. Routes through subscription like all other inference. */
   imagePaths?: string[];
+  /** Set to `false` to disable the extended-thinking budget for this call (sets
+   * MAX_THINKING_TOKENS=0 in the subprocess env). Every `claude --print` call
+   * otherwise silently spends a thinking budget — measured ~14.9s vs ~3.2s on a
+   * snap-judgment classification payload, with model tier nearly irrelevant.
+   * Implicitly disabled for `level: 'fast'`. */
+  thinking?: boolean;
 }
 
 export interface InferenceResult {
@@ -115,6 +122,15 @@ export async function inference(options: InferenceOptions): Promise<InferenceRes
     // either path leaks subscription work onto API-key billing. Scrub both.
     delete env.ANTHROPIC_API_KEY;
     delete env.ANTHROPIC_AUTH_TOKEN;
+
+    // Disable the extended-thinking budget for latency-sensitive calls. Every
+    // `claude --print` subprocess otherwise silently spends a thinking budget
+    // (measured ~14.9s vs ~3.2s on a snap-judgment classification payload, with
+    // model tier nearly irrelevant). `fast` is a snap judgment by definition;
+    // other levels opt out explicitly with `thinking: false`.
+    if (level === 'fast' || options.thinking === false) {
+      env.MAX_THINKING_TOKENS = '0';
+    }
 
     const hasImages = options.imagePaths && options.imagePaths.length > 0;
     const args = [
@@ -414,6 +430,7 @@ async function main() {
   let expectJson = false;
   let timeout: number | undefined;
   let level: InferenceLevel = 'standard';
+  let noThinking = false;
   let mode: 'inference' | 'advisor' = 'inference';
   let autoState = false;  // v3.24 P5
   const positionalArgs: string[] = [];
@@ -444,6 +461,8 @@ async function main() {
     } else if (args[i] === '--timeout' && args[i + 1]) {
       timeout = parseInt(args[i + 1], 10);
       i++;
+    } else if (args[i] === '--no-thinking') {
+      noThinking = true;
     } else {
       positionalArgs.push(args[i]);
     }
@@ -483,7 +502,7 @@ async function main() {
   }
 
   if (positionalArgs.length < 2) {
-    console.error('Usage: bun Inference.ts [--level fast|standard|smart] [--json] [--timeout <ms>] <system_prompt> <user_prompt>');
+    console.error('Usage: bun Inference.ts [--level fast|standard|smart] [--json] [--timeout <ms>] [--no-thinking] <system_prompt> <user_prompt>');
     process.exit(1);
   }
 
@@ -495,6 +514,7 @@ async function main() {
     level,
     expectJson,
     timeout,
+    thinking: noThinking ? false : undefined,
   });
 
   if (result.success) {


### PR DESCRIPTION
## Problem

Every `claude --print` subprocess spawned by `Inference.ts` silently spends an extended-thinking budget. On snap-judgment payloads (classification, tab titles, session naming) this adds ~10s+ of pure latency with negligible quality benefit — and the thinking budget, **not** the model tier, dominates the cost.

Measured on a classification-shaped payload:

| call | latency |
|------|---------|
| `claude --print --model haiku` (default) | ~14.9s |
| same call, `MAX_THINKING_TOKENS=0` | ~3.2s |
| `--model sonnet`, `MAX_THINKING_TOKENS=0` | ~3.6s |

Downgrading the model barely helps; disabling the thinking budget is what collapses the latency.

## Change

- Add a `thinking?: boolean` option to `inference()` and a `--no-thinking` CLI flag. When `thinking: false` (or `--no-thinking`), the call sets `MAX_THINKING_TOKENS=0` in the subprocess env, disabling the extended-thinking budget.
- `level: 'fast'` implies it — `fast` is for snap tasks (quick generation, basic classification) by definition, so it no longer pays the thinking tax. `standard` and `smart` are unchanged unless they opt out explicitly.

Single file, +22/−2, no new dependencies. Parses/transpiles clean; CLI usage string updated.

## Reproduction

```bash
time claude --print --model haiku --tools '' --output-format text \
  --system-prompt 'Classify the message as A or B. Output one letter.' <<< 'hello'

time MAX_THINKING_TOKENS=0 claude --print --model haiku --tools '' --output-format text \
  --system-prompt 'Classify the message as A or B. Output one letter.' <<< 'hello'
```

## Note

The one behavior change is the `fast`-level default (fast now disables thinking). Happy to make that opt-in instead if you'd prefer zero default change — it's a one-line tweak.
