### PR TITLE
fix(pulse): use LIFEOS (all-caps) runtime dir in observability.ts

### DIFF
--- a/LifeOS/install/LifeOS/PULSE/Observability/observability.ts
+++ b/LifeOS/install/LifeOS/PULSE/Observability/observability.ts
@@ -55,7 +55,7 @@ export interface ObservabilityConfig {
 // ── Path Construction ──
 
 const HOME = process.env.HOME ?? ""
-const LIFEOS_DIR = join(HOME, ".claude", "LifeOS")
+const LIFEOS_DIR = join(HOME, ".claude", "LIFEOS")
 const MEMORY_DIR = join(LIFEOS_DIR, "MEMORY")
 
 const WORK_JSON_PATH = join(MEMORY_DIR, "STATE", "work.json")
@@ -142,7 +142,7 @@ function getDashboardDir(): string {
   const dir = config.dashboard_dir ?? DEFAULT_DASHBOARD_DIR
   // Resolve relative paths against Pulse directory
   if (!dir.startsWith("/")) {
-    return join(HOME, ".claude", "LifeOS", "PULSE", dir)
+    return join(HOME, ".claude", "LIFEOS", "PULSE", dir)
   }
   return dir
 }
@@ -1626,7 +1626,7 @@ function readDirMdFiles(dir: string): { name: string, content: string, sections:
 
 function handleUserIndexApi(filter: string | null): Response {
   try {
-    const LIFEOS_DIR = process.env.LIFEOS_DIR || join(process.env.HOME || "", ".claude", "LifeOS")
+    const LIFEOS_DIR = process.env.LIFEOS_DIR || join(process.env.HOME || "", ".claude", "LIFEOS")
     const indexPath = join(LIFEOS_DIR, "PULSE", "state", "user-index.json")
     const raw = Bun.file(indexPath)
     if (!raw.size) {


### PR DESCRIPTION
Fixes #1391.

`DeployCore` deploys the runtime to `~/.claude/LIFEOS` (all-caps), but `observability.ts` hardcodes `~/.claude/LifeOS` in three places (const `LIFEOS_DIR`, dashboard dir helper, and an env-fallback). On case-sensitive filesystems (Linux) Pulse crash-loops with `ENOENT` on first start — and the crash loop mkdir's a stray real `~/.claude/LifeOS/` directory (captures `pulse.pid`) that then shadows any later symlink workaround. macOS is unaffected only because APFS defaults to case-insensitive.

**Fix:** all three occurrences now use `LIFEOS`, matching the deployer.

**Verified on** Ubuntu 24.04: with paths aligned, Pulse boots clean under the shipped systemd user unit (`manage.sh install`) and binds 127.0.0.1:31337.