### PR TITLE
fix(linux): normalize runtime-root dir casing (LifeOS → LIFEOS) — silent memory failure on case-sensitive FS

### DIFF
--- a/LifeOS/install/LifeOS/PULSE/Observability/observability.ts
+++ b/LifeOS/install/LifeOS/PULSE/Observability/observability.ts
@@ -55,7 +55,7 @@ export interface ObservabilityConfig {
 // ── Path Construction ──
 
 const HOME = process.env.HOME ?? ""
-const LIFEOS_DIR = join(HOME, ".claude", "LifeOS")
+const LIFEOS_DIR = join(HOME, ".claude", "LIFEOS")
 const MEMORY_DIR = join(LIFEOS_DIR, "MEMORY")
 
 const WORK_JSON_PATH = join(MEMORY_DIR, "STATE", "work.json")
@@ -142,7 +142,7 @@ function getDashboardDir(): string {
   const dir = config.dashboard_dir ?? DEFAULT_DASHBOARD_DIR
   // Resolve relative paths against Pulse directory
   if (!dir.startsWith("/")) {
-    return join(HOME, ".claude", "LifeOS", "PULSE", dir)
+    return join(HOME, ".claude", "LIFEOS", "PULSE", dir)
   }
   return dir
 }
@@ -1626,7 +1626,7 @@ function readDirMdFiles(dir: string): { name: string, content: string, sections:
 
 function handleUserIndexApi(filter: string | null): Response {
   try {
-    const LIFEOS_DIR = process.env.LIFEOS_DIR || join(process.env.HOME || "", ".claude", "LifeOS")
+    const LIFEOS_DIR = process.env.LIFEOS_DIR || join(process.env.HOME || "", ".claude", "LIFEOS")
     const indexPath = join(LIFEOS_DIR, "PULSE", "state", "user-index.json")
     const raw = Bun.file(indexPath)
     if (!raw.size) {

--- a/LifeOS/install/LifeOS/PULSE/Performance/cost-aggregator.ts
+++ b/LifeOS/install/LifeOS/PULSE/Performance/cost-aggregator.ts
@@ -14,7 +14,7 @@ import { join, basename, dirname } from "path"
 import { existsSync, readFileSync, writeFileSync, appendFileSync, readdirSync, statSync, mkdirSync } from "fs"
 
 const HOME = process.env.HOME ?? ""
-const LIFEOS_DIR = join(HOME, ".claude", "LifeOS")
+const LIFEOS_DIR = join(HOME, ".claude", "LIFEOS")
 const PROJECTS_DIR = join(HOME, ".claude", "projects")
 const OUTPUT_FILE = join(LIFEOS_DIR, "MEMORY", "OBSERVABILITY", "session-costs.jsonl")
 const STATE_FILE = join(LIFEOS_DIR, "PULSE", "Performance", "aggregator-state.json")

--- a/LifeOS/install/LifeOS/PULSE/Performance/module.ts
+++ b/LifeOS/install/LifeOS/PULSE/Performance/module.ts
@@ -14,7 +14,7 @@ import { join } from "path"
 import { existsSync, readFileSync } from "fs"
 
 const HOME = process.env.HOME ?? ""
-const LIFEOS_DIR = join(HOME, ".claude", "LifeOS")
+const LIFEOS_DIR = join(HOME, ".claude", "LIFEOS")
 const MEMORY_DIR = join(LIFEOS_DIR, "MEMORY")
 const SESSION_COSTS_PATH = join(MEMORY_DIR, "OBSERVABILITY", "session-costs.jsonl")
 const TOOL_FAILURES_PATH = join(MEMORY_DIR, "OBSERVABILITY", "tool-failures.jsonl")
@@ -278,7 +278,7 @@ async function handleAnthropicCostApi(): Promise<Response> {
   const { readFileSync, existsSync } = await import("fs")
   const { join } = await import("path")
   const home = process.env.HOME ?? ""
-  const obsDir = join(home, ".claude", "LifeOS", "MEMORY", "OBSERVABILITY")
+  const obsDir = join(home, ".claude", "LIFEOS", "MEMORY", "OBSERVABILITY")
   const ledgerPath = join(obsDir, "anthropic-cost.jsonl")
   const sitesPath = join(obsDir, "anthropic-call-sites.json")
 

--- a/LifeOS/install/LifeOS/PULSE/Tools/SnapshotFromFixture.ts
+++ b/LifeOS/install/LifeOS/PULSE/Tools/SnapshotFromFixture.ts
@@ -6,8 +6,8 @@ import type { PageData } from "../Schema/PulseSchema";
 import { PageDataSchema } from "../Schema/PulseSchema";
 
 const HOME = process.env.HOME!;
-const FIX_DIR = resolve(HOME, ".claude", "LifeOS", "PULSE", "Schema", "Fixtures");
-const OUT_DIR = resolve(HOME, ".claude", "LifeOS", "PULSE", "Schema", "Snapshots");
+const FIX_DIR = resolve(HOME, ".claude", "LIFEOS", "PULSE", "Schema", "Fixtures");
+const OUT_DIR = resolve(HOME, ".claude", "LIFEOS", "PULSE", "Schema", "Snapshots");
 mkdirSync(OUT_DIR, { recursive: true });
 
 const fixtures = readdirSync(FIX_DIR).filter((f) => f.endsWith(".json") && !f.startsWith("invalid"));

--- a/LifeOS/install/LifeOS/PULSE/Tools/SnapshotPages.ts
+++ b/LifeOS/install/LifeOS/PULSE/Tools/SnapshotPages.ts
@@ -7,7 +7,7 @@ import { readIndex, readPage } from "../lib/data-plane";
 import { loadAllManifests } from "../lib/manifest-loader";
 
 const HOME = process.env.HOME!;
-const SNAP_DIR = resolve(HOME, ".claude", "LifeOS", "PULSE", "Schema", "Snapshots");
+const SNAP_DIR = resolve(HOME, ".claude", "LIFEOS", "PULSE", "Schema", "Snapshots");
 mkdirSync(SNAP_DIR, { recursive: true });
 
 const idx = readIndex();

--- a/LifeOS/install/LifeOS/PULSE/VoiceServer/voice.ts
+++ b/LifeOS/install/LifeOS/PULSE/VoiceServer/voice.ts
@@ -163,7 +163,7 @@ function escapeRegex(str: string): string {
 }
 
 function loadPronunciations(customPath?: string): void {
-  const paiDir = join(process.env.HOME ?? "~", ".claude", "LifeOS")
+  const paiDir = join(process.env.HOME ?? "~", ".claude", "LIFEOS")
   const userPronPath = customPath ?? join(paiDir, "USER", "PRINCIPAL", "PRONUNCIATIONS.json")
 
   try {

--- a/LifeOS/install/LifeOS/PULSE/adapters/AdapterRunner.ts
+++ b/LifeOS/install/LifeOS/PULSE/adapters/AdapterRunner.ts
@@ -8,7 +8,7 @@ import { getProvenance } from "../lib/frontmatter";
 import { inference, type InferenceLevel } from "../../TOOLS/Inference";
 
 const HOME = process.env.HOME!;
-const OBSERVABILITY_DIR = resolve(HOME, ".claude", "LifeOS", "MEMORY", "OBSERVABILITY");
+const OBSERVABILITY_DIR = resolve(HOME, ".claude", "LIFEOS", "MEMORY", "OBSERVABILITY");
 const RUNS_LOG = join(OBSERVABILITY_DIR, "adapter-runs.jsonl");
 
 const ADAPTER_TIMEOUT_MS = 120_000;

--- a/LifeOS/install/LifeOS/PULSE/checks/airgradient-poll.ts
+++ b/LifeOS/install/LifeOS/PULSE/checks/airgradient-poll.ts
@@ -14,7 +14,7 @@ import { join } from "node:path"
 import { mkdirSync, writeFileSync, appendFileSync, readFileSync, existsSync } from "node:fs"
 
 const HOME = process.env.HOME ?? ""
-const CACHE_DIR = join(HOME, ".claude", "LifeOS", "MEMORY", "_AIRGRADIENT")
+const CACHE_DIR = join(HOME, ".claude", "LIFEOS", "MEMORY", "_AIRGRADIENT")
 const LATEST = join(CACHE_DIR, "latest.json")
 const HISTORY = join(CACHE_DIR, "history.jsonl")
 

--- a/LifeOS/install/LifeOS/PULSE/checks/github-work.ts
+++ b/LifeOS/install/LifeOS/PULSE/checks/github-work.ts
@@ -14,7 +14,7 @@ import { parse } from "smol-toml"
 import { SignJWT, importPKCS8 } from "jose"
 
 const HOME = process.env.HOME ?? ""
-const PULSE_DIR = join(HOME, ".claude", "LifeOS", "PULSE")
+const PULSE_DIR = join(HOME, ".claude", "LIFEOS", "PULSE")
 const STATE_FILE = join(PULSE_DIR, "state", "work-token.json")
 
 // ── Worker Config (from PULSE.toml [worker] section) ──

--- a/LifeOS/install/LifeOS/PULSE/checks/github.ts
+++ b/LifeOS/install/LifeOS/PULSE/checks/github.ts
@@ -12,8 +12,8 @@ import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, writeF
 import { dirname, join } from "path"
 
 const HOME = process.env.HOME ?? ""
-const LEGACY_STATE_FILE = join(HOME, ".claude", "LifeOS", "PULSE", "state", "github-seen.json")
-const STATE_FILE = join(HOME, ".claude", "LifeOS", "PULSE", "state", "github-seen.jsonl")
+const LEGACY_STATE_FILE = join(HOME, ".claude", "LIFEOS", "PULSE", "state", "github-seen.json")
+const STATE_FILE = join(HOME, ".claude", "LIFEOS", "PULSE", "state", "github-seen.jsonl")
 // Repos to monitor for new issues / activity. Override via LIFEOS_PULSE_REPOS
 // env var (comma-separated "owner/name" pairs). Empty default keeps fresh
 // installs from polling repos the user hasn't opted into.

--- a/LifeOS/install/LifeOS/PULSE/checks/life-morning-brief.ts
+++ b/LifeOS/install/LifeOS/PULSE/checks/life-morning-brief.ts
@@ -13,7 +13,7 @@ import { join } from "path"
 import { existsSync, readFileSync } from "fs"
 
 const HOME = process.env.HOME ?? ""
-const TELOS_DIR = join(HOME, ".claude", "LifeOS", "USER", "TELOS")
+const TELOS_DIR = join(HOME, ".claude", "LIFEOS", "USER", "TELOS")
 
 function readFile(name: string): string {
   const p = join(TELOS_DIR, name)

--- a/LifeOS/install/LifeOS/PULSE/checks/notification-governor.ts
+++ b/LifeOS/install/LifeOS/PULSE/checks/notification-governor.ts
@@ -33,7 +33,7 @@ import { join, dirname } from "path";
 import { createHash } from "crypto";
 
 const HOME = process.env.HOME || "";
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const STATE_FILE = join(LIFEOS_DIR, "PULSE", "state", "notification-governor.json");
 const LOG_FILE = join(LIFEOS_DIR, "MEMORY", "OBSERVABILITY", "notification-governor.jsonl");
 const NOTIFY_URL = "http://localhost:31337/notify";

--- a/LifeOS/install/LifeOS/PULSE/checks/poller-meta-monitor.ts
+++ b/LifeOS/install/LifeOS/PULSE/checks/poller-meta-monitor.ts
@@ -19,7 +19,7 @@ import { readFileSync, existsSync } from "fs";
 import { join } from "path";
 
 const HOME = process.env.HOME || "";
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const PULSE_STATE = join(LIFEOS_DIR, "PULSE", "state", "state.json");
 const PULSE_TOML = join(LIFEOS_DIR, "PULSE", "PULSE.toml");
 

--- a/LifeOS/install/LifeOS/PULSE/edit/edit-handler.ts
+++ b/LifeOS/install/LifeOS/PULSE/edit/edit-handler.ts
@@ -5,8 +5,8 @@ import { parseFrontmatter, serializeFrontmatter } from "../lib/frontmatter";
 import { sha256Hex } from "../lib/cache";
 
 const HOME = process.env.HOME!;
-const USER_ROOT = resolve(HOME, ".claude", "LifeOS", "USER");
-const EDITS_LOG = resolve(HOME, ".claude", "LifeOS", "MEMORY", "OBSERVABILITY", "pulse-edits.jsonl");
+const USER_ROOT = resolve(HOME, ".claude", "LIFEOS", "USER");
+const EDITS_LOG = resolve(HOME, ".claude", "LIFEOS", "MEMORY", "OBSERVABILITY", "pulse-edits.jsonl");
 const CONTAINMENT_PREFIX_DENY = ["MEMORY/PULSE_DATA", "MEMORY/OBSERVABILITY"];
 
 export interface EditRequest {
@@ -32,7 +32,7 @@ function isInUserTree(absPath: string): boolean {
 }
 
 function isContainmentPath(absPath: string): boolean {
-  const rel = absPath.replace(resolve(HOME, ".claude", "LifeOS") + "/", "");
+  const rel = absPath.replace(resolve(HOME, ".claude", "LIFEOS") + "/", "");
   return CONTAINMENT_PREFIX_DENY.some((p) => rel.startsWith(p));
 }
 

--- a/LifeOS/install/LifeOS/PULSE/lib.ts
+++ b/LifeOS/install/LifeOS/PULSE/lib.ts
@@ -50,7 +50,7 @@ export interface DaemonConfig {
 
 export const USER_CRON_PATH = join(
   process.env.HOME ?? "~",
-  ".claude", "LifeOS", "USER", "CONFIG", "PULSE.user.toml",
+  ".claude", "LIFEOS", "USER", "CONFIG", "PULSE.user.toml",
 )
 
 export interface JobState {
@@ -319,7 +319,7 @@ export async function spawnScript(command: string, timeoutMs = 60_000): Promise<
   const proc = Bun.spawn([BASH_PATH, "-c", command], {
     stdout: "pipe",
     stderr: "pipe",
-    cwd: join(process.env.HOME ?? "~", ".claude", "LifeOS", "PULSE"),
+    cwd: join(process.env.HOME ?? "~", ".claude", "LIFEOS", "PULSE"),
     env: { ...process.env },
   })
 

--- a/LifeOS/install/LifeOS/PULSE/lib/data-plane.ts
+++ b/LifeOS/install/LifeOS/PULSE/lib/data-plane.ts
@@ -5,7 +5,7 @@ import { atomicWriteJSON } from "./atomic-write";
 import type { PageData, PageMeta, Provenance } from "../Schema/PulseSchema";
 
 const HOME = process.env.HOME!;
-export const PULSE_DATA_DIR = resolve(HOME, ".claude", "LifeOS", "MEMORY", "PULSE_DATA");
+export const PULSE_DATA_DIR = resolve(HOME, ".claude", "LIFEOS", "MEMORY", "PULSE_DATA");
 
 export interface DataPlaneFile {
   schemaVersion: string;

--- a/LifeOS/install/LifeOS/PULSE/lib/provenance-watcher.ts
+++ b/LifeOS/install/LifeOS/PULSE/lib/provenance-watcher.ts
@@ -5,7 +5,7 @@ import { atomicWriteText } from "./atomic-write";
 import { parseFrontmatter, serializeFrontmatter } from "./frontmatter";
 
 const HOME = process.env.HOME!;
-const EDITS_LOG = resolve(HOME, ".claude", "LifeOS", "MEMORY", "OBSERVABILITY", "pulse-edits.jsonl");
+const EDITS_LOG = resolve(HOME, ".claude", "LIFEOS", "MEMORY", "OBSERVABILITY", "pulse-edits.jsonl");
 const PULSE_EDIT_GRACE_MS = 5_000;
 
 export interface WatcherOptions {

--- a/LifeOS/install/LifeOS/PULSE/lib/telegram-proposals.ts
+++ b/LifeOS/install/LifeOS/PULSE/lib/telegram-proposals.ts
@@ -21,7 +21,7 @@ import {
 } from "../../TOOLS/MemoryTypes";
 
 const HOME = process.env.HOME ?? homedir();
-const OBS_DIR = join(HOME, ".claude", "LifeOS", "MEMORY", "OBSERVABILITY");
+const OBS_DIR = join(HOME, ".claude", "LIFEOS", "MEMORY", "OBSERVABILITY");
 const PROPOSAL_REPLIES_LOG_PATH = join(OBS_DIR, "proposal-replies.jsonl");
 const IDENTITY_PROPOSALS_LOG_PATH = join(OBS_DIR, "identity-proposals.jsonl");
 

--- a/LifeOS/install/LifeOS/PULSE/modules/hypotheses.ts
+++ b/LifeOS/install/LifeOS/PULSE/modules/hypotheses.ts
@@ -28,7 +28,7 @@ import { existsSync, readFileSync, readdirSync, writeFileSync, unlinkSync, mkdir
 import { join } from "path";
 
 const HOME = process.env.HOME || "";
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const FRAMES_DIR = join(LIFEOS_DIR, "MEMORY", "WISDOM", "FRAMES");
 const HYPOTHESES_DIR = join(FRAMES_DIR, "_hypotheses");
 const ARCHIVE_DIR = join(HYPOTHESES_DIR, "_archive");

--- a/LifeOS/install/LifeOS/PULSE/modules/imessage.ts
+++ b/LifeOS/install/LifeOS/PULSE/modules/imessage.ts
@@ -63,8 +63,8 @@ export interface IMessageHealth {
 
 const HOME = process.env.HOME ?? ""
 const CWD = join(HOME, ".claude")
-const STATE_DIR = join(HOME, ".claude", "LifeOS", "PULSE", "state", "imessage")
-const LOGS_DIR = join(HOME, ".claude", "LifeOS", "PULSE", "logs", "imessage")
+const STATE_DIR = join(HOME, ".claude", "LIFEOS", "PULSE", "state", "imessage")
+const LOGS_DIR = join(HOME, ".claude", "LIFEOS", "PULSE", "logs", "imessage")
 
 let pollTimer: ReturnType<typeof setInterval> | null = null
 let running = false

--- a/LifeOS/install/LifeOS/PULSE/modules/local-intelligence.ts
+++ b/LifeOS/install/LifeOS/PULSE/modules/local-intelligence.ts
@@ -25,8 +25,8 @@ const MODULE_NAME = "local-intelligence"
 
 // Primary path: user-scoped customizations directory (per {{PRINCIPAL_NAME}} directive 2026-05-03).
 // Fallback path: legacy MEMORY/DATA path (used when customizations file absent).
-const CUSTOMIZATIONS_DIR = join(HOME, ".claude", "LifeOS", "USER", "CUSTOMIZATIONS", "SKILLS", "LocalIntelligence")
-const LEGACY_DATA_DIR = join(HOME, ".claude", "LifeOS", "MEMORY", "DATA", "LocalIntelligence")
+const CUSTOMIZATIONS_DIR = join(HOME, ".claude", "LIFEOS", "USER", "CUSTOMIZATIONS", "SKILLS", "LocalIntelligence")
+const LEGACY_DATA_DIR = join(HOME, ".claude", "LIFEOS", "MEMORY", "DATA", "LocalIntelligence")
 const LATEST_PATH = join(CUSTOMIZATIONS_DIR, "latest.json")
 const LEGACY_LATEST_PATH = join(LEGACY_DATA_DIR, "latest.json")
 const DATA_DIR = CUSTOMIZATIONS_DIR  // alias for existing references in this file

--- a/LifeOS/install/LifeOS/PULSE/modules/tab-freshness.ts
+++ b/LifeOS/install/LifeOS/PULSE/modules/tab-freshness.ts
@@ -30,7 +30,7 @@ import { existsSync, statSync, readdirSync, readFileSync } from "fs"
 import { join } from "path"
 
 const HOME = process.env.HOME ?? "~"
-const LIFEOS_DIR = join(HOME, ".claude", "LifeOS")
+const LIFEOS_DIR = join(HOME, ".claude", "LIFEOS")
 const USER_DIR = join(LIFEOS_DIR, "USER")
 const TELOS_DIR = join(USER_DIR, "TELOS")
 

--- a/LifeOS/install/LifeOS/PULSE/modules/telegram.ts
+++ b/LifeOS/install/LifeOS/PULSE/modules/telegram.ts
@@ -64,8 +64,8 @@ export interface TelegramConfig {
 
 const HOME = process.env.HOME ?? ""
 const CWD = join(HOME, ".claude")
-const STATE_DIR = join(HOME, ".claude", "LifeOS", "PULSE", "state", "telegram")
-const LOGS_DIR = join(HOME, ".claude", "LifeOS", "PULSE", "logs", "telegram")
+const STATE_DIR = join(HOME, ".claude", "LIFEOS", "PULSE", "state", "telegram")
+const LOGS_DIR = join(HOME, ".claude", "LIFEOS", "PULSE", "logs", "telegram")
 const STALE_ACK_CACHE_DIR = join(STATE_DIR, "ack-cache")
 const MAX_TELEGRAM_LENGTH = 4096
 const CURSOR = " ▌"
@@ -76,7 +76,7 @@ const IDLE_TIMEOUT_MS = 60 * 60 * 1000          // 1 hour — gap of silence tha
 const INFERENCE_HARD_BUDGET_MS = 10_000         // outer race cap on summarize; measured Sonnet subprocess cost is 4-6s, this gives slack without losing the voice trailing the text by too much
 const MIN_FALLBACK_WORDS = 6                    // a fallback summary shorter than this is presumed too thin to be worth voicing
 const MEANINGFUL_REPLY_WORDS = 25               // when a reply is at least this long, a too-short fallback is a regression — skip voice rather than ship a "0:00" stub
-const LIFEOS_DIR = join(HOME, ".claude", "LifeOS")
+const LIFEOS_DIR = join(HOME, ".claude", "LIFEOS")
 
 // Voice ID for outbound voice summaries. Read at module import from
 // PaiConfig — `[da.voices.main] voice_id` in LIFEOS/USER/CONFIG/LIFEOS_CONFIG.toml.

--- a/LifeOS/install/LifeOS/PULSE/modules/user-index.ts
+++ b/LifeOS/install/LifeOS/PULSE/modules/user-index.ts
@@ -23,7 +23,7 @@ import { readFileSync, writeFileSync, statSync, readdirSync, mkdirSync, existsSy
 import { join, relative, basename, dirname } from "path"
 
 const HOME = process.env.HOME ?? ""
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LifeOS")
+const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS")
 const USER_DIR = join(LIFEOS_DIR, "USER")
 const STATE_DIR = join(LIFEOS_DIR, "PULSE", "state")
 const INDEX_PATH = join(STATE_DIR, "user-index.json")

--- a/LifeOS/install/LifeOS/PULSE/modules/wiki.ts
+++ b/LifeOS/install/LifeOS/PULSE/modules/wiki.ts
@@ -36,7 +36,7 @@ import MiniSearch from "minisearch"
 // Path Construction
 
 const HOME = process.env.HOME ?? "~"
-const LIFEOS_DIR = join(HOME, ".claude", "LifeOS")
+const LIFEOS_DIR = join(HOME, ".claude", "LIFEOS")
 const DOCUMENTATION_DIR = join(LIFEOS_DIR, "DOCUMENTATION")
 const KNOWLEDGE_DIR = join(LIFEOS_DIR, "MEMORY", "KNOWLEDGE")
 const BOOKMARKS_DIR = join(LIFEOS_DIR, "MEMORY", "BOOKMARKS")

--- a/LifeOS/install/LifeOS/PULSE/modules/work.ts
+++ b/LifeOS/install/LifeOS/PULSE/modules/work.ts
@@ -26,7 +26,7 @@ import { join } from "path";
 import { loadWorkConfig, type WorkConfig } from "../../../hooks/lib/work-config";
 
 const HOME = process.env.HOME || "";
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const PULSE_STATE_DIR = join(LIFEOS_DIR, "PULSE", "state");
 const CACHE_PATH = join(PULSE_STATE_DIR, "work-cache.json");
 const MODULE = "work";
@@ -145,7 +145,7 @@ function extractSlug(title: string): string | undefined {
 // issues; the workload is bounded and the files are small.
 function extractPrincipalGoal(slug: string | undefined): string | undefined {
   if (!slug) return undefined;
-  const isaPath = join(HOME, ".claude", "LifeOS", "MEMORY", "WORK", slug, "ISA.md");
+  const isaPath = join(HOME, ".claude", "LIFEOS", "MEMORY", "WORK", slug, "ISA.md");
   if (!existsSync(isaPath)) return undefined;
   try {
     const content = readFileSync(isaPath, "utf-8");

--- a/LifeOS/install/LifeOS/PULSE/pulse-old.ts
+++ b/LifeOS/install/LifeOS/PULSE/pulse-old.ts
@@ -46,7 +46,7 @@ import {
 
 // ── Constants ──
 
-const PULSE_DIR = join(process.env.HOME ?? "~", ".claude", "LifeOS", "PULSE")
+const PULSE_DIR = join(process.env.HOME ?? "~", ".claude", "LIFEOS", "PULSE")
 const STATE_PATH = join(PULSE_DIR, "state", "state.json")
 const PID_PATH = join(PULSE_DIR, "state", "pulse.pid")
 const HOOK_PORT = parseInt(process.env.HOOK_SERVER_PORT || "8686", 10)

--- a/LifeOS/install/LifeOS/PULSE/pulse-unified.ts
+++ b/LifeOS/install/LifeOS/PULSE/pulse-unified.ts
@@ -21,7 +21,7 @@ import { parse } from "smol-toml"
 // ── Load .env before anything else ──
 
 const HOME = process.env.HOME ?? "~"
-const LIFEOS_DIR = join(HOME, ".claude", "LifeOS")
+const LIFEOS_DIR = join(HOME, ".claude", "LIFEOS")
 const PULSE_DIR = join(LIFEOS_DIR, "PULSE")
 
 const envPath = join(HOME, ".claude", ".env")

--- a/LifeOS/install/LifeOS/PULSE/pulse.ts
+++ b/LifeOS/install/LifeOS/PULSE/pulse.ts
@@ -21,7 +21,7 @@ import { parse } from "smol-toml"
 // ── Load .env before anything else ──
 
 const HOME = process.env.HOME ?? "~"
-const LIFEOS_DIR = join(HOME, ".claude", "LifeOS")
+const LIFEOS_DIR = join(HOME, ".claude", "LIFEOS")
 const PULSE_DIR = join(LIFEOS_DIR, "PULSE")
 
 const envPath = join(HOME, ".claude", ".env")

--- a/LifeOS/install/LifeOS/PULSE/run-job.ts
+++ b/LifeOS/install/LifeOS/PULSE/run-job.ts
@@ -31,7 +31,7 @@ if (!jobName) {
   process.exit(1)
 }
 
-const PULSE_DIR = join(process.env.HOME ?? "~", ".claude", "LifeOS", "PULSE")
+const PULSE_DIR = join(process.env.HOME ?? "~", ".claude", "LIFEOS", "PULSE")
 const config = await loadConfig(PULSE_DIR)
 const job = config.jobs.find((j) => j.name === jobName)
 if (!job) {

--- a/LifeOS/install/LifeOS/PULSE/setup.ts
+++ b/LifeOS/install/LifeOS/PULSE/setup.ts
@@ -14,7 +14,7 @@ import { join, resolve } from "path"
 import { existsSync, mkdirSync } from "fs"
 
 const HOME = process.env.HOME ?? "~"
-const LIFEOS_DIR = join(HOME, ".claude", "LifeOS")
+const LIFEOS_DIR = join(HOME, ".claude", "LIFEOS")
 const PULSE_DIR = join(LIFEOS_DIR, "PULSE")
 
 // ── Helpers ──

--- a/LifeOS/install/LifeOS/TOOLS/ActivityParser.ts
+++ b/LifeOS/install/LifeOS/TOOLS/ActivityParser.ts
@@ -22,7 +22,7 @@ import * as path from "path";
 // ============================================================================
 
 const CLAUDE_DIR = path.join(process.env.HOME!, ".claude");
-const MEMORY_DIR = path.join(CLAUDE_DIR, "LifeOS", "MEMORY");
+const MEMORY_DIR = path.join(CLAUDE_DIR, "LIFEOS", "MEMORY");
 const USERNAME = process.env.USER || require("os").userInfo().username;
 const PROJECTS_DIR = path.join(CLAUDE_DIR, "projects", `-Users-${USERNAME}--claude`);  // Claude Code native storage
 const SYSTEM_UPDATES_DIR = path.join(MEMORY_DIR, "PAISYSTEMUPDATES");  // Canonical system change history

--- a/LifeOS/install/LifeOS/TOOLS/AgentWatchdog.ts
+++ b/LifeOS/install/LifeOS/TOOLS/AgentWatchdog.ts
@@ -20,7 +20,7 @@
 import { existsSync, readFileSync, statSync } from "fs";
 import { join } from "path";
 
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(process.env.HOME!, ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || join(process.env.HOME!, ".claude", "LIFEOS");
 const OBS_DIR = join(LIFEOS_DIR, "MEMORY", "OBSERVABILITY");
 const ACTIVITY_FILE = join(OBS_DIR, "tool-activity.jsonl");
 const STARTS_FILE = join(OBS_DIR, "subagent-starts.json");

--- a/LifeOS/install/LifeOS/TOOLS/AlgorithmPhaseReport.ts
+++ b/LifeOS/install/LifeOS/TOOLS/AlgorithmPhaseReport.ts
@@ -18,7 +18,7 @@ import { join } from "path";
 import { homedir } from "os";
 import { parseArgs } from "util";
 
-const STATE_DIR = join(homedir(), ".claude", "LifeOS", "MEMORY", "STATE");
+const STATE_DIR = join(homedir(), ".claude", "LIFEOS", "MEMORY", "STATE");
 const STATE_FILE = join(STATE_DIR, "algorithm-phase.json");
 
 interface AlgorithmState {

--- a/LifeOS/install/LifeOS/TOOLS/ApproveCurrentStateEntries.ts
+++ b/LifeOS/install/LifeOS/TOOLS/ApproveCurrentStateEntries.ts
@@ -20,7 +20,7 @@ import { readFileSync, writeFileSync, existsSync } from "fs";
 import { join } from "path";
 
 const HOME = process.env.HOME || "";
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const QUEUE_FILE = join(LIFEOS_DIR, "USER", "TELOS", "CURRENT_STATE", "proposals.jsonl");
 const CURRENT_STATE_DIR = join(LIFEOS_DIR, "USER", "TELOS", "CURRENT_STATE");
 

--- a/LifeOS/install/LifeOS/TOOLS/ArchDecisionHarvest.ts
+++ b/LifeOS/install/LifeOS/TOOLS/ArchDecisionHarvest.ts
@@ -24,7 +24,7 @@ import * as os from "os";
 // ============================================================================
 
 const HOME = process.env.HOME || os.homedir();
-const LIFEOS_DIR = process.env.LIFEOS_DIR || path.join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || path.join(HOME, ".claude", "LIFEOS");
 const DEFAULT_WORK_DIR = path.join(LIFEOS_DIR, "MEMORY", "WORK");
 const DEFAULT_ARCH_DOC = path.join(LIFEOS_DIR, "DOCUMENTATION", "LifeosSystemArchitecture.md");
 const ARCH_DECISIONS_HEADING = "## Architecture Decisions";

--- a/LifeOS/install/LifeOS/TOOLS/ArchitectureSummaryGenerator.ts
+++ b/LifeOS/install/LifeOS/TOOLS/ArchitectureSummaryGenerator.ts
@@ -20,7 +20,7 @@ import * as path from "path";
 // ============================================================================
 
 const HOME = process.env.HOME!;
-const LIFEOS_DIR = process.env.LIFEOS_DIR || path.join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || path.join(HOME, ".claude", "LIFEOS");
 const ARCH_SOURCE = path.join(LIFEOS_DIR, "DOCUMENTATION", "LifeosSystemArchitecture.md");
 const SUMMARY_OUTPUT = path.join(LIFEOS_DIR, "DOCUMENTATION", "ARCHITECTURE_SUMMARY.md");
 const ALGORITHM_DIR = path.join(LIFEOS_DIR, "ALGORITHM");

--- a/LifeOS/install/LifeOS/TOOLS/Banner.ts
+++ b/LifeOS/install/LifeOS/TOOLS/Banner.ts
@@ -164,7 +164,7 @@ function getStats(): SystemStats {
   let repoUrl = "github.com/danielmiessler/LifeOS";
   try {
     // Identity from DA_IDENTITY.md frontmatter (canonical source)
-    const daPath = join(CLAUDE_DIR, "LifeOS", "USER", "DIGITAL_ASSISTANT", "DA_IDENTITY.md");
+    const daPath = join(CLAUDE_DIR, "LIFEOS", "USER", "DIGITAL_ASSISTANT", "DA_IDENTITY.md");
     if (existsSync(daPath)) {
       const content = readFileSync(daPath, "utf-8");
       const m = content.match(/^---\n([\s\S]*?)\n---/);
@@ -179,12 +179,12 @@ function getStats(): SystemStats {
   } catch {}
   try {
     // LifeOS version: ~/.claude/LIFEOS/VERSION (single source of truth)
-    const versionPath = join(CLAUDE_DIR, "LifeOS", "VERSION");
+    const versionPath = join(CLAUDE_DIR, "LIFEOS", "VERSION");
     if (existsSync(versionPath)) {
       paiVersion = readFileSync(versionPath, "utf-8").trim() || paiVersion;
     }
     // Algorithm version: ~/.claude/LIFEOS/ALGORITHM/LATEST
-    const latestPath = join(CLAUDE_DIR, "LifeOS", "ALGORITHM", "LATEST");
+    const latestPath = join(CLAUDE_DIR, "LIFEOS", "ALGORITHM", "LATEST");
     if (existsSync(latestPath)) {
       algorithmVersion = readFileSync(latestPath, "utf-8").trim().replace(/^v/i, "") || algorithmVersion;
     }
@@ -198,7 +198,7 @@ function getStats(): SystemStats {
   // `--single` mode (~20ms each) instead of the full multi-key walk which
   // recursed into LIFEOS/USER/ (123k files) for keys nothing displays.
   let skills = 0, hooks = 0, sessions = 0;
-  const getCountsPath = join(CLAUDE_DIR, "LifeOS", "TOOLS", "GetCounts.ts");
+  const getCountsPath = join(CLAUDE_DIR, "LIFEOS", "TOOLS", "GetCounts.ts");
   try {
     const r = spawnSync("bun", [getCountsPath, "--single", "skills"], { encoding: "utf-8", timeout: 1000 });
     if (r.stdout) skills = parseInt(r.stdout.trim(), 10) || 0;

--- a/LifeOS/install/LifeOS/TOOLS/BannerMatrix.ts
+++ b/LifeOS/install/LifeOS/TOOLS/BannerMatrix.ts
@@ -315,7 +315,7 @@ function countHooks(): number {
 }
 
 function countWorkItems(): number {
-  const workDir = join(CLAUDE_DIR, "LifeOS", "MEMORY", "WORK");
+  const workDir = join(CLAUDE_DIR, "LIFEOS", "MEMORY", "WORK");
   if (!existsSync(workDir)) return 0;
   let count = 0;
   try {
@@ -327,7 +327,7 @@ function countWorkItems(): number {
 }
 
 function countLearnings(): number {
-  const learningsDir = join(CLAUDE_DIR, "LifeOS", "MEMORY", "LEARNING");
+  const learningsDir = join(CLAUDE_DIR, "LIFEOS", "MEMORY", "LEARNING");
   if (!existsSync(learningsDir)) return 0;
   let count = 0;
   const countRecursive = (dir: string) => {

--- a/LifeOS/install/LifeOS/TOOLS/BookmarkSweep.ts
+++ b/LifeOS/install/LifeOS/TOOLS/BookmarkSweep.ts
@@ -25,7 +25,7 @@ import { join } from "path";
 declare const Bun: { spawn: (cmd: string[], opts?: any) => any };
 
 const HOME = process.env.HOME || "";
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const X_DIR = join(HOME, ".claude", "skills", "_X");
 const BOOKMARKS_TOOL = join(X_DIR, "Tools", "bookmarks.ts");
 const BOOKMARK_ISSUE_TOOL = join(X_DIR, "Tools", "bookmark-issue.ts");

--- a/LifeOS/install/LifeOS/TOOLS/CodexUpdate.ts
+++ b/LifeOS/install/LifeOS/TOOLS/CodexUpdate.ts
@@ -21,7 +21,7 @@ import { join, dirname } from "path";
 
 const HOME = process.env.HOME || "";
 const PKG = "@openai/codex";
-const LOG = join(HOME, ".claude", "LifeOS", "MEMORY", "OBSERVABILITY", "codex-update.jsonl");
+const LOG = join(HOME, ".claude", "LIFEOS", "MEMORY", "OBSERVABILITY", "codex-update.jsonl");
 
 function codexVersion(): string | null {
   const r = spawnSync("codex", ["--version"], { encoding: "utf-8" });

--- a/LifeOS/install/LifeOS/TOOLS/CommitmentSweep.ts
+++ b/LifeOS/install/LifeOS/TOOLS/CommitmentSweep.ts
@@ -25,7 +25,7 @@ import { spawnSync } from "child_process";
 import { loadWorkConfig } from "../../hooks/lib/work-config";
 
 const HOME = process.env.HOME || "";
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const OBS_DIR = join(LIFEOS_DIR, "MEMORY", "OBSERVABILITY");
 const OBS_LOG = join(OBS_DIR, "commitment-digest.jsonl");
 const PULSE_NOTIFY = "http://localhost:31337/notify";

--- a/LifeOS/install/LifeOS/TOOLS/ComputeGap.ts
+++ b/LifeOS/install/LifeOS/TOOLS/ComputeGap.ts
@@ -24,7 +24,7 @@ import { readFileSync, existsSync, appendFileSync, mkdirSync } from "fs";
 import { join, dirname } from "path";
 
 const HOME = process.env.HOME || "";
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const IDEAL_DIR = join(LIFEOS_DIR, "USER", "TELOS", "IDEAL_STATE");
 const CURRENT_DIR = join(LIFEOS_DIR, "USER", "TELOS", "CURRENT_STATE");
 const HEALTH_DIR = join(LIFEOS_DIR, "USER", "HEALTH");

--- a/LifeOS/install/LifeOS/TOOLS/ContextAudit.ts
+++ b/LifeOS/install/LifeOS/TOOLS/ContextAudit.ts
@@ -13,7 +13,7 @@ import { CONTEXT_FRESHNESS_REGISTRY, parseFrontmatter, type ContextFile } from "
 import { currentModel } from "./models";
 
 const HOME = process.env.HOME || "";
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const CLAUDE_DIR = dirname(LIFEOS_DIR);
 const AUDIT_PATH = join(
   LIFEOS_DIR,

--- a/LifeOS/install/LifeOS/TOOLS/CostTracker.ts
+++ b/LifeOS/install/LifeOS/TOOLS/CostTracker.ts
@@ -33,7 +33,7 @@ import { join } from "path";
 import { execSync } from "child_process";
 
 const HOME = process.env.HOME ?? "";
-const LIFEOS_DIR = join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = join(HOME, ".claude", "LIFEOS");
 const OBS_DIR = join(LIFEOS_DIR, "MEMORY", "OBSERVABILITY");
 const LEDGER_PATH = join(OBS_DIR, "anthropic-cost.jsonl");
 const CALL_SITES_PATH = join(OBS_DIR, "anthropic-call-sites.json");
@@ -129,9 +129,9 @@ async function fetchApiSpend(): Promise<{ month_used_usd: number | null; source:
 
 // Paths we scan (source-of-truth for LifeOS-local billing risk)
 const SCAN_ROOTS = [
-  join(HOME, ".claude", "LifeOS", "PULSE"),
-  join(HOME, ".claude", "LifeOS", "TOOLS"),
-  join(HOME, ".claude", "LifeOS", "USER"),
+  join(HOME, ".claude", "LIFEOS", "PULSE"),
+  join(HOME, ".claude", "LIFEOS", "TOOLS"),
+  join(HOME, ".claude", "LIFEOS", "USER"),
   join(HOME, ".claude", "skills"),
   join(HOME, ".claude", "hooks"),
 ];

--- a/LifeOS/install/LifeOS/TOOLS/CrossVendorAudit.ts
+++ b/LifeOS/install/LifeOS/TOOLS/CrossVendorAudit.ts
@@ -22,7 +22,7 @@ import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 
 const HOME = homedir();
-const LIFEOS_DIR = join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = join(HOME, ".claude", "LIFEOS");
 const WORK_DIR = join(LIFEOS_DIR, "MEMORY", "WORK");
 const FINDINGS_LOG = join(LIFEOS_DIR, "MEMORY", "VERIFICATION", "cato-findings.jsonl");
 const TOOL_ACTIVITY_LOG = join(LIFEOS_DIR, "MEMORY", "OBSERVABILITY", "tool-activity.jsonl");

--- a/LifeOS/install/LifeOS/TOOLS/DAGrowth.ts
+++ b/LifeOS/install/LifeOS/TOOLS/DAGrowth.ts
@@ -15,7 +15,7 @@
 import { join } from "path"
 
 const HOME = process.env.HOME ?? "~"
-const LifeOS = join(HOME, ".claude", "LifeOS")
+const LifeOS = join(HOME, ".claude", "LIFEOS")
 const REGISTRY_PATH = join(LifeOS, "USER", "DA", "_registry.yaml")
 
 // ── Types ──

--- a/LifeOS/install/LifeOS/TOOLS/DASchedule.ts
+++ b/LifeOS/install/LifeOS/TOOLS/DASchedule.ts
@@ -14,7 +14,7 @@ import { join } from "path"
 import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync } from "fs"
 
 const HOME = process.env.HOME ?? "~"
-const LIFEOS_DIR = join(HOME, ".claude", "LifeOS")
+const LIFEOS_DIR = join(HOME, ".claude", "LIFEOS")
 const TASKS_DIR = join(LIFEOS_DIR, "PULSE", "state", "da")
 const TASKS_PATH = join(TASKS_DIR, "scheduled-tasks.jsonl")
 

--- a/LifeOS/install/LifeOS/TOOLS/DerivedSync.ts
+++ b/LifeOS/install/LifeOS/TOOLS/DerivedSync.ts
@@ -77,7 +77,7 @@ type RunSummary = {
 
 const HOME = process.env.HOME || "";
 const CLAUDE_DIR = join(HOME, ".claude");
-const LIFEOS_DIR = join(CLAUDE_DIR, "LifeOS");
+const LIFEOS_DIR = join(CLAUDE_DIR, "LIFEOS");
 const USER_DIR = join(LIFEOS_DIR, "USER");
 const TOOLS_DIR = join(LIFEOS_DIR, "TOOLS");
 const PULSE_PAGES_DIR = join(LIFEOS_DIR, "PULSE", "pages");

--- a/LifeOS/install/LifeOS/TOOLS/ForgeProgress.ts
+++ b/LifeOS/install/LifeOS/TOOLS/ForgeProgress.ts
@@ -67,7 +67,7 @@ function preflightCodex(home: string): string | null {
   catch (_error: unknown) { return null; } // Safe: caller emits the exact unavailable JSON.
 }
 async function ensureSlugDir(home: string, slug: string): Promise<Paths> {
-  const slugDir = join(home, ".claude", "LifeOS", "MEMORY", "WORK", slug);
+  const slugDir = join(home, ".claude", "LIFEOS", "MEMORY", "WORK", slug);
   await mkdir(slugDir, { recursive: true }); // Local artifact I/O is unbounded so errors can surface naturally.
   return { eventsFile: join(slugDir, "forge-events.jsonl"), finalFile: join(slugDir, "forge-final.txt") };
 }

--- a/LifeOS/install/LifeOS/TOOLS/FreshnessCache.ts
+++ b/LifeOS/install/LifeOS/TOOLS/FreshnessCache.ts
@@ -17,7 +17,7 @@ import { join } from "path";
 import { readContextFreshness } from "./TelosFreshness";
 
 const HOME = process.env.HOME || "";
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const CACHE_DIR = join(LIFEOS_DIR, "USER", "CACHE");
 const CACHE_PATH = join(CACHE_DIR, "freshness.json");
 

--- a/LifeOS/install/LifeOS/TOOLS/GetCounts.ts
+++ b/LifeOS/install/LifeOS/TOOLS/GetCounts.ts
@@ -40,7 +40,7 @@ const HOME = process.env.HOME!;
 const CLAUDE_DIR = join(HOME, ".claude");
 // skills/, hooks/, settings.json live under CLAUDE_DIR.
 // MEMORY/, USER/ live under LIFEOS_DIR (which is CLAUDE_DIR/PAI).
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(CLAUDE_DIR, "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || join(CLAUDE_DIR, "LIFEOS");
 
 interface Counts {
   skills: number;

--- a/LifeOS/install/LifeOS/TOOLS/HarvestExecutor.ts
+++ b/LifeOS/install/LifeOS/TOOLS/HarvestExecutor.ts
@@ -14,7 +14,7 @@ import * as path from "path";
 import { inference } from "./Inference";
 
 const HOME = process.env.HOME!;
-const LIFEOS_DIR = path.join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = path.join(HOME, ".claude", "LIFEOS");
 const MEMORY_DIR = path.join(LIFEOS_DIR, "MEMORY");
 const KNOWLEDGE_DIR = path.join(MEMORY_DIR, "KNOWLEDGE");
 const LEARNING_DIR = path.join(MEMORY_DIR, "LEARNING");

--- a/LifeOS/install/LifeOS/TOOLS/HealthSync.ts
+++ b/LifeOS/install/LifeOS/TOOLS/HealthSync.ts
@@ -42,7 +42,7 @@ type CliCommand = "pull" | "status" | "current" | "auth";
 const HOME = process.env.HOME || "";
 const PREFIX = "[HealthSync]";
 const SOURCE_NAMES: readonly SourceName[] = ["oura", "eightsleep", "apple", "function"];
-const CURRENT_PATH = join(HOME, ".claude", "LifeOS", "USER", "HEALTH", "current.json");
+const CURRENT_PATH = join(HOME, ".claude", "LIFEOS", "USER", "HEALTH", "current.json");
 const HEALTHSYNC_LOG_PATH = join(
   HOME,
   ".claude",

--- a/LifeOS/install/LifeOS/TOOLS/Inference.ts
+++ b/LifeOS/install/LifeOS/TOOLS/Inference.ts
@@ -419,8 +419,8 @@ export async function synthesizeAdvisorState(): Promise<string> {
   const fs = await import("fs/promises");
   const path = await import("path");
   const home = process.env.HOME || process.env.USERPROFILE || "";
-  const workDir = path.join(home, ".claude", "LifeOS", "MEMORY", "WORK");
-  const stateFile = path.join(home, ".claude", "LifeOS", "MEMORY", "STATE", "work.json");
+  const workDir = path.join(home, ".claude", "LIFEOS", "MEMORY", "WORK");
+  const stateFile = path.join(home, ".claude", "LIFEOS", "MEMORY", "STATE", "work.json");
 
   // Try to read active session from work.json
   let activeSlug: string | undefined;

--- a/LifeOS/install/LifeOS/TOOLS/InstallCommitmentSweep.ts
+++ b/LifeOS/install/LifeOS/TOOLS/InstallCommitmentSweep.ts
@@ -17,7 +17,7 @@ const HOME = process.env.HOME || "";
 const TEMPLATE = join(HOME, ".claude", "LIFEOS", "TOOLS", "com.lifeos.commitmentsweep.plist.template");
 const TARGET_DIR = join(HOME, "Library", "LaunchAgents");
 const TARGET = join(TARGET_DIR, "com.lifeos.commitmentsweep.plist");
-const STATE_DIR = join(HOME, ".claude", "LifeOS", "MEMORY", "STATE");
+const STATE_DIR = join(HOME, ".claude", "LIFEOS", "MEMORY", "STATE");
 const LABEL = "com.lifeos.commitmentsweep";
 
 function uid(): string {

--- a/LifeOS/install/LifeOS/TOOLS/InstallDerivedSync.ts
+++ b/LifeOS/install/LifeOS/TOOLS/InstallDerivedSync.ts
@@ -87,7 +87,7 @@ async function install(): Promise<void> {
   }
   const bunPath = await detectBun();
   const bunDir = bunPath.replace(/\/bun$/, "");
-  const userDir = realpathSync(join(HOME, ".claude", "LifeOS", "USER"));
+  const userDir = realpathSync(join(HOME, ".claude", "LIFEOS", "USER"));
   console.log(`[InstallDerivedSync] detected bun at ${bunPath}`);
   const template = readFileSync(TEMPLATE_PATH, "utf-8");
   const materialized = template

--- a/LifeOS/install/LifeOS/TOOLS/InterviewIdealState.ts
+++ b/LifeOS/install/LifeOS/TOOLS/InterviewIdealState.ts
@@ -19,7 +19,7 @@ import { readFileSync, writeFileSync, existsSync, readdirSync } from "fs";
 import { join } from "path";
 
 const HOME = process.env.HOME || "";
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const TELOS_DIR = join(LIFEOS_DIR, "USER", "TELOS");
 const IDEAL_DIR = join(TELOS_DIR, "IDEAL_STATE");
 const STATE_FILE = join(LIFEOS_DIR, "USER", "TELOS", "CURRENT_STATE", "interview-state.json");

--- a/LifeOS/install/LifeOS/TOOLS/InterviewScan.ts
+++ b/LifeOS/install/LifeOS/TOOLS/InterviewScan.ts
@@ -21,7 +21,7 @@ import { join } from "path";
 import { readTelosFreshness, sectionSlug, type SectionFreshness } from "./TelosFreshness";
 
 const HOME = process.env.HOME || "";
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const USER_DIR = join(LIFEOS_DIR, "USER");
 const TELOS_DIR = join(USER_DIR, "TELOS");
 const TELOS_PATH = join(TELOS_DIR, "TELOS.md");

--- a/LifeOS/install/LifeOS/TOOLS/KnowledgeGraph.ts
+++ b/LifeOS/install/LifeOS/TOOLS/KnowledgeGraph.ts
@@ -32,7 +32,7 @@ import * as path from "path";
 // ============================================================================
 
 const HOME = process.env.HOME!;
-const LIFEOS_DIR = process.env.LIFEOS_DIR || path.join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || path.join(HOME, ".claude", "LIFEOS");
 const KNOWLEDGE_DIR = path.join(LIFEOS_DIR, "MEMORY", "KNOWLEDGE");
 const DOMAINS = ["People", "Companies", "Ideas", "Research"];
 const SKIP_FILES = new Set(["_index.md", "_schema.md", "_log.md"]);

--- a/LifeOS/install/LifeOS/TOOLS/KnowledgeHarvester.ts
+++ b/LifeOS/install/LifeOS/TOOLS/KnowledgeHarvester.ts
@@ -27,7 +27,7 @@ import * as path from "path";
 // ============================================================================
 
 const HOME = process.env.HOME!;
-const LIFEOS_DIR = process.env.LIFEOS_DIR || path.join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || path.join(HOME, ".claude", "LIFEOS");
 const MEMORY_DIR = path.join(LIFEOS_DIR, "MEMORY");
 const KNOWLEDGE_DIR = path.join(MEMORY_DIR, "KNOWLEDGE");
 const WORK_DIR = path.join(MEMORY_DIR, "WORK");

--- a/LifeOS/install/LifeOS/TOOLS/LearningPatternSynthesis.ts
+++ b/LifeOS/install/LifeOS/TOOLS/LearningPatternSynthesis.ts
@@ -32,7 +32,7 @@ import * as crypto from "crypto";
 // ============================================================================
 
 const CLAUDE_DIR = path.join(process.env.HOME!, ".claude");
-const LIFEOS_DIR = path.join(CLAUDE_DIR, "LifeOS");
+const LIFEOS_DIR = path.join(CLAUDE_DIR, "LIFEOS");
 const MEMORY_DIR = path.join(LIFEOS_DIR, "MEMORY");
 const LEARNING_DIR = path.join(MEMORY_DIR, "LEARNING");
 const RATINGS_FILE = path.join(LEARNING_DIR, "SIGNALS", "ratings.jsonl");

--- a/LifeOS/install/LifeOS/TOOLS/MemoryGraph.ts
+++ b/LifeOS/install/LifeOS/TOOLS/MemoryGraph.ts
@@ -29,7 +29,7 @@ import * as fs from "fs";
 import * as path from "path";
 
 const HOME = process.env.HOME!;
-const LIFEOS_DIR = process.env.LIFEOS_DIR || path.join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || path.join(HOME, ".claude", "LIFEOS");
 const MEMORY = path.join(LIFEOS_DIR, "MEMORY");
 const KNOWLEDGE_DIR = path.join(MEMORY, "KNOWLEDGE");
 const WORK_DIR = path.join(MEMORY, "WORK");

--- a/LifeOS/install/LifeOS/TOOLS/MemoryRetriever.ts
+++ b/LifeOS/install/LifeOS/TOOLS/MemoryRetriever.ts
@@ -41,7 +41,7 @@ import { spawnSync } from "child_process";
 // ============================================================================
 
 const HOME = process.env.HOME!;
-const LIFEOS_DIR = process.env.LIFEOS_DIR || path.join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || path.join(HOME, ".claude", "LIFEOS");
 const KNOWLEDGE_DIR = path.join(LIFEOS_DIR, "MEMORY", "KNOWLEDGE");
 const DOMAINS = ["People", "Companies", "Ideas", "Research"];
 
@@ -392,8 +392,8 @@ function formatResults(
 // dual-tier prefetch, no graph traversal on hot path).
 
 const MEMORY_FILES: ReadonlyArray<{ path: string; title: string }> = [
-  { path: path.join(HOME, ".claude", "LifeOS", "USER", "PRINCIPAL", "PRINCIPAL_MEMORY.md"), title: "Principal Memory" },
-  { path: path.join(HOME, ".claude", "LifeOS", "USER", "DIGITAL_ASSISTANT", "DA_MEMORY.md"), title: "DA Memory" },
+  { path: path.join(HOME, ".claude", "LIFEOS", "USER", "PRINCIPAL", "PRINCIPAL_MEMORY.md"), title: "Principal Memory" },
+  { path: path.join(HOME, ".claude", "LIFEOS", "USER", "DIGITAL_ASSISTANT", "DA_MEMORY.md"), title: "DA Memory" },
 ];
 
 const RELEVANT_CACHE_TTL_MS = 60_000;

--- a/LifeOS/install/LifeOS/TOOLS/MemoryStatus.ts
+++ b/LifeOS/install/LifeOS/TOOLS/MemoryStatus.ts
@@ -33,7 +33,7 @@ import {
 import { read as readMemory } from "./MemoryWriter";
 
 const CLAUDE_ROOT = pathResolve(homedir(), ".claude");
-const LIFEOS_DIR = pathJoin(CLAUDE_ROOT, "LifeOS");
+const LIFEOS_DIR = pathJoin(CLAUDE_ROOT, "LIFEOS");
 const IDEAS_DIR = pathJoin(LIFEOS_DIR, "MEMORY", "IDEAS");
 const KNOWLEDGE_DIR = pathJoin(LIFEOS_DIR, "MEMORY", "KNOWLEDGE");
 const OBS_DIR = pathJoin(LIFEOS_DIR, "MEMORY", "OBSERVABILITY");

--- a/LifeOS/install/LifeOS/TOOLS/MemoryTypes.ts
+++ b/LifeOS/install/LifeOS/TOOLS/MemoryTypes.ts
@@ -34,7 +34,7 @@ import { homedir } from "node:os";
 // ── Paths ──
 
 const CLAUDE_ROOT = pathResolve(homedir(), ".claude");
-const LIFEOS_DIR = pathJoin(CLAUDE_ROOT, "LifeOS");
+const LIFEOS_DIR = pathJoin(CLAUDE_ROOT, "LIFEOS");
 const KNOWLEDGE_DIR = pathJoin(LIFEOS_DIR, "MEMORY", "KNOWLEDGE");
 
 export const PRINCIPAL_MEMORY_PATH = pathJoin(LIFEOS_DIR, "USER", "PRINCIPAL", "PRINCIPAL_MEMORY.md");

--- a/LifeOS/install/LifeOS/TOOLS/MigrateApprove.ts
+++ b/LifeOS/install/LifeOS/TOOLS/MigrateApprove.ts
@@ -26,7 +26,7 @@ import { readFileSync, writeFileSync, existsSync, appendFileSync, mkdirSync } fr
 import { join, dirname } from "path";
 
 const HOME = process.env.HOME || "";
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const QUEUE_FILE = join(LIFEOS_DIR, "MEMORY", "MIGRATION", "migration-proposals.jsonl");
 const COMMITTED_LOG = join(LIFEOS_DIR, "MEMORY", "MIGRATION", "committed.jsonl");
 

--- a/LifeOS/install/LifeOS/TOOLS/MigrateContextFreshness.ts
+++ b/LifeOS/install/LifeOS/TOOLS/MigrateContextFreshness.ts
@@ -19,7 +19,7 @@ import {
 } from "./TelosFreshness";
 
 const HOME = process.env.HOME || "";
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const CLAUDE_DIR = dirname(LIFEOS_DIR);
 const SEED_ISO = "2026-05-03T23:00:00-07:00";
 const BACKUP_TS = "2026-05-03-23-00-00";

--- a/LifeOS/install/LifeOS/TOOLS/MigrateScan.ts
+++ b/LifeOS/install/LifeOS/TOOLS/MigrateScan.ts
@@ -24,7 +24,7 @@ import { join, basename, dirname, extname } from "path";
 import { randomUUID } from "crypto";
 
 const HOME = process.env.HOME || "";
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const QUEUE_FILE = join(LIFEOS_DIR, "MEMORY", "MIGRATION", "migration-proposals.jsonl");
 
 type Target =

--- a/LifeOS/install/LifeOS/TOOLS/MigrateTelosFreshness.ts
+++ b/LifeOS/install/LifeOS/TOOLS/MigrateTelosFreshness.ts
@@ -24,7 +24,7 @@ import { createHash } from "crypto";
 import { join } from "path";
 
 const HOME = process.env.HOME || "";
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const TELOS_PATH = join(LIFEOS_DIR, "USER", "TELOS", "TELOS.md");
 const BACKUP_DIR = join(LIFEOS_DIR, "USER", "TELOS", "Backups");
 

--- a/LifeOS/install/LifeOS/TOOLS/NeofetchBanner.ts
+++ b/LifeOS/install/LifeOS/TOOLS/NeofetchBanner.ts
@@ -362,7 +362,7 @@ function countHooks(): number {
 }
 
 function countWorkItems(): string {
-  const workDir = join(CLAUDE_DIR, "LifeOS", "MEMORY", "WORK");
+  const workDir = join(CLAUDE_DIR, "LIFEOS", "MEMORY", "WORK");
   if (!existsSync(workDir)) return "0";
   let count = 0;
   try {
@@ -374,7 +374,7 @@ function countWorkItems(): string {
 }
 
 function countLearnings(): number {
-  const learningsDir = join(CLAUDE_DIR, "LifeOS", "MEMORY", "LEARNING");
+  const learningsDir = join(CLAUDE_DIR, "LIFEOS", "MEMORY", "LEARNING");
   if (!existsSync(learningsDir)) return 0;
   let count = 0;
   const countRecursive = (dir: string) => {

--- a/LifeOS/install/LifeOS/TOOLS/PaiUpgrade.ts
+++ b/LifeOS/install/LifeOS/TOOLS/PaiUpgrade.ts
@@ -282,7 +282,7 @@ function main(): never {
   const args = parseArgs(process.argv.slice(2));
 
   // Sanity: must be running against a recognizable LifeOS tree.
-  if (!existsSync(join(CLAUDE_ROOT, "LifeOS"))) {
+  if (!existsSync(join(CLAUDE_ROOT, "LIFEOS"))) {
     console.error(`PaiUpgrade: ${CLAUDE_ROOT}/PAI not found — is this a LifeOS install?`);
     process.exit(2);
   }

--- a/LifeOS/install/LifeOS/TOOLS/PangramScore.ts
+++ b/LifeOS/install/LifeOS/TOOLS/PangramScore.ts
@@ -27,7 +27,7 @@ const ENV_PATH = `${process.env.HOME}/.claude/.env`;
 // WritingGate Stop hook reads this so its pass condition is "Pangram ran on
 // this content", not "a token string is present" (Forge audit 2026-07-01).
 const RUNS_PATH = join(
-  process.env.LIFEOS_DIR || `${process.env.HOME}/.claude/LifeOS`,
+  process.env.LIFEOS_DIR || `${process.env.HOME}/.claude/LIFEOS`,
   "MEMORY", "OBSERVABILITY", "pangram-runs.jsonl",
 );
 export function normalizeForHash(text: string): string {

--- a/LifeOS/install/LifeOS/TOOLS/ProposeCurrentStateEntry.ts
+++ b/LifeOS/install/LifeOS/TOOLS/ProposeCurrentStateEntry.ts
@@ -22,7 +22,7 @@ import { join, dirname } from "path";
 import { randomUUID } from "crypto";
 
 const HOME = process.env.HOME || "";
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const QUEUE_FILE = join(LIFEOS_DIR, "USER", "TELOS", "CURRENT_STATE", "proposals.jsonl");
 
 const ALLOWED_SOURCES = ["lifelog", "calendar", "gmail", "homebridge", "manual", "amazon", "bills"];

--- a/LifeOS/install/LifeOS/TOOLS/Recommend.ts
+++ b/LifeOS/install/LifeOS/TOOLS/Recommend.ts
@@ -18,7 +18,7 @@ import { readFileSync, existsSync } from "fs";
 import { join } from "path";
 
 const HOME = process.env.HOME || "";
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const TELOS_DIR = join(LIFEOS_DIR, "USER", "TELOS");
 const CURRENT_DIR = join(TELOS_DIR, "CURRENT_STATE");
 

--- a/LifeOS/install/LifeOS/TOOLS/SessionHarvester.ts
+++ b/LifeOS/install/LifeOS/TOOLS/SessionHarvester.ts
@@ -34,7 +34,7 @@ const CLAUDE_DIR = path.join(process.env.HOME!, ".claude");
 // Linux: ${HOME}/.claude → ${HARNESS_USER_DIR}
 const CWD_SLUG = CLAUDE_DIR.replace(/[\/\.]/g, "-");
 const PROJECTS_DIR = path.join(CLAUDE_DIR, "projects", CWD_SLUG);
-const LEARNING_DIR = path.join(CLAUDE_DIR, "LifeOS", "MEMORY", "LEARNING");
+const LEARNING_DIR = path.join(CLAUDE_DIR, "LIFEOS", "MEMORY", "LEARNING");
 
 // Patterns indicating learning moments in conversations
 const CORRECTION_PATTERNS = [
@@ -392,7 +392,7 @@ function confidenceIcon(c: number): string {
   return "\u{1F534}";                  // red circle
 }
 
-const HARVEST_QUEUE_DIR = path.join(CLAUDE_DIR, "LifeOS", "MEMORY", "KNOWLEDGE", "_harvest-queue");
+const HARVEST_QUEUE_DIR = path.join(CLAUDE_DIR, "LIFEOS", "MEMORY", "KNOWLEDGE", "_harvest-queue");
 
 function writeToQueue(mem: MinedMemory): string {
   if (!fs.existsSync(HARVEST_QUEUE_DIR)) {

--- a/LifeOS/install/LifeOS/TOOLS/TelosFreshness.ts
+++ b/LifeOS/install/LifeOS/TOOLS/TelosFreshness.ts
@@ -26,7 +26,7 @@ import { readFileSync, writeFileSync, existsSync } from "fs";
 import { basename, join } from "path";
 
 const HOME = process.env.HOME || "";
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const TELOS_PATH = join(LIFEOS_DIR, "USER", "TELOS", "TELOS.md");
 const DA_IDENTITY_PATH = join(LIFEOS_DIR, "USER", "DIGITAL_ASSISTANT", "DA_IDENTITY.md");
 const PRINCIPAL_IDENTITY_PATH = join(LIFEOS_DIR, "USER", "PRINCIPAL", "PRINCIPAL_IDENTITY.md");

--- a/LifeOS/install/LifeOS/TOOLS/UpdateModels.ts
+++ b/LifeOS/install/LifeOS/TOOLS/UpdateModels.ts
@@ -98,7 +98,7 @@ export function detectNewModelIds(text: string): string[] {
   return [...seen];
 }
 
-export const MODEL_RELEASES_PATH = join(CLAUDE_DIR, "LifeOS", "MEMORY", "OBSERVABILITY", "model-releases.jsonl");
+export const MODEL_RELEASES_PATH = join(CLAUDE_DIR, "LIFEOS", "MEMORY", "OBSERVABILITY", "model-releases.jsonl");
 
 /**
  * Build the propose-not-auto action commands for detected IDs. Each is a full,

--- a/LifeOS/install/LifeOS/TOOLS/UpdatePaiState.ts
+++ b/LifeOS/install/LifeOS/TOOLS/UpdatePaiState.ts
@@ -30,7 +30,7 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
 import { join, dirname } from "path";
 
 const HOME = process.env.HOME || "";
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const IDEAL_DIR = join(LIFEOS_DIR, "USER", "TELOS", "IDEAL_STATE");
 const CURRENT_DIR = join(LIFEOS_DIR, "USER", "TELOS", "CURRENT_STATE");
 const STATE_FILE = join(LIFEOS_DIR, "USER", "TELOS", "LIFEOS_STATE.json");

--- a/LifeOS/install/LifeOS/TOOLS/WorkSweep.ts
+++ b/LifeOS/install/LifeOS/TOOLS/WorkSweep.ts
@@ -31,7 +31,7 @@ import { loadWorkConfig } from "../../hooks/lib/work-config";
 declare const Bun: { spawn: (cmd: string[], opts?: any) => any };
 
 const HOME = process.env.HOME || "";
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const WORK_DIR = join(LIFEOS_DIR, "MEMORY", "WORK");
 const OBS_DIR = join(LIFEOS_DIR, "MEMORY", "OBSERVABILITY");
 const OBS_LOG = join(OBS_DIR, "worksweep.jsonl");

--- a/LifeOS/install/LifeOS/TOOLS/healthsync/store.ts
+++ b/LifeOS/install/LifeOS/TOOLS/healthsync/store.ts
@@ -11,9 +11,9 @@ import type {
 
 const HOME = process.env.HOME || "";
 const ENV_PATH = join(HOME, ".claude", ".env");
-const STATE_DIR = join(HOME, ".claude", "LifeOS", "MEMORY", "STATE");
-const DATA_DIR = join(HOME, ".claude", "LifeOS", "USER", "HEALTH", "DATA");
-const OBS_DIR = join(HOME, ".claude", "LifeOS", "MEMORY", "OBSERVABILITY");
+const STATE_DIR = join(HOME, ".claude", "LIFEOS", "MEMORY", "STATE");
+const DATA_DIR = join(HOME, ".claude", "LIFEOS", "USER", "HEALTH", "DATA");
+const OBS_DIR = join(HOME, ".claude", "LIFEOS", "MEMORY", "OBSERVABILITY");
 const TOKENS_PATH = join(STATE_DIR, "healthsync-tokens.json");
 const STATE_PATH = join(STATE_DIR, "healthsync-state.json");
 

--- a/LifeOS/install/LifeOS/TOOLS/lifeos.ts
+++ b/LifeOS/install/LifeOS/TOOLS/lifeos.ts
@@ -31,7 +31,7 @@ import { join, basename } from "path";
 const CLAUDE_DIR = join(homedir(), ".claude");
 const MCP_DIR = join(CLAUDE_DIR, "MCPs");
 const ACTIVE_MCP = join(CLAUDE_DIR, ".mcp.json");
-const BANNER_SCRIPT = join(homedir(), ".claude", "LifeOS", "TOOLS", "Banner.ts");
+const BANNER_SCRIPT = join(homedir(), ".claude", "LIFEOS", "TOOLS", "Banner.ts");
 const VOICE_SERVER = "http://localhost:31337/notify/personality";
 const WALLPAPER_DIR = join(homedir(), "Projects", "Wallpaper");
 // Note: RAW archiving removed - Claude Code handles its own cleanup (30-day retention in projects/)
@@ -398,7 +398,7 @@ async function cmdLaunch(options: { mcp?: string; resume?: boolean; skipPerms?: 
 
   // LifeOS System Prompt — constitutional rules appended to Claude Code's system prompt
   // These rules get highest instruction authority (system prompt layer > CLAUDE.md layer)
-  const systemPromptFile = options.systemPrompt ?? join(CLAUDE_DIR, "LifeOS", "LIFEOS_SYSTEM_PROMPT.md");
+  const systemPromptFile = options.systemPrompt ?? join(CLAUDE_DIR, "LIFEOS", "LIFEOS_SYSTEM_PROMPT.md");
   if (existsSync(systemPromptFile)) {
     args.push("--append-system-prompt-file", systemPromptFile);
   }

--- a/LifeOS/install/hooks/DriftReminder.hook.ts
+++ b/LifeOS/install/hooks/DriftReminder.hook.ts
@@ -27,7 +27,7 @@ interface DriftState {
 
 const STDIN_TIMEOUT_MS = 300;
 const MIN_TURNS_BETWEEN_FIRES = 5;
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(process.env.HOME || "", ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || join(process.env.HOME || "", ".claude", "LIFEOS");
 const LAST_RESPONSE_PATH = join(LIFEOS_DIR, "MEMORY", "STATE", "last-response.txt");
 const STATE_PATH = join(LIFEOS_DIR, "MEMORY", "STATE", "drift-reminder.json");
 const INITIAL_STATE: DriftState = {

--- a/LifeOS/install/hooks/ReminderRouter.hook.ts
+++ b/LifeOS/install/hooks/ReminderRouter.hook.ts
@@ -24,7 +24,7 @@ import { join, dirname } from "path";
 import { loadWorkConfig } from "./lib/work-config";
 
 const HOME = process.env.HOME || "";
-const STATE_PATH = join(HOME, ".claude", "LifeOS", "MEMORY", "STATE", "reminder-router-seen.json");
+const STATE_PATH = join(HOME, ".claude", "LIFEOS", "MEMORY", "STATE", "reminder-router-seen.json");
 
 interface HookInput {
   session_id?: string;

--- a/LifeOS/install/hooks/Safety.hook.ts
+++ b/LifeOS/install/hooks/Safety.hook.ts
@@ -58,7 +58,7 @@ const LIFEOS_DIR = process.env.LIFEOS_DIR
       /^\$\{?HOME\}?(?=\/|$)/,
       HOME,
     )
-  : join(HOME, ".claude", "LifeOS");
+  : join(HOME, ".claude", "LIFEOS");
 const STATE_DIR = join(LIFEOS_DIR, "MEMORY", "STATE");
 const OBS_DIR = join(LIFEOS_DIR, "MEMORY", "OBSERVABILITY");
 const CACHE_PATH = join(STATE_DIR, "permission-cache.json");

--- a/LifeOS/install/hooks/SkillSurface.hook.ts
+++ b/LifeOS/install/hooks/SkillSurface.hook.ts
@@ -44,7 +44,7 @@ interface ScoredSkill {
 const STDIN_TIMEOUT_MS = 300;
 const MAX_SKILLS_TO_EMIT = 3;
 const MIN_DISTINCT_TRIGGER_TOKEN_HITS = 2;
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(process.env.HOME || "", ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || join(process.env.HOME || "", ".claude", "LIFEOS");
 const SKILLS_DIR = join(process.env.HOME || "", ".claude", "skills");
 const CACHE_PATH = join(LIFEOS_DIR, "MEMORY", "STATE", "skill-index.json");
 

--- a/LifeOS/install/hooks/SuccessClaimGate.hook.ts
+++ b/LifeOS/install/hooks/SuccessClaimGate.hook.ts
@@ -40,7 +40,7 @@ import { appendFileSync, mkdirSync } from "fs";
 import { dirname, join } from "path";
 
 const OBS_PATH = join(
-  process.env.LIFEOS_DIR || join(process.env.HOME!, ".claude", "LifeOS"),
+  process.env.LIFEOS_DIR || join(process.env.HOME!, ".claude", "LIFEOS"),
   "MEMORY",
   "OBSERVABILITY",
   "success-claim-gate.jsonl",

--- a/LifeOS/install/hooks/WritingGate.hook.ts
+++ b/LifeOS/install/hooks/WritingGate.hook.ts
@@ -30,7 +30,7 @@ import { appendFileSync, mkdirSync, existsSync, readFileSync } from "fs";
 import { createHash } from "crypto";
 import { dirname, join } from "path";
 
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(process.env.HOME!, ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || join(process.env.HOME!, ".claude", "LIFEOS");
 const OBS_PATH = join(LIFEOS_DIR, "MEMORY", "OBSERVABILITY", "writing-gate.jsonl");
 const RUNS_PATH = join(LIFEOS_DIR, "MEMORY", "OBSERVABILITY", "pangram-runs.jsonl");
 const RUN_WINDOW_MS = 30 * 60 * 1000; // a run counts as "this turn" within 30 min

--- a/LifeOS/install/hooks/lib/work-config.ts
+++ b/LifeOS/install/hooks/lib/work-config.ts
@@ -30,7 +30,7 @@ import { join } from "path";
 declare const Bun: { spawnSync: (cmd: string[], opts?: any) => any };
 
 const HOME = process.env.HOME || "";
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const REPO_JSON_PATH = join(LIFEOS_DIR, "USER", "WORK", "work_repo.json");
 const COLUMNS_YAML_PATH = join(LIFEOS_DIR, "USER", "WORK", "config.yaml");
 

--- a/LifeOS/install/skills/Daemon/Tools/DaemonAggregator.ts
+++ b/LifeOS/install/skills/Daemon/Tools/DaemonAggregator.ts
@@ -22,7 +22,7 @@ import { filterContent, filterDaemonData, loadSecurityOverrides } from "./Securi
 // ─── Path Resolution ───
 
 const HOME = process.env.HOME || process.env.USERPROFILE || "";
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LifeOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const USER_DIR = join(LIFEOS_DIR, "USER");
 const MEMORY_DIR = join(LIFEOS_DIR, "MEMORY");
 const TELOS_DIR = join(USER_DIR, "TELOS");

--- a/LifeOS/install/skills/LocalIntelligence/Tools/Refresh.ts
+++ b/LifeOS/install/skills/LocalIntelligence/Tools/Refresh.ts
@@ -22,7 +22,7 @@ import { fetchArrests } from "./FetchArrests.ts"
 import { fetchNews } from "./FetchNews.ts"
 import { fetchCrime } from "./FetchCrime.ts"
 
-const DATA_DIR = join(homedir(), ".claude", "LifeOS", "MEMORY", "DATA", "LocalIntelligence")
+const DATA_DIR = join(homedir(), ".claude", "LIFEOS", "MEMORY", "DATA", "LocalIntelligence")
 
 const fetchers: Record<SectionKey, Fetcher> = {
   construction: fetchConstruction,


### PR DESCRIPTION
## Context (friendly heads-up: people are already deploying v6 on Linux!)

First — congrats on the 6.0.0 "one skill, one install" release. I picked it up within hours of the tag and installed it on **Linux** (Ubuntu), and it mostly came up beautifully. This PR reports one silent failure I hit during that deploy, with a fix. Sharing it partly because it's the kind of thing that only surfaces off-macOS, and you probably want to know early.

## The bug: `LifeOS` vs `LIFEOS` — a case-sensitivity silent failure on Linux

The runtime is deployed to the **all-caps** `<configRoot>/LIFEOS/` — `DeployCore` does this deliberately (its own comment: *"Targets the config-root runtime at the ALL-CAPS `<configRoot>/LIFEOS/` so it matches the `@LIFEOS/...` imports in CLAUDE.md"*), and `CLAUDE.template.md` imports `@LIFEOS/...`.

But **many runtime tools and hooks resolve the root as mixed-case** `~/.claude/LifeOS` — e.g. `const LIFEOS_DIR = join(HOME, ".claude", "LifeOS")`.

- On **macOS** (case-insensitive FS by default) `LifeOS` and `LIFEOS` are the same inode → everything works, invisible.
- On **Linux** (case-sensitive) they're different paths → the tools read a directory that doesn't exist and **silently return empty**.

### Repro (Linux)
```
$ bun ~/.claude/LIFEOS/TOOLS/MemoryStatus.ts
Corpus:
  knowledge   no dir yet        # ← but KNOWLEDGE/ exists at LIFEOS/MEMORY/KNOWLEDGE
```
It's looking at `~/.claude/LifeOS/MEMORY/KNOWLEDGE` (nonexistent on Linux) instead of `~/.claude/LIFEOS/MEMORY/KNOWLEDGE`. No error is thrown — the corpus just appears empty, which is the dangerous part. After normalizing the path casing, `MemoryStatus` correctly reports the corpus.

## The fix

Normalize the **runtime-root** path segment `"LifeOS"` → `"LIFEOS"` (the canonical `DeployCore`/`CLAUDE.md` already use) across the install-payload tools and hooks — **119 references across 91 files**.

- **No-op on macOS** (case-insensitive), a **fix on Linux** — strictly safe cross-platform.
- **Scoped carefully:** only touches runtime-root references (`.claude/LifeOS`, `CLAUDE_ROOT/"LifeOS"`, etc.). The legitimately mixed-case **`skills/LifeOS`** and **`install/LifeOS`** source-directory references are deliberately left untouched (verified).

## Notes / happy to adjust

- This is the minimal, mechanical normalization. Longer term a single shared root resolver (e.g. one `lifeosDir()` helper the tools import, instead of each re-deriving the path) would prevent the casing from drifting again — glad to follow up with that if you'd prefer it over the flat normalization.
- `PLATFORM.md` lists Linux as "Fully Supported," so this seemed worth fixing rather than working around locally (a `~/.claude/LifeOS → LIFEOS` symlink also masks it, but that's a band-aid).

Thanks for building and open-sourcing this — genuinely a pleasure to deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
