### PR TITLE
fix(MemoryGraph): first-wins on duplicate KNOWLEDGE slugs (drop UsageGraphError crash)

### DIFF
--- a/LifeOS/install/LifeOS/TOOLS/MemoryGraph.ts
+++ b/LifeOS/install/LifeOS/TOOLS/MemoryGraph.ts
@@ -284,8 +284,19 @@ function buildGraph(raws: Raw[], layer: EdgeLayer = "declared"): { graph: Graph;
 
   // bare-slug -> id resolver (knowledge slug is bare; work id is "work:slug")
   const bareToId = new Map<string, string>();
+  // Track winner's source path so we can warn on collision (report-generator
+  // tool, not a scriptable pipe — silent drop hides data loss from users).
+  const idToPath = new Map<string, string>();
   for (const { node } of raws) {
+    if (graph.hasNode(node.id)) {
+      // First-wins on duplicate ids (e.g. Companies/synthesis.md and
+      // Research/synthesis.md both derive slug "synthesis"). Matches the
+      // bareToId first-wins semantics below.
+      console.warn(`[MemoryGraph] slug collision: kept ${idToPath.get(node.id)}, skipped ${node.path}`);
+      continue;
+    }
     graph.addNode(node.id, { ...node });
+    idToPath.set(node.id, node.path);
     const bare = node.id.startsWith("work:") ? node.id.slice(5) : node.id;
     if (!bareToId.has(bare)) bareToId.set(bare, node.id);
   }


### PR DESCRIPTION
## Bug

`buildGraph` at `LifeOS/install/LifeOS/TOOLS/MemoryGraph.ts:288` iterates KNOWLEDGE domains (People/Companies/Ideas/Research) and derives node IDs from bare filenames:

```typescript
const slug = entry.replace(/\.md$/, "");
raws.push({ node: { id: slug, silo: "knowledge", ... } });
```

No domain prefix, so any two files sharing a basename across domains produce identical IDs. The second `graph.addNode(node.id, ...)` throws:

```
UsageGraphError: Graph.addNode: the "synthesis" node already exist in the graph.
    at addNode (…/graphology.mjs:3708:11)
    at buildGraph (…/MemoryGraph.ts:288:11)
```

The crash blocks the whole build. `graph.json` never regenerates, `PATTERNS.md` stays stale, Pulse's `/api/memory/graph` route silently serves nothing.

## Fix

Guards `graph.addNode` with `hasNode`, matching the existing first-wins semantics of the `bareToId` population two lines below (`if (!bareToId.has(bare)) bareToId.set(...)`).

Emits `console.warn` listing the kept-path and skipped-path so users notice the data loss. `MemoryGraph.ts` is a report-generator tool with multi-line human output, not a scriptable pipe; a silent drop would hide files the user wrote.

## Reproducer

```bash
mkdir -p ~/.claude/LIFEOS/MEMORY/KNOWLEDGE/{Companies,Research}
printf '%s\n' '---' 'title: A' '---' 'body' > ~/.claude/LIFEOS/MEMORY/KNOWLEDGE/Companies/foo.md
printf '%s\n' '---' 'title: B' '---' 'body' > ~/.claude/LIFEOS/MEMORY/KNOWLEDGE/Research/foo.md
bun ~/.claude/LIFEOS/TOOLS/MemoryGraph.ts build
# crashes without this fix
# With this fix: builds cleanly, prints:
# [MemoryGraph] slug collision: kept .../Companies/foo.md, skipped .../Research/foo.md
```

## Orthogonal issues noticed (out of scope — worth separate PRs)

- KNOWLEDGE-first ordering in `ingest()` means WORK ISAs lose bare-slug wikilink resolution when a KNOWLEDGE file shares the basename
- `patterns` command rebuilds only on 60-min cache age, never checks source file mtimes — edit a note, get stale patterns silently
- `addEdge` widens weight on collision but never upgrades `kind` (a later `related` edge over an earlier `tag` keeps kind `tag` — provenance loss)

## Verify

Reproducer above passes with this diff applied. Existing populated KNOWLEDGE trees without collisions are unchanged (the guard is a no-op path).
