### PR TITLE
fix(algorithm): route sequential ISA worker to subscription billing, not API

### DIFF
--- a/LifeOS/install/LIFEOS/TOOLS/algorithm.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/algorithm.ts
@@ -1317,13 +1317,19 @@ async function runLoop(isaPath: string, maxOverride?: number, agentCount: number
     // ── Sequential path: single agent (existing behavior) ──
     const prompt = buildIterationPrompt(absPath, newIteration, max);
 
+    // BILLING: subscription, not API. No --bare (forces ANTHROPIC_API_KEY),
+    // strip the key from inherited env (bun auto-loads .env). Mirrors runParallelIteration.
+    const workerEnv: Record<string, string> = { ...process.env } as Record<string, string>;
+    delete workerEnv.ANTHROPIC_API_KEY;
+
     const result = spawnSync("claude", [
-      "-p", "--bare", prompt,
+      "-p", prompt,
       "--allowedTools", "Edit,Write,Bash,Read,Glob,Grep,WebFetch,WebSearch,Task,TaskCreate,TaskUpdate,TaskList,NotebookEdit",
     ], {
       stdio: ["pipe", "pipe", "pipe"],
       timeout: 600_000, // 10 minute timeout per iteration
       cwd: dirname(absPath), // Run from ISA's directory context
+      env: workerEnv,
     });
 
     const iterEndTime = Date.now();


### PR DESCRIPTION
## Problem

The sequential-path worker in `runLoop()` (`LIFEOS/TOOLS/algorithm.ts`) spawns `claude -p --bare`, which forces `ANTHROPIC_API_KEY` auth and bypasses OAuth/keychain — billing every Algorithm iteration on that path to the pay-as-you-go API instead of the subscription.

This is a leak the codebase already documents and guards against; it was just never applied to this one call site:

- **The in-file TODO was never actioned here.** The sibling `runParallelIteration()` carries [`// BILLING: subscription, not API. Remove --bare …`](https://github.com/danielmiessler/LifeOS/blob/58b270f6cef652e21599b6cbca3b48f6fb141442/LifeOS/install/LIFEOS/TOOLS/algorithm.ts#L831) and strips it — the sequential path below it kept `--bare`.
- **The incident is on record** — [`PULSE/lib.ts`](https://github.com/danielmiessler/LifeOS/blob/58b270f6cef652e21599b6cbca3b48f6fb141442/LifeOS/install/LIFEOS/PULSE/lib.ts#L342): *"the Apr 2026 Haiku $22.66 line item on the Anthropic invoice (heartbeat + tasks + memory consolidation all used --bare, all billed API)."*
- **There's a detector for exactly this** — [`CostTracker.ts`](https://github.com/danielmiessler/LifeOS/blob/58b270f6cef652e21599b6cbca3b48f6fb141442/LifeOS/install/LIFEOS/TOOLS/CostTracker.ts#L158) flags `claude.*--bare` as a `bypass`: *"remove it, use Inference.ts flag pattern, and strip ANTHROPIC_API_KEY from env."* This file trips that detector. ([why the tool exists](https://github.com/danielmiessler/LifeOS/blob/58b270f6cef652e21599b6cbca3b48f6fb141442/LifeOS/install/LIFEOS/TOOLS/CostTracker.ts#L7))
- **Another call site already fixed it** — [`lifeos.ts`](https://github.com/danielmiessler/LifeOS/blob/58b270f6cef652e21599b6cbca3b48f6fb141442/LifeOS/install/LIFEOS/TOOLS/lifeos.ts#L571) ("Removed --bare").
- **The rule is constitutional** — [`LIFEOS_SYSTEM_PROMPT.md`](https://github.com/danielmiessler/LifeOS/blob/58b270f6cef652e21599b6cbca3b48f6fb141442/LifeOS/install/LIFEOS/LIFEOS_SYSTEM_PROMPT.md#L242): *"Never use `claude --bare` … costly subscription billing leak."* [`PulseSystem.md`](https://github.com/danielmiessler/LifeOS/blob/58b270f6cef652e21599b6cbca3b48f6fb141442/LifeOS/install/LIFEOS/DOCUMENTATION/Pulse/PulseSystem.md#L282): *"a real billing incident drove this rule."*

## Why removing `--bare` alone isn't enough

Per Anthropic's [authentication precedence chain](https://code.claude.com/docs/en/authentication#authentication-precedence), an `ANTHROPIC_API_KEY` present in the inherited env (bun auto-loads `.env`) outranks `CLAUDE_CODE_OAUTH_TOKEN` — so `claude -p` keeps billing API even without `--bare`. The complete fix is what the parallel path already does: drop `--bare` **and** pass a scrubbed env with `ANTHROPIC_API_KEY` deleted.

## Fix

Mirror `runParallelIteration()` on the sequential `spawnSync`: remove `--bare`, add `env: workerEnv` with `ANTHROPIC_API_KEY` deleted. Behavior-preserving; auth routing only. 1 file, +7/-1.

## Testing

**Auth-routing confirmed at runtime (invalid-key contrast, macOS).** Two `claude -p` spawns (no `--bare`) with a deliberately invalid `ANTHROPIC_API_KEY` in the environment — costs nothing, an invalid key can't bill:

- **Key present in env** → fails: `⚠ claude.ai connectors are disabled because ANTHROPIC_API_KEY … takes precedence over your claude.ai login` → `Invalid API key`. The CLI itself confirms an env key outranks the subscription login, so `claude -p` bills API even without `--bare` — i.e. the leak is real **and** removing `--bare` alone would not fix it.
- **Key stripped from the child env** (what this patch does) → returns `PONG` via OAuth/subscription. Confirms the scrub routes to subscription.

**Also verified by inspection + build.** The diff is a byte-for-byte match of the env-scrub pattern already shipping in this repo — `runParallelIteration()` (same file, directly above), `lifeos.ts`, and `PULSE/lib.ts`. `bun build` on the changed file is clean.

**OS:** macOS (darwin 25.5). The auth-routing mechanism the patch relies on is runtime-proven above; the change itself is mechanical (one flag + one env scrub) and mirrors code already in production.
