### PR TITLE
fix(statusline): correct context percentage when switching models mid-session

### DIFF
--- a/Releases/v4.0.3/.claude/statusline-command.sh
+++ b/Releases/v4.0.3/.claude/statusline-command.sh
@@ -100,6 +100,27 @@ context_remaining=${context_remaining:-100}
 total_input=${total_input:-0}
 total_output=${total_output:-0}
 
+# Model-aware context window correction. When switching between Opus (1M) and
+# Sonnet/Haiku (200K) mid-session, Claude Code may report context_window_size
+# from the session's starting model, not the current model. Use model_name to
+# derive the expected window and recalculate context_pct against the right value.
+_model_lower="${model_name,,}"
+if [[ "$_model_lower" == *"opus"* ]]; then
+    _expected_ctx=1048576
+elif [[ "$_model_lower" == *"sonnet"* ]] || [[ "$_model_lower" == *"haiku"* ]] || [[ "$_model_lower" == *"fable"* ]]; then
+    _expected_ctx=200000
+else
+    _expected_ctx=""
+fi
+if [ -n "$_expected_ctx" ] && [ "$context_max" != "$_expected_ctx" ] && [ "$_expected_ctx" -gt 0 ]; then
+    if [ "$total_input" -gt 0 ]; then
+        context_pct=$(( total_input * 100 / _expected_ctx ))
+    elif [ "$context_max" -gt 0 ] && [ "$context_pct" -gt 0 ]; then
+        context_pct=$(( context_pct * context_max / _expected_ctx ))
+    fi
+    context_max="$_expected_ctx"
+fi
+
 # NOTE: Removed fallback that calculated context_pct from total_input + total_output
 # when used_percentage was 0. total_input/output_tokens are CUMULATIVE session totals
 # (like an odometer) — they can far exceed context_window_size. After /clear,


### PR DESCRIPTION
## Problem

When a Claude Code session starts with one model (e.g. Opus, 1M context window) and the user switches to another model (e.g. Sonnet, 200K context window) mid-session, the context percentage displayed in the status line becomes incorrect.

Root cause: `context_window_size` in the Claude Code session JSON can reflect the *session's starting model* rather than the currently active model. The `used_percentage` field is calculated against that stale denominator, so switching from Opus → Sonnet shows ~14% when the real usage is ~75%.

## Fix

After the defaults block, derive the expected context window from `model_name` (which IS current), then recalculate `context_pct` using `total_input_tokens` (absolute token count, model-independent) against the correct window. Falls back to proportional rescaling if `total_input` is zero. No-op when `context_max` already matches the model's expected size.

**Model → context window mapping:**
| Model | Tokens |
|-------|--------|
| Opus 4.x | 1,048,576 |
| Sonnet 4.x | 200,000 |
| Haiku 4.x | 200,000 |
| Fable | 200,000 |
| Unknown | no correction |

## Example

Session started as Opus, 150K tokens consumed, user switches to Sonnet:
- Before fix: `context_max=1048576`, `context_pct=14%` (wrong)
- After fix: `context_max=200000`, `context_pct=75%` (correct)

## Change

21 lines added to `Releases/v4.0.3/.claude/statusline-command.sh`, immediately after the defaults block. Non-destructive: the block only fires when the reported `context_max` mismatches the model's known window size.