### PR TITLE
fix(settings): expand $HOME/${HOME}/~ in env values during settings m…

### DIFF
--- a/LifeOS/install/LIFEOS/TOOLS/MergeSettings.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/MergeSettings.ts
@@ -12,6 +12,7 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import path from "node:path";
+import os from "node:os";
 
 type CliMode =
   | { kind: "output"; path: string }
@@ -116,6 +117,50 @@ export function mergeSettings(system: any, user: any): any {
   }
 
   return cloneJsonValue(user);
+}
+
+/**
+ * Expands a home-directory reference in a single env value string. The Claude
+ * Code harness shell-expands `$HOME` in hook `command` fields (they run through
+ * a shell) but injects `env` values VERBATIM — so a template that ships
+ * `"LIFEOS_DIR": "$HOME/.claude/LIFEOS"` reaches process.env unexpanded, and any
+ * tool that writes to it gets a NON-absolute path that resolves against cwd,
+ * littering the working directory (observed: a literal `$HOME/` dir in project
+ * roots). We expand here so the template stays portable (`$HOME`, not a
+ * hardcoded home) while the generated settings.json carries absolute paths.
+ * Handles a leading `~`/`~/`, `${HOME}`, and bare `$HOME` (token-bounded so
+ * `$HOMER` is left alone).
+ */
+export function expandHomeReference(value: string, home: string): string {
+  let out = value;
+  if (out === "~") {
+    out = home;
+  } else if (out.startsWith("~/")) {
+    out = home + out.slice(1);
+  }
+  return out
+    .replace(/\$\{HOME\}/g, home)
+    .replace(/\$HOME(?![A-Za-z0-9_])/g, home);
+}
+
+/**
+ * Expands home-directory references in `settings.env` string values, in place.
+ * Scoped to `env` only: `command` fields must keep `$HOME` literal so the
+ * harness's own shell expansion keeps them portable across installs. Runs AFTER
+ * the merge, so a user override (which wins and is typically already absolute)
+ * is seen as-is and left untouched; only remaining `$HOME`-style system
+ * defaults expand.
+ */
+export function expandEnvHomeReferences(settings: any, home: string = os.homedir()): any {
+  if (isObjectRecord(settings) && isObjectRecord(settings.env)) {
+    for (const key of Object.keys(settings.env)) {
+      const value = settings.env[key];
+      if (typeof value === "string") {
+        settings.env[key] = expandHomeReference(value, home);
+      }
+    }
+  }
+  return settings;
 }
 
 /**
@@ -473,6 +518,7 @@ async function runCli(argv: string[]): Promise<number> {
     const system = await parseJsonFileOrThrow(options.systemPath);
     const user = await parseJsonFileOrThrow(options.userPath);
     const merged = mergeSettings(system, user);
+    expandEnvHomeReferences(merged);
 
     const dropped = prunePermissionRules(merged);
     if (dropped.length > 0) {


### PR DESCRIPTION
  ## Problem

  `settings.system.json` ships env values that use a literal `$HOME`, e.g.:

      "env": {
        "LIFEOS_DIR": "$HOME/.claude/LIFEOS",
        "LIFEOS_CONFIG_DIR": "$HOME/.claude/LIFEOS",
        "PROJECTS_DIR": "$HOME/Projects"
      }

  The Claude Code harness shell-expands `$HOME` in hook **`command`** fields (they run through a shell), but injects **`env`** values **verbatim**. So `process.env.LIFEOS_DIR`
  ends up as the literal string `"$HOME/.claude/LIFEOS"` — a **non-absolute** path.

  Any tool/hook that resolves a path from that env var and writes to it (memory state, observability gates, freshness cache, learning captures) then writes to a path that
  resolves **against the current working directory**. In practice this creates a stray directory literally named `$HOME/` inside whatever project the session is running in:

      <project>/$HOME/.claude/LIFEOS/MEMORY/...
      <project>/$HOME/.claude/LIFEOS/USER/CACHE/freshness.json

  — silently littering user project roots, and (worse) redirecting memory/learning writes away from the real `~/.claude` tree.

  ## Root cause

  The merge stage (`MergeSettings.ts`) copies env values through untouched, and the harness never expands `$HOME` in env. Hardcoding an absolute path into `settings.system.json`
  is **not** an option — the template intentionally uses `$HOME` everywhere (including all `command` fields) so it stays portable across installs and home directories.

  ## Fix

  Expand home references in **`settings.env`** values at merge time, keeping the template portable:                                                                   
  
  - New `expandHomeReference(value, home)` — resolves a leading `~`/`~/`, `${HOME}`, and bare `$HOME` (token-bounded, so `$HOMER` is left alone). Non-path values (e.g.
  `http://localhost:...`) are untouched.
  - New `expandEnvHomeReferences(settings, home = os.homedir())` — walks `settings.env` string values in place.
  - Wired into `runCli` **after** the merge, so a user override (which wins and is typically already absolute) is seen as-is; only remaining `$HOME`-style system defaults expand.

  Scoped to `env` only — `command` fields keep `$HOME` literal so the harness's own shell expansion continues to make them portable. Pure addition (no lines removed). Idempotent:
  values that are already absolute pass through unchanged.

  ## Verification

      expandHomeReference("~/x",        "/H") -> "/H/x"
      expandHomeReference("$HOME/a",    "/H") -> "/H/a"
      expandHomeReference("${HOME}/b",  "/H") -> "/H/b"
      expandHomeReference("$HOMER",     "/H") -> "$HOMER"        # token-bounded, untouched
      expandHomeReference("http://x",   "/H") -> "http://x"      # non-path, untouched

  Merging `settings.system.json` with an **empty** user overlay (no override) now yields absolute `LIFEOS_DIR` / `LIFEOS_CONFIG_DIR` / `PROJECTS_DIR` with no literal `$HOME`
  remaining. The existing `--check` invariant (`merge(system, user) === settings.json`) holds after regeneration.
