### PR TITLE
fix(learning-readback): surface CONTEXT.md summaries instead of mangled dir slugs

### DIFF
--- a/Releases/v5.0.0/.claude/hooks/lib/learning-readback.ts
+++ b/Releases/v5.0.0/.claude/hooks/lib/learning-readback.ts
@@ -172,12 +172,23 @@ export function loadFailurePatterns(paiDir: string): string | null {
 
           try {
             const content = readFileSync(contextPath, 'utf-8');
-            // Extract slug as human-readable failure description
-            const slug = dir.replace(/^\d{4}-\d{2}-\d{2}-\d{6}_/, '').replace(/-/g, ' ');
             // Get date from dir name
             const dateMatch = dir.match(/^(\d{4}-\d{2}-\d{2})/);
             const date = dateMatch ? dateMatch[1] : '';
-            patterns.push(`[${date}] ${slug.substring(0, 70)}`);
+            // Prefer CONTEXT.md's own one-liner over the mangled dir slug
+            // (previously the file was read but its content discarded)
+            let desc = content.match(/\*\*Summary:\*\*\s*(.+)/)?.[1]?.trim()
+              || content.match(/## What Happened\s*\n+([^\n]+)/)?.[1]?.trim()
+              || dir.replace(/^\d{4}-\d{2}-\d{2}-\d{6}_/, '').replace(/-/g, ' ');
+            // Truncate at a word boundary instead of a hard mid-word cut
+            if (desc.length > 110) {
+              const cut = desc.lastIndexOf(' ', 110);
+              desc = desc.slice(0, cut > 60 ? cut : 110) + '…';
+            }
+            // Skip duplicate captures of the same event (a double-fire can
+            // produce two dirs with different slugs but identical summaries)
+            if (patterns.some(p => p.endsWith(desc))) continue;
+            patterns.push(`[${date}] ${desc}`);
           } catch { /* skip unreadable */ }
         }
       } catch { /* skip unreadable months */ }


### PR DESCRIPTION
## Problem

In `Releases/v5.0.0/.claude/hooks/lib/learning-readback.ts`, `loadFailurePatterns()` reads each failure capture's `CONTEXT.md` into `content` and then never uses it — it injects the de-slugified directory name instead, hard-truncated at 70 characters with no word boundary. Every session start gets garbled lines like:

```
[2026-06-15] userfrustrated analysis incomplete demanding comprehensive audit of all sub
```

while the discarded `CONTEXT.md` contains a clean `**Summary:**` one-liner that `FailureCapture.ts` wrote at capture time. Additionally, if one event is captured twice (two dirs, different slugs, identical summaries), both lines are injected.

## Fix

1. Prefer `CONTEXT.md`'s `**Summary:**` line; fall back to the first line of `## What Happened`; fall back to the de-slugged dir name (previous behavior).
2. Truncate at a word boundary (~110 chars) with an ellipsis instead of a hard 70-char mid-word cut.
3. Skip captures whose summary is already in the pattern list (dedupes double-fires).

## Before / after (same capture)

```
before: [2026-06-15] userfrustrated analysis incomplete demanding comprehensive audit of all sub
after:  [2026-06-15] Frustrated — analysis incomplete, requesting comprehensive audit of all submissions
```

Behavior is unchanged when `CONTEXT.md` has no Summary/What-Happened sections — the slug fallback path is preserved.

## Related (not in this PR)

`loadLearningDigest()` has the same discard pattern — it keeps an 80-char `**Feedback:**` stub and drops the Context paragraph. Happy to follow up with the same treatment if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)