### PR TITLE
fix(Security/AnnualReports): repair stale UpdateSources parser (0 → 390 reports)

### DIFF
--- a/Packs/Security/src/AnnualReports/Tools/UpdateSources.ts
+++ b/Packs/Security/src/AnnualReports/Tools/UpdateSources.ts
@@ -8,8 +8,8 @@
  *   bun run UpdateSources.ts --diff          # Show diff with upstream
  */
 
-import { readFileSync, writeFileSync, existsSync } from 'fs';
-import { join } from 'path';
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
 
 const SOURCES_PATH = join(import.meta.dir, '..', 'Data', 'sources.json');
 const UPSTREAM_URL = 'https://raw.githubusercontent.com/jacobdjwilson/awesome-annual-security-reports/main/README.md';
@@ -48,50 +48,53 @@ function parseMarkdownReports(markdown: string): Map<string, Report[]> {
   let currentCategory = '';
   let currentSection = '';
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i].trim();
+  // Current upstream format (one line per report):
+  //   - [Vendor](vendor-url) - [Report Name](report-path) (year) - description
+  const entryRe = /^-\s+\[([^\]]+)\]\(([^)]+)\)\s*-\s*\[([^\]]+)\]\(([^)]+)\)/;
 
-    // Track main sections (Analysis Reports / Survey Reports)
+  for (const raw of lines) {
+    const line = raw.trim();
+
+    // Track main sections (only Analysis / Survey are captured; anything else,
+    // including the "## Contents" TOC and "## Resources", resets tracking so
+    // stray "- [..](..)" links there are never mistaken for report entries).
     if (line.startsWith('## Analysis Reports')) {
       currentSection = 'analysis';
-    } else if (line.startsWith('## Survey Reports')) {
+      currentCategory = '';
+      continue;
+    }
+    if (line.startsWith('## Survey Reports')) {
       currentSection = 'survey';
+      currentCategory = '';
+      continue;
+    }
+    if (line.startsWith('## ')) {
+      currentSection = '';
+      currentCategory = '';
+      continue;
     }
 
-    // Track categories (### headers)
+    // Track categories (### headers) within a tracked section
     if (line.startsWith('### ')) {
       currentCategory = line.replace('### ', '').toLowerCase().replace(/\s+/g, '_');
-      if (!reports.has(`${currentSection}_${currentCategory}`)) {
-        reports.set(`${currentSection}_${currentCategory}`, []);
+      if (currentSection) {
+        const key = `${currentSection}_${currentCategory}`;
+        if (!reports.has(key)) reports.set(key, []);
       }
+      continue;
     }
 
-    // Parse report entries (numbered lists or bullet points with links)
-    const reportMatch = line.match(/^\d+\.\s+\*\*(.+?)\*\*/) || line.match(/^-\s+\*\*(.+?)\*\*/);
-    if (reportMatch && currentCategory) {
-      const reportName = reportMatch[1];
-
-      // Look for vendor and URL in following lines
-      let vendor = '';
-      let url = '';
-
-      for (let j = i + 1; j < Math.min(i + 5, lines.length); j++) {
-        const nextLine = lines[j].trim();
-        if (nextLine.startsWith('- Vendor:')) {
-          vendor = nextLine.replace('- Vendor:', '').trim();
-        } else if (nextLine.startsWith('- URL:')) {
-          url = nextLine.replace('- URL:', '').trim();
-        } else if (nextLine.match(/^\d+\.\s+\*\*/) || nextLine.startsWith('### ')) {
-          break;
-        }
-      }
-
-      if (vendor && url) {
-        const key = `${currentSection}_${currentCategory}`;
-        const existing = reports.get(key) || [];
-        existing.push({ vendor, name: reportName, url });
-        reports.set(key, existing);
-      }
+    // Parse report entries only when inside a tracked section + category
+    if (!currentSection || !currentCategory) continue;
+    const m = line.match(entryRe);
+    if (m) {
+      const vendor = m[1].trim();
+      const vendorUrl = m[2].trim();
+      const reportName = m[3].trim();
+      const key = `${currentSection}_${currentCategory}`;
+      const existing = reports.get(key) || [];
+      existing.push({ vendor, name: reportName, url: vendorUrl });
+      reports.set(key, existing);
     }
   }
 
@@ -216,15 +219,29 @@ async function main() {
       return;
     }
 
-    // Note: Full update would merge parsed data into sources.json
-    // For now, just update the timestamp since manual curation is preferred
-    current.metadata.lastUpdated = new Date().toISOString().split('T')[0];
-    current.metadata.totalReports = countReports(current);
+    // Rebuild sources.json from the parsed upstream data.
+    const updated: Sources = {
+      metadata: {
+        source: UPSTREAM_URL.replace('/README.md', ''),
+        lastUpdated: new Date().toISOString().split('T')[0],
+        totalReports: parsedTotal,
+      },
+      categories: { analysis: {}, survey: {} },
+    };
+    for (const [key, reports] of parsed) {
+      if (reports.length === 0) continue;
+      if (key.startsWith('analysis_')) {
+        updated.categories.analysis[key.slice('analysis_'.length)] = reports;
+      } else if (key.startsWith('survey_')) {
+        updated.categories.survey[key.slice('survey_'.length)] = reports;
+      }
+    }
 
-    writeFileSync(SOURCES_PATH, JSON.stringify(current, null, 2));
+    mkdirSync(dirname(SOURCES_PATH), { recursive: true });
+    writeFileSync(SOURCES_PATH, JSON.stringify(updated, null, 2));
     console.log('✅ Updated sources.json');
-    console.log(`   Total reports: ${current.metadata.totalReports}`);
-    console.log(`   Last updated: ${current.metadata.lastUpdated}`);
+    console.log(`   Total reports: ${updated.metadata.totalReports}`);
+    console.log(`   Last updated: ${updated.metadata.lastUpdated}`);
 
     console.log('\n💡 For full upstream sync, manually review changes at:');
     console.log(`   ${UPSTREAM_URL.replace('/README.md', '')}`);


### PR DESCRIPTION
## Summary

The **AnnualReports** skill (Security pack) is non-functional as shipped: its `UpdateSources` tool parses **0 reports** from the upstream data source and then crashes on write, so the companion `ListSources` and `FetchReport` tools have no `sources.json` to read. This PR repairs `UpdateSources.ts` — verified end-to-end at **0 → 390 reports**.

## What a user hits today

```
$ bun run Packs/Security/src/AnnualReports/Tools/UpdateSources.ts
📥 Fetching upstream README...
✅ Fetched 253071 bytes
  Total parsed: 0            # ← every category empty
❌ Error: ENOENT ... open '.../AnnualReports/Data/sources.json'
```

The skill ships **no seed `Data/sources.json`**, so `ListSources`/`FetchReport` also ENOENT until an update succeeds — which it never does. Net effect: the skill is dead on install.

## Root cause — three independent defects

1. **Obsolete parser.** `parseMarkdownReports` expected an old README layout with `- Vendor:` / `- URL:` sub-bullets. The upstream source ([jacobdjwilson/awesome-annual-security-reports](https://github.com/jacobdjwilson/awesome-annual-security-reports)) now uses a single line per report:
   `- [Vendor](vendor-url) - [Report Name](report-path) (year) - description`
   The old pattern matches nothing → 0 reports.
2. **`main()` never merged parsed data.** It only rewrote an existing file's timestamp (`current.metadata.lastUpdated = ...`) and never wrote the parsed reports — so even a working parser produced no data.
3. **Missing directory.** `writeFileSync(SOURCES_PATH, ...)` raised `ENOENT` whenever `Data/` did not exist (i.e. every fresh install).

## The fix (single file: `UpdateSources.ts`)

- Rewrote `parseMarkdownReports` for the current one-line entry format. Section tracking now also **resets on any non-`Analysis`/`Survey` `##` header**, so links in the `## Contents` TOC and `## Resources` sections can never be mistaken for report entries.
- `main()` now **rebuilds `sources.json` from the parsed data** (metadata + `analysis`/`survey` categories).
- Added `mkdirSync(dirname(SOURCES_PATH), { recursive: true })` before write.

Imports extended with `mkdirSync` (`fs`) and `dirname` (`path`). No changes were needed to `ListSources.ts` or `FetchReport.ts` — they were correct and simply had no data to consume.

## Before / after

| | Before | After |
|---|---|---|
| Reports parsed | **0** | **390** |
| `UpdateSources` write | ENOENT crash | writes `Data/sources.json` |
| `ListSources` | ENOENT | 21 categories, counts render |
| `FetchReport` (live) | ENOENT | fetches + caches summary |

## Testing

Run against the live upstream README, from a clean checkout of this branch:

```
$ bun run Packs/Security/src/AnnualReports/Tools/UpdateSources.ts
✅ Fetched 253071 bytes
  Total parsed: 390
✅ Updated sources.json
   Total reports: 390

$ bun run Packs/Security/src/AnnualReports/Tools/ListSources.ts
Total Reports: 390
  Global Threat Intelligence: 72 reports
  Industry Trends: 81 reports
  ...

$ bun run Packs/Security/src/AnnualReports/Tools/FetchReport.ts verizon "data breach"
📄 Found: Verizon - Data Breach Investigations Report
✅ Summary saved: .../Reports/verizon/data-breach-investigations-report-summary.md
```

## Notes for reviewers

- **Scope:** only `Packs/Security/src/AnnualReports/Tools/UpdateSources.ts`. The identical stale copies under `Releases/v2.3–v2.5/` are frozen snapshots and are assumed to regenerate from `Packs/src`; left untouched.
- **`Data/sources.json` is intentionally not committed** — it is generated at runtime from the live upstream source. If you'd prefer to ship a seed file so the skill works before the first `UPDATE`, I'm happy to add one.
- The upstream data occasionally carries vendor-name typos (e.g. "Artic Wolf Labs", "Crowd Strike"); these are mirrored verbatim and are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
