### PR TITLE
Fix: DeployComponents leaves __BUN_PATH__ unsubstituted in the pulse launchd plist (EX_CONFIG)

### DIFF
--- a/LifeOS/Tools/DeployComponents.ts
+++ b/LifeOS/Tools/DeployComponents.ts
@@ -156,7 +156,9 @@ function deployPulse(ctx: Ctx): ComponentResult {
     ensurePresent("PULSE", ctx);
     const plistSrc = join(pulseDir, "com.lifeos.pulse.plist");
     if (!existsSync(plistSrc)) throw new Error(`plist template missing at ${plistSrc}`);
-    const materialized = readFileSync(plistSrc, "utf-8").replaceAll("__HOME__", ctx.home);
+    const materialized = readFileSync(plistSrc, "utf-8")
+      .replaceAll("__HOME__", ctx.home)
+      .replaceAll("__BUN_PATH__", process.execPath);
     const u = uid();
     const sameOnDisk = existsSync(plistDst) && readFileSync(plistDst, "utf-8") === materialized;
     const alreadyLoaded = launchctl(["print", `gui/${u}/com.lifeos.pulse`]).ok;


### PR DESCRIPTION
## Problem

The `pulse` component in `DeployComponents.ts` materializes the launchd plist from the template `com.lifeos.pulse.plist`, which contains two placeholders — `__HOME__` and `__BUN_PATH__`. But materialization substitutes only `__HOME__`:

```ts
const materialized = readFileSync(plistSrc, "utf-8").replaceAll("__HOME__", ctx.home);
```

`__BUN_PATH__` is left literal, so the written plist is:

```xml
<key>ProgramArguments</key>
<array>
    <string>__BUN_PATH__</string>
    <string>run</string>
    <string>pulse.ts</string>
</array>
```

launchd can't exec a program literally named `__BUN_PATH__`, so the service fails to start and `launchctl print gui/<uid>/com.lifeos.pulse` reports `last exit code = 78 (EX_CONFIG)`. `bun Tools/DeployComponents.ts --apply --components pulse` returns `applied: true` but the healthz probe returns `000` — the daemon never runs under launchd, even though it runs fine when invoked directly (`bun run pulse.ts`).

## Fix

Also substitute `__BUN_PATH__`, using the bun binary running the deploy (`process.execPath`):

```ts
const materialized = readFileSync(plistSrc, "utf-8")
  .replaceAll("__HOME__", ctx.home)
  .replaceAll("__BUN_PATH__", process.execPath);
```

## Verification

- **Before:** managed service exits `EX_CONFIG`; `healthz → 000`; dashboard unreachable.
- **After** (plist with the substitution): `launchctl print` shows `state = running`, `last exit code = (never exited)`; `healthz → 200`; dashboard `200`. Same daemon, now execs correctly under launchd.

Single line, single file. (The dry-run action message near L151 also only names `__HOME__`; happy to update it to mention `__BUN_PATH__` for accuracy if desired.)
