### PR TITLE
fix(TOOLS): declare graphology deps for MemoryGraph.ts

### DIFF
--- a/LifeOS/install/LifeOS/TOOLS/package.json
+++ b/LifeOS/install/LifeOS/TOOLS/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "lifeos-tools",
+  "private": true,
+  "type": "module",
+  "description": "Runtime deps for LIFEOS/TOOLS/*.ts scripts at this parent level (currently MemoryGraph.ts). Uses parent-directory scope deliberately, rather than a per-tool subdir, because moving MemoryGraph.ts into TOOLS/MemoryGraph/ breaks every existing consumer path (Pulse Observability's /api/memory/graph route, install engine references, sibling tooling). Nested tool subdirs (llcli/, TokenXray/) get their own package.json for isolation; scripts at TOOLS/ root inherit deps from here.",
+  "dependencies": {
+    "graphology": "^0.26.0",
+    "graphology-communities-louvain": "^2.0.2",
+    "graphology-metrics": "^2.4.0"
+  }
+}


### PR DESCRIPTION
## Bug

`LifeOS/install/LifeOS/TOOLS/MemoryGraph.ts` imports three npm packages that are not declared in any `package.json` in the repo:

```typescript
import Graph from "graphology";
import louvain from "graphology-communities-louvain";
import pagerank from "graphology-metrics/centrality/pagerank";
```

`find LifeOS/install -name package.json | xargs grep -l graphology` returns nothing. Fresh installers hit `Cannot find module 'graphology'` the first time they invoke `bun ~/.claude/LIFEOS/TOOLS/MemoryGraph.ts build`, which silently breaks Pulse's `/api/memory/graph` route (returns empty `graph.json` with the "run: bun LIFEOS/TOOLS/MemoryGraph.ts build --all" hint that then also fails).

## Fix

Adds `LifeOS/install/LifeOS/TOOLS/package.json` declaring the 3 direct deps with `^` caret ranges (matching the house style used by sibling manifests like `TOOLS/TokenXray/package.json` and `PULSE/Observability/package.json`).

Uses parent-directory scope deliberately, rather than moving `MemoryGraph.ts` into a `TOOLS/MemoryGraph/` subdir to match the exact sibling pattern of `TOOLS/llcli/` and `TOOLS/TokenXray/`. Moving the file would break every existing consumer path:

- `LifeOS/install/LifeOS/PULSE/Observability/observability.ts` → `handleMemoryGraphApi()` reads `MEMORY/GRAPH/graph.json` built by this exact path
- `PULSE/modules/user-index.ts` references
- `LIFEOS_INSTALL/engine/detect.ts` + `actions.ts` install-time refs

Deliberate deviation is documented in the manifest's `description` field.

## Reproducer

```bash
curl -fsSL https://ourlifeos.ai/install.sh | bash
bun ~/.claude/LIFEOS/TOOLS/MemoryGraph.ts build
# error: Cannot find module 'graphology'
```

After this PR, adds `bun install` in `LIFEOS/TOOLS/` (or bun resolves via the parent walk) and the build succeeds.

## Verify

`cd LifeOS/install/LifeOS/TOOLS && bun install && bun MemoryGraph.ts build` succeeds.
