### PR TITLE
fix(hooks): SuccessClaimGate no longer misclassifies shell/CLI liveness as UI liveness

### DIFF
--- a/LifeOS/install/hooks/SuccessClaimGate.hook.ts
+++ b/LifeOS/install/hooks/SuccessClaimGate.hook.ts
@@ -64,6 +64,7 @@ const CLAIM_PATTERNS: RegExp[] = [
 const NARRATION_GUARDS: RegExp[] = [
   /\b(shipped|deployed|landed|verified|finished|pushed|merged|complete[d]?)\s+(in|back\s+in|since|during|by)\s+(19|20)\d\d\b/gim, // past-dated narration
   /"[^"]*\b(shipped|deployed|landed|verified|finished|pushed|merged|complete[d]?)\b[^"]*"/gim, // quoted/attributed
+  /"[^"]*\b((is|it'?s|site'?s|page'?s|now)\s+live|went\s+live|locked\s+down|works\s+(now|in\s+the\s+browser|end[\s-]?to[\s-]?end))\b[^"]*"/gim, // quoted WEB-UI vocab — mention, not assertion
   /(thesis|essay|framing|claim|story|version|post|repo|project)\s+\w*\s*(I|we)\s+(shipped|deployed|landed|finished|pushed|merged)/gim, // narrating a named past artifact
   // Backward-reference to a PRIOR turn ("deployed ... earlier", "already live-verified",
   // "prod rollout was done in the prior turns") is narration about already-finished,
@@ -114,6 +115,8 @@ function appendObs(record: SuccessGateRecord): void {
 // for this-turn done-claims, so the gate only fires on real assertions.
 function stripNarration(message: string): string {
   let out = message;
+  out = out.replace(/```[\s\S]*?```/g, " "); // fenced code block — mention, not assertion
+  out = out.replace(/`[^`\n]+`/g, " ");       // inline code — mention, not assertion
   for (const guard of NARRATION_GUARDS) out = out.replace(guard, " ");
   return out;
 }
@@ -171,7 +174,7 @@ const HONEST_DOWNGRADE =
 function isUnverifiedWebUiClaim(message: string): boolean {
   const s = stripNarration(message);
   const assertsLive = LIVE_UI_CLAIM.test(s) || DEPLOY_CLAIM.test(s) || /\b(it\s+works|works\s+now)\b/i.test(s);
-  const isUi = WEB_UI_NOUN.test(s) || RENDER_VERB.test(s) || LIVE_UI_CLAIM.test(s);
+  const isUi = WEB_UI_NOUN.test(s) || RENDER_VERB.test(s);
   if (!(assertsLive && isUi)) return false;
   if (INTERCEPTOR_EVIDENCE.test(message)) return false; // verified the right way
   if (HONEST_DOWNGRADE.test(message)) return false; // honestly deferred


### PR DESCRIPTION
## Problem

`hooks/SuccessClaimGate.hook.ts` fires its `WEB-UI VERIFICATION GAP` block-back on any Stop-chain response that says a shell hook, CLI tool, or backend subsystem `is now live` / `works end-to-end` — even when no browser surface is claimed. The gate correctly closes the incident it was built for (curl-only "admin page is live and locked down"), but the classifier collapses two orthogonal notions (liveness vs. UI-ness) and over-triggers.

**Reproduction** — this trips the gate with no page, no UI, no HTTP surface:

> Memory subsystem now live end-to-end. Both hooks wired via symlink.

Recursive dimension: a message *reporting* this bug — where the trigger vocabulary has to be quoted for reference — trips the same gate. The quoted-attribution guard in `stripNarration` covers `CLAIM_PATTERNS` vocab (`shipped|deployed|landed|…`) but not `LIVE_UI_CLAIM` vocab (`is live`, `locked down`, `works end-to-end`), and code-delimited mentions (backticks — the standard example-quoting convention) aren't stripped at all.

## Root cause & fix (3 changes, +4/-1)

**1. `isUi` OR-branch collapse.** `LIVE_UI_CLAIM` proves *liveness*, not *UI-ness*, but it was an OR-branch of `isUi`, so every liveness claim self-classified as a UI claim regardless of noun:

~~~diff
- const isUi = WEB_UI_NOUN.test(s) || RENDER_VERB.test(s) || LIVE_UI_CLAIM.test(s);
+ const isUi = WEB_UI_NOUN.test(s) || RENDER_VERB.test(s);
~~~

Real UI signal comes from `WEB_UI_NOUN` (page/site/admin/dashboard/UI/…) or `RENDER_VERB` (renders/loads/in the browser/…). `LIVE_UI_CLAIM` stays in `assertsLive` where it belongs — the gate still requires `assertsLive && isUi`, so a genuine UI claim (which always names a UI noun or a render verb) still blocks.

**2. Mentions vs. assertions.** Quoted or code-delimited trigger vocabulary is a *mention*, not an assertion. Strip markdown code delimiters before pattern-testing, and extend the quoted guard to cover WEB-UI vocab:

~~~diff
 function stripNarration(message: string): string {
   let out = message;
+  out = out.replace(/```[\s\S]*?```/g, " "); // fenced code block — mention, not assertion
+  out = out.replace(/`[^`\n]+`/g, " ");       // inline code — mention, not assertion
   for (const guard of NARRATION_GUARDS) out = out.replace(guard, " ");
~~~

~~~diff
   /"[^"]*\b(shipped|deployed|landed|verified|finished|pushed|merged|complete[d]?)\b[^"]*"/gim, // quoted/attributed
+  /"[^"]*\b((is|it'?s|site'?s|page'?s|now)\s+live|went\s+live|locked\s+down|works\s+(now|in\s+the\s+browser|end[\s-]?to[\s-]?end))\b[^"]*"/gim, // quoted WEB-UI vocab — mention, not assertion
~~~

The new guard reuses the exact shape of the existing accepted quoted-attribution guard (`"[^"]*…[^"]*"`), so it carries no new backtracking risk.

## Regression coverage

| Case | Message | Before | After |
|------|---------|--------|-------|
| A | `Memory subsystem now live end-to-end. Both hooks wired via symlink.` | block | **pass** (false positive fixed) |
| B | bug report quoting `now live` / `locked down` in backticks | block | **pass** (false positive fixed) |
| C | `The admin page is live and locked down.` | block | **block** (2026 incident coverage preserved — `admin`/`page` match `WEB_UI_NOUN`) |
| D | `The dashboard renders correctly and is now live.` | block | **block** (`dashboard` matches `WEB_UI_NOUN`) |

No new deps, no settings changes — purely a classifier tightening. The repo ships no hook test harness, so there is no test file to update; the four cases above are the manual verification (also confirmed against a deployed copy on WSL2/Bun).

Reproduced against `v6.0.0`; the affected lines are unchanged on `main` (`v6.0.3`).
