### PR TITLE
fix(pulse): declare yaml dependency in Observability package.json

### DIFF
--- a/LifeOS/install/LifeOS/PULSE/Observability/package.json
+++ b/LifeOS/install/LifeOS/PULSE/Observability/package.json
@@ -30,7 +30,8 @@
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.4.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "yaml": "^2.6.0"
   },
   "devDependencies": {
     "@types/node": "^20",


### PR DESCRIPTION
Fixes #1390.

`observability.ts` imports `yaml` but the package is not declared in `PULSE/Observability/package.json` (nor `PULSE/package.json`). On a fresh v6.0.0 install the Observability module fails to resolve (`Cannot find package 'yaml'`), so the daemon runs but every dashboard page and `/api/*` route it serves returns 404.

**Fix:** declare `yaml` in dependencies (pinned `^2.6.0`; verified working with 2.9.x).

**Verified on** Ubuntu 24.04 + bun 1.2.x: after `bun install`, Pulse logs `Observability module loaded` and `/` + `/api/telos/overview` return 200.