### PR TITLE
fix(CrossVendorAudit): raise codex timeout to 600s and pin reasoning_effort=medium

### DIFF
--- a/Releases/v5.0.0/.claude/PAI/TOOLS/CrossVendorAudit.ts
+++ b/Releases/v5.0.0/.claude/PAI/TOOLS/CrossVendorAudit.ts
@@ -28,7 +28,7 @@ const CODEX_BIN = join(HOME, ".bun", "bin", "codex");
 const BUNDLE_TOKEN_CAP = 80_000;
 const CHARS_PER_TOKEN = 4; // rough estimate for bundle sizing
 const BUNDLE_CHAR_CAP = BUNDLE_TOKEN_CAP * CHARS_PER_TOKEN;
-const CODEX_TIMEOUT_MS = 120_000;
+const CODEX_TIMEOUT_MS = 600_000;
 const TOOL_ACTIVITY_TAIL_LINES = 200;
 const ARTIFACT_PER_FILE_CAP = 30_000 * CHARS_PER_TOKEN;
 
@@ -191,14 +191,14 @@ function invokeCodex(bundle: string): Promise<{ stdout: string; stderr: string; 
   return new Promise((resolvePromise) => {
     const proc = spawn(
       CODEX_BIN,
-      ["exec", "--sandbox", "read-only", "--model", "gpt-5.4", "-"],
+      ["exec", "-c", "model_reasoning_effort=medium", "--sandbox", "read-only", "--model", "gpt-5.4", "-"],
       { stdio: ["pipe", "pipe", "pipe"] }
     );
     let stdout = "";
     let stderr = "";
     const timer = setTimeout(() => {
       proc.kill("SIGTERM");
-      resolvePromise({ stdout, stderr: stderr + "\n[TIMEOUT after 120s]", code: 124 });
+      resolvePromise({ stdout, stderr: stderr + "\n[TIMEOUT after 600s]", code: 124 });
     }, CODEX_TIMEOUT_MS);
 
     proc.stdout.on("data", (chunk) => (stdout += chunk.toString()));


### PR DESCRIPTION

**Problem.** Cato's cross-vendor audit (Rule 2a, E4/E5) silently returns `verdict: "skipped"` on real ISAs. `CrossVendorAudit.ts` caps the codex call at `CODEX_TIMEOUT_MS = 120_000` (2 min), but `codex exec --model gpt-5.4` is a reasoning model: on a real ISA + artifact bundle it routinely needs ~3 min. The 120s cap fires first → `SIGTERM` → `[TIMEOUT after 120s]` → the audit is skipped before GPT-5.4 ever returns a verdict. The cross-vendor gate looks like it ran but produced nothing.

Two compounding factors:
1. **The cap is too tight** for gpt-5.4's reasoning latency on a non-trivial bundle.
2. **No `reasoning_effort` is pinned**, so the call inherits `~/.codex/config.toml`'s default. If that default is `high`/`xhigh`, the call blows past even a generous timeout. Empirically, `medium` returns a full audit in ~3 min; `xhigh` exceeds 600s on a real bundle.

**Fix.** Raise the in-process cap to 600s and pin `model_reasoning_effort=medium` so latency is bounded by an explicit, known-good effort tier rather than an inherited config default.

```diff
-const CODEX_TIMEOUT_MS = 120_000;
+const CODEX_TIMEOUT_MS = 600_000;
```
```diff
-      ["exec", "--sandbox", "read-only", "--model", "gpt-5.4", "-"],
+      ["exec", "-c", "model_reasoning_effort=medium", "--sandbox", "read-only", "--model", "gpt-5.4", "-"],
```
```diff
-      resolvePromise({ stdout, stderr: stderr + "\n[TIMEOUT after 120s]", code: 124 });
+      resolvePromise({ stdout, stderr: stderr + "\n[TIMEOUT after 600s]", code: 124 });
```

**Why `medium` and not just a bigger timeout.** A bigger timeout alone doesn't help if the inherited effort default is `xhigh` (it can exceed 600s on a real ISA). Pinning `medium` makes the audit's latency predictable and keeps it inside the cap. This is the load-bearing half of the fix.

**Scope / non-overlap.** Narrowly scoped to the timeout constant, the spawn args, and the timeout message string. Does **not** touch the `--skip-git-repo-check` / `OPENAI_API_KEY` env-inheritance work already in flight in #1346 — these are independent and should merge cleanly alongside it.

**Testing.** `bun CrossVendorAudit.ts --doctor` still passes; a full E4/E5 audit that previously skipped at 120s now returns a parsed verdict in ~3 min.

---

