### PR TITLE
fix(memory): self-heal missing entry markers so hot-layer memory persists

### DIFF
--- a/LifeOS/install/LIFEOS/TOOLS/MemoryWriter.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/MemoryWriter.ts
@@ -222,13 +222,26 @@ function parseFile(content: string): ParsedFile {
   const endIdx = afterFm.indexOf(END_MARKER);
 
   if (beginIdx === -1 || endIdx === -1 || endIdx < beginIdx) {
-    // Markers missing or malformed — treat as empty entries with the whole
-    // body as preEntries; this preserves principal content if they edited.
+    // Self-heal: markers missing or malformed (e.g. a template that shipped
+    // without a BEGIN marker, or a file where prior writes appended stray END
+    // markers). Recover every well-formed entry line, drop ALL stray markers,
+    // preserve the intro text before the first entry, and rebuild a single
+    // clean BEGIN/END scaffold. Without this, each write compounded corruption.
+    const recovered: string[] = [];
+    const introLines: string[] = [];
+    let sawEntry = false;
+    for (const line of afterFm.split("\n")) {
+      const t = line.trim();
+      if (t === BEGIN_MARKER || t === END_MARKER) continue;
+      if (PREFIX_PATTERN.test(t)) { recovered.push(t); sawEntry = true; continue; }
+      if (!sawEntry) introLines.push(line);
+    }
+    const intro = introLines.join("\n").replace(/\n+$/, "");
     return {
       frontmatter,
-      preEntriesBody: afterFm,
-      entries: [],
-      postEntriesBody: "",
+      preEntriesBody: (intro ? intro + "\n" : "") + BEGIN_MARKER,
+      entries: recovered,
+      postEntriesBody: END_MARKER,
     };
   }
 

--- a/LifeOS/install/USER/DIGITAL_ASSISTANT/DA_MEMORY.md
+++ b/LifeOS/install/USER/DIGITAL_ASSISTANT/DA_MEMORY.md
@@ -12,3 +12,5 @@ convention: pai-freshness-v1
 > 🎯 SAMPLE TEMPLATE — auto-curated hot-layer memory your DA keeps about how it works with you. Starts empty; the memory reviewer populates it over time. Nothing to fill in manually. Pulse's memory panel reads this file.
 
 <!-- Entries are appended automatically by the memory curation loop. Empty on a fresh install — this is expected. -->
+<!-- BEGIN ENTRIES -->
+<!-- END ENTRIES -->

--- a/LifeOS/install/USER/PRINCIPAL/PRINCIPAL_MEMORY.md
+++ b/LifeOS/install/USER/PRINCIPAL/PRINCIPAL_MEMORY.md
@@ -12,3 +12,5 @@ convention: pai-freshness-v1
 > 🎯 SAMPLE TEMPLATE — auto-curated hot-layer memory about you. It starts empty and the memory reviewer writes durable facts here as you work with your DA. Nothing to fill in manually. Pulse's memory panel reads this file.
 
 <!-- Entries are appended automatically by the memory curation loop. Empty on a fresh install — this is expected. -->
+<!-- BEGIN ENTRIES -->
+<!-- END ENTRIES -->


### PR DESCRIPTION
## Problem

The two hot-layer memory templates — `USER/PRINCIPAL/PRINCIPAL_MEMORY.md` and `USER/DIGITAL_ASSISTANT/DA_MEMORY.md` — ship without the `<!-- BEGIN ENTRIES -->` / `<!-- END ENTRIES -->` marker pair that `MemoryWriter.ts` requires. On a stock install the "memory that compounds" loop silently never persists:

- `parseFile()` hits its markers-missing branch and returns `entries: []`, so every reader (`LoadMemory.hook`, `MemoryHealthCheck`, Pulse) sees zero entries no matter how many the reviewer has written.
- `serializeFile()` re-adds a lone `END` marker on each write, so the file accretes orphan `END` markers while staying unreadable — and nothing alarms (`setEntries` returns `ok`).

Reported in #1409 and #1426.

## Fix

Minimal, no new abstractions:

1. **Templates** — add the `BEGIN`/`END` marker pair to both shipped templates so fresh installs start well-formed.
2. **`parseFile()` self-heal** — on a marker-less or corrupted file, recover well-formed entry lines, drop stray markers, preserve the intro text, and rebuild a single clean `BEGIN`/`END` scaffold. This also repairs files already corrupted in the field, not just fresh installs — a serialize-side `BEGIN`-guard alone would leave existing orphaned entries stranded outside the markers.

## Verified (macOS, LifeOS v6.0.5)

- **Reproduced** on a live v6.0.5 install: the shipped template had `0` `BEGIN` markers; after the reviewer ran, `PRINCIPAL_MEMORY.md` held real entries interleaved with several stray `<!-- END ENTRIES -->` markers and no `BEGIN`; `LoadMemory` injected `(no entries yet)` while `read()` returned `0`.
- **Parser change, checked in isolation:**
  - marker-less file → first serialize yields exactly one `BEGIN`/`END` pair
  - corrupted file (entries + multiple stray `END`s, no `BEGIN`) → `parseFile` recovers all N entries, serialize emits one marker pair, round-trips idempotently
- **After the fix**, `read()` returns the correct entry count and `LoadMemory` injects the entries.

## Manual verification steps

```bash
# Before: stock template has no markers
grep -c 'BEGIN ENTRIES' LifeOS/install/USER/PRINCIPAL/PRINCIPAL_MEMORY.md   # -> 0

# After this PR: marker pair present
grep -c 'BEGIN ENTRIES' LifeOS/install/USER/PRINCIPAL/PRINCIPAL_MEMORY.md   # -> 1

# Self-heal: on a marker-less file that already has entry lines,
# MemoryWriter read/parse now returns the entries instead of 0, and the
# next write rebuilds a single clean BEGIN/END pair (no stray markers).
```

## Limitations

- Verified on **macOS** only. The change is platform-agnostic — pure string/marker parsing, no OS-specific calls — but I have not run it on Linux.
- **No automated test added.** `MemoryWriter.ts`'s built-in `smokeTest()` writes to the installed `~/.claude/…` path (via `ALLOWED_FILES` keyed to `homedir()`), not a repo fixture, so it can't run hermetically against the repo copy — I verified the parser logic in isolation instead. Happy to add a fixture-based test if you'd prefer one.

Fixes #1409, #1426
