### PR TITLE
Inference.ts: scrub ANTHROPIC_BASE_URL alongside API key/token in nested claude spawn

### DIFF
--- a/LifeOS/install/LIFEOS/TOOLS/Inference.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/Inference.ts
@@ -162,6 +162,12 @@ async function inferenceAttempt(options: InferenceOptions, modelOverride?: strin
     // either path leaks subscription work onto API-key billing. Scrub both.
     delete env.ANTHROPIC_API_KEY;
     delete env.ANTHROPIC_AUTH_TOKEN;
+    // Also scrub ANTHROPIC_BASE_URL: if it points at a local proxy (e.g. a
+    // LiteLLM gateway used for cost tracking/observability), the child process
+    // would still target that proxy after losing its credentials above,
+    // causing every nested call to fail auth (401) and retry until timeout.
+    // Force nested subscription calls straight to Anthropic's real API.
+    delete env.ANTHROPIC_BASE_URL;
 
     const hasImages = options.imagePaths && options.imagePaths.length > 0;
     const args = [


### PR DESCRIPTION
Fixes #1440.

## Bug

`Inference.ts`'s nested `claude --print` subprocess spawn deletes `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` from the child environment to force subscription billing (per the existing comment on that block), but never cleared `ANTHROPIC_BASE_URL`.

If a user has `ANTHROPIC_BASE_URL` set to a local proxy (e.g. a LiteLLM gateway used for cost tracking/observability — a documented pattern), every nested `inference()` call — including the mode/tier classifier `PromptProcessing.hook.ts` invokes on every prompt, and the Advisor calls in the Algorithm's VERIFY phase — kept targeting that proxy, but now with zero valid Anthropic credentials in env (both keys just stripped). The proxy correctly rejects with `401 Unauthorized`, the subprocess retries, and the call burns its full timeout before giving up.

**Observed impact**: with `ANTHROPIC_BASE_URL` set, the mode classifier failed on *every single message* (`Timeout after 25000ms`), forcing the fail-safe path (`SOURCE: fail-safe`, default tier) instead of real classification — plus a steady stream of 401s in the proxy's logs from the retries.

## Fix

One-line addition scrubbing `ANTHROPIC_BASE_URL` alongside the existing two deletes, so nested subscription-billed calls always go straight to Anthropic's real API regardless of what the parent shell has configured for interactive proxy routing.

## Testing

Verified against a live setup with `ANTHROPIC_BASE_URL` pointed at a local LiteLLM proxy: before the fix, every classifier invocation timed out with repeated 401s in the proxy logs; the fix routes nested calls around the proxy as intended.