### PR TITLE
fix(pulse/telegram): correct canUseTool return schema to match SDK's expected shape

### DIFF
--- a/LifeOS/install/LIFEOS/PULSE/modules/telegram.ts
+++ b/LifeOS/install/LIFEOS/PULSE/modules/telegram.ts
@@ -847,10 +847,10 @@ export async function startTelegram(config: TelegramConfig): Promise<void> {
               : String(input)
             if (cmd.includes("31337") || cmd.includes("/notify")) {
               log("warn", "canUseTool blocked /notify curl from SDK subprocess", { cmd: cmd.slice(0, 200) })
-              return { result: "deny", reason: "Telegram mode: /notify and port 31337 are blocked. Voice is delivered via Telegram sendVoice, not the desktop speaker." }
+              return { behavior: "deny", message: "Telegram mode: /notify and port 31337 are blocked. Voice is delivered via Telegram sendVoice, not the desktop speaker." }
             }
           }
-          return { result: "allow" }
+          return { behavior: "allow", updatedInput: (input as Record<string, unknown>) ?? {} }
         },
         systemPrompt: {
           type: "preset",


### PR DESCRIPTION
The canUseTool permission callback in PULSE/modules/telegram.ts returned
{ result: "allow" | "deny", reason } instead of the shape the installed
@anthropic-ai/claude-agent-sdk validates against:
{ behavior: "allow", updatedInput } | { behavior: "deny", message }.

Since neither variant of the return value matched the SDK's Zod union,
every tool-permission check threw — allow and deny alike — blocking all
Read/Write/Bash calls from the Telegram bot. Conversational replies with
no tool use were unaffected, which made this easy to miss.

Fixes #1433.