### PR TITLE
Guard `MemoryRetriever.compress()` against meta-artifact "summaries"

### DIFF
--- a/LifeOS/install/LIFEOS/TOOLS/MemoryRetriever.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/MemoryRetriever.ts
@@ -309,6 +309,30 @@ function extractExcerpt(note: KnowledgeNote, queryTerms: string[]): string {
 // LLM Compression via Inference.ts
 // ============================================================================
 
+// A compression call can exit 0 with non-empty output yet return the model's
+// clarification/refusal instead of a summary (e.g. it treats the note as absent
+// and answers "I need the actual note content to compress…"). Those bodies then
+// masquerade as real summaries. These high-signal tells detect that case; the
+// guard's failure mode is benign — it falls back to a raw excerpt.
+const META_ARTIFACT_PATTERNS: RegExp[] = [
+  /\bi need the actual\b/i,
+  /\bpaste the full\b/i,
+  /\byou'?ve provided the title\b/i,
+  /\bthe note body itself\b/i,
+  /\bnote content to compress\b/i,
+  /\bcontent to compress isn'?t\b/i,
+  /\bi'?ll compress it\b/i,
+  /\bcompress it to under\b/i,
+  /\bready when you share\b/i,
+  /\bplease (?:paste|share)\b[\s\S]{0,30}\bnote\b/i,
+  /\bnote\b[\s\S]{0,20}\b(?:isn'?t|not|wasn'?t) (?:included|provided)\b/i,
+  /\b(?:isn'?t|not|wasn'?t) (?:included|provided)\b[\s\S]{0,20}\bnote\b/i,
+];
+
+export function looksLikeMetaArtifact(s: string): boolean {
+  return META_ARTIFACT_PATTERNS.some((p) => p.test(s));
+}
+
 function compress(text: string, budget: number): string {
   const inferPath = path.join(LIFEOS_DIR, "TOOLS", "Inference.ts");
 
@@ -327,7 +351,10 @@ function compress(text: string, budget: number): string {
   );
 
   if (result.status === 0 && result.stdout.trim()) {
-    return result.stdout.trim();
+    const summary = result.stdout.trim();
+    // Reject a "successful" result that is actually the model's clarification or
+    // refusal rather than a summary; fall through to the raw-truncation fallback.
+    if (!looksLikeMetaArtifact(summary)) return summary;
   }
 
   // Fallback: return truncated raw text


### PR DESCRIPTION
# Guard `MemoryRetriever.compress()` against meta-artifact "summaries"

Fixes the issue where `compress()` shows the compression model's refusal as a note summary.

## What

`compress()` trusts any exit-0, non-empty LLM result as a summary. When the model returns a clarification instead of a summary ("I need the actual note content to compress… under N tokens… please paste the full note"), that reply gets shown as the summary. The note on disk is fine — it's a display-time artifact.

This adds a small output guard: reject a result that matches high-signal meta-artifact patterns and fall through to the raw-truncation fallback that's already there.

## Change

`LIFEOS/TOOLS/MemoryRetriever.ts` only — single file, no API change, no new dependency:

- New `META_ARTIFACT_PATTERNS` + exported `looksLikeMetaArtifact()`. Exported on purpose so it's a pure, unit-testable predicate.
- `compress()` returns the summary only if `!looksLikeMetaArtifact(summary)`; otherwise it falls through to the existing raw-truncation fallback (same one that already handled process failures).

## Why it's safe

The guard degrades gracefully. A false positive yields a raw excerpt — exactly what `--raw` returns — never a crash, never data loss. Nothing's written to the corpus.

## Verification

`looksLikeMetaArtifact` is the deterministic surface (the `compress()` call itself shells out to an LLM, so it's not worth asserting on directly). Cases:

| Input | Expected | Result |
|---|---|---|
| "I need the actual note content to compress… paste the full note… under 166 tokens" | reject | ✅ caught |
| "…the note content to compress isn't included" | reject | ✅ caught |
| "Please share the note and I'll summarize it" | reject | ✅ caught |
| A real dense summary (role-scope note, launchd-PATH note, etc.) | pass | ✅ passed |
| A summary that legitimately mentions "compression"/"tokens" | pass | ✅ passed (no false trip) |
| RFI business prose ("Please share under NDA: SOC 2 report…") | pass | ✅ passed (tightened) |

- False negatives: **0** — both observed real garbage bodies caught.
- False positives: **0 / 6002** real note bodies (full active corpus). The scan first surfaced 4 false positives from RFI "please share …" prose; tightening the `please paste/share` tell to require "note" cleared them with no garbage missed.
- Patched retriever run non-`--raw` against a live query → clean summaries, no regression.

Tested on macOS 26.5.2 (Darwin 25.5.0), Bun 1.3.14.

> Note: this repo has no test runner, so no test file is included here. The predicate is exported so a `bun test` can cover it wherever one's wired; the case table above is the reviewable proof.

## Scope

Display/compression path only. `--raw` callers skip `compress()` and are unaffected.
