### PR TITLE
fix: expand literal $HOME in injected env path vars (LIFEOS_DIR/LIFEOS_CONFIG_DIR/PROJECTS_DIR) — fixes #1404 shadow-$HOME directories and orphaned learning data

### DIFF
--- a/LifeOS/Tools/LinkUser.ts
+++ b/LifeOS/Tools/LinkUser.ts
@@ -13,6 +13,13 @@
 import { join } from "node:path";
 import { checkSymlinkContract, detectDevTree, setupUserSeparation } from "./InstallEngine";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 function main(): void {
   const a = process.argv.slice(2);
   const get = (f: string): string | undefined => {

--- a/LifeOS/Tools/ScaffoldUser.ts
+++ b/LifeOS/Tools/ScaffoldUser.ts
@@ -13,6 +13,13 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { copyMissing, detectDevTree } from "./InstallEngine";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 function main(): void {
   const a = process.argv.slice(2);
   const get = (f: string): string | undefined => {

--- a/LifeOS/Tools/SeedPulse.ts
+++ b/LifeOS/Tools/SeedPulse.ts
@@ -15,6 +15,13 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { detectDevTree } from "./InstallEngine";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const GENERATORS = ["GenerateTelosSummary.ts", "UpdateLifeosState.ts"];
 
 function main(): void {

--- a/LifeOS/install/LIFEOS/LIFEOS_INSTALL/engine/detect.ts
+++ b/LifeOS/install/LIFEOS/LIFEOS_INSTALL/engine/detect.ts
@@ -10,6 +10,13 @@ import { homedir } from "os";
 import { join, resolve } from "path";
 import type { DetectionResult, ExistingUserContentDetection } from "./types";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 function tryExec(cmd: string): string | null {
   try {
     return execSync(cmd, { timeout: 5000, stdio: ["pipe", "pipe", "pipe"] })

--- a/LifeOS/install/LIFEOS/LIFEOS_INSTALL/engine/state.ts
+++ b/LifeOS/install/LIFEOS/LIFEOS_INSTALL/engine/state.ts
@@ -9,6 +9,13 @@ import { join, dirname } from "path";
 import type { InstallState, StepId } from "./types";
 import { INSTALLER_VERSION } from "./types";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const STATE_FILE = join(
   process.env.LIFEOS_CONFIG_DIR || join(homedir(), ".config", "LifeOS"),
   "LIFEOS_INSTALL",

--- a/LifeOS/install/LIFEOS/LIFEOS_StatusLine.sh
+++ b/LifeOS/install/LIFEOS/LIFEOS_StatusLine.sh
@@ -12,6 +12,11 @@ set -o pipefail
 # ─────────────────────────────────────────────────────────────────────────────
 
 LIFEOS_DIR="${LIFEOS_DIR:-$HOME/.claude/LIFEOS}"
+# Claude Code injects settings.json env values without shell expansion (LifeOS#1404):
+# a shipped value of "$HOME/.claude/LIFEOS" arrives literal. Expand it here.
+LIFEOS_DIR="${LIFEOS_DIR/#\$HOME/$HOME}"
+LIFEOS_DIR="${LIFEOS_DIR/#\$\{HOME\}/$HOME}"
+LIFEOS_DIR="${LIFEOS_DIR/#\~\//$HOME/}"
 CLAUDE_HOME="$HOME/.claude"
 SETTINGS_FILE="$CLAUDE_HOME/settings.json"
 RATINGS_FILE="$LIFEOS_DIR/MEMORY/LEARNING/SIGNALS/ratings.jsonl"

--- a/LifeOS/install/LIFEOS/PULSE/Observability/observability.ts
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/observability.ts
@@ -26,6 +26,13 @@ import { join, extname } from "path"
 import { readFileSync, readdirSync, existsSync, realpathSync, statSync, watch, type FSWatcher } from "fs"
 import YAML from "yaml"
 import { effortToCanonicalTierName } from "../../../hooks/lib/effort"
+
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
 // Growth is an OPTIONAL USER customization (USER/CUSTOMIZATIONS/TOOLS/Growth.ts): present on the
 // principal's machine, absent on fresh installs (private code, not shipped). It is loaded via a
 // guarded dynamic import in handleLifeGrowth so the Pulse server boots without it. A static import

--- a/LifeOS/install/LIFEOS/PULSE/checks/notification-governor.ts
+++ b/LifeOS/install/LIFEOS/PULSE/checks/notification-governor.ts
@@ -32,6 +32,13 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync, appendFileSync } fr
 import { join, dirname } from "path";
 import { createHash } from "crypto";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const HOME = process.env.HOME || "";
 const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const STATE_FILE = join(LIFEOS_DIR, "PULSE", "state", "notification-governor.json");

--- a/LifeOS/install/LIFEOS/PULSE/checks/poller-meta-monitor.ts
+++ b/LifeOS/install/LIFEOS/PULSE/checks/poller-meta-monitor.ts
@@ -18,6 +18,13 @@
 import { readFileSync, existsSync } from "fs";
 import { join } from "path";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const HOME = process.env.HOME || "";
 const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const PULSE_STATE = join(LIFEOS_DIR, "PULSE", "state", "state.json");

--- a/LifeOS/install/LIFEOS/PULSE/modules/hypotheses.ts
+++ b/LifeOS/install/LIFEOS/PULSE/modules/hypotheses.ts
@@ -27,6 +27,13 @@
 import { existsSync, readFileSync, readdirSync, writeFileSync, unlinkSync, mkdirSync } from "fs";
 import { join } from "path";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const HOME = process.env.HOME || "";
 const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const FRAMES_DIR = join(LIFEOS_DIR, "MEMORY", "WISDOM", "FRAMES");

--- a/LifeOS/install/LIFEOS/PULSE/modules/user-index.ts
+++ b/LifeOS/install/LIFEOS/PULSE/modules/user-index.ts
@@ -22,6 +22,13 @@
 import { readFileSync, writeFileSync, statSync, readdirSync, mkdirSync, existsSync, watch } from "fs"
 import { join, relative, basename, dirname } from "path"
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const HOME = process.env.HOME ?? ""
 const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS")
 const USER_DIR = join(LIFEOS_DIR, "USER")

--- a/LifeOS/install/LIFEOS/PULSE/modules/work.ts
+++ b/LifeOS/install/LIFEOS/PULSE/modules/work.ts
@@ -25,6 +25,13 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync, statSync } from "fs
 import { join } from "path";
 import { loadWorkConfig, type WorkConfig } from "../../../hooks/lib/work-config";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const HOME = process.env.HOME || "";
 const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const PULSE_STATE_DIR = join(LIFEOS_DIR, "PULSE", "state");

--- a/LifeOS/install/LIFEOS/TOOLS/AgentWatchdog.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/AgentWatchdog.ts
@@ -20,6 +20,13 @@
 import { existsSync, readFileSync, statSync } from "fs";
 import { join } from "path";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const LIFEOS_DIR = process.env.LIFEOS_DIR || join(process.env.HOME!, ".claude", "LIFEOS");
 const OBS_DIR = join(LIFEOS_DIR, "MEMORY", "OBSERVABILITY");
 const ACTIVITY_FILE = join(OBS_DIR, "tool-activity.jsonl");

--- a/LifeOS/install/LIFEOS/TOOLS/ApproveCurrentStateEntries.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/ApproveCurrentStateEntries.ts
@@ -19,6 +19,13 @@
 import { readFileSync, writeFileSync, existsSync } from "fs";
 import { join } from "path";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const HOME = process.env.HOME || "";
 const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const QUEUE_FILE = join(LIFEOS_DIR, "USER", "TELOS", "CURRENT_STATE", "proposals.jsonl");

--- a/LifeOS/install/LIFEOS/TOOLS/ArchDecisionHarvest.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/ArchDecisionHarvest.ts
@@ -19,6 +19,13 @@ import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 // ============================================================================
 // Configuration
 // ============================================================================

--- a/LifeOS/install/LIFEOS/TOOLS/ArchitectureSummaryGenerator.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/ArchitectureSummaryGenerator.ts
@@ -15,6 +15,13 @@ import { parseArgs } from "util";
 import * as fs from "fs";
 import * as path from "path";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 // ============================================================================
 // Configuration
 // ============================================================================

--- a/LifeOS/install/LIFEOS/TOOLS/BookmarkSweep.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/BookmarkSweep.ts
@@ -22,6 +22,13 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync, appendFileSync, renameSync } from "fs";
 import { join } from "path";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 declare const Bun: { spawn: (cmd: string[], opts?: any) => any };
 
 const HOME = process.env.HOME || "";

--- a/LifeOS/install/LIFEOS/TOOLS/CommitmentSweep.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/CommitmentSweep.ts
@@ -24,6 +24,13 @@ import { join } from "path";
 import { spawnSync } from "child_process";
 import { loadWorkConfig } from "../../hooks/lib/work-config";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const HOME = process.env.HOME || "";
 const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const OBS_DIR = join(LIFEOS_DIR, "MEMORY", "OBSERVABILITY");

--- a/LifeOS/install/LIFEOS/TOOLS/ComputeGap.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/ComputeGap.ts
@@ -23,6 +23,13 @@
 import { readFileSync, existsSync, appendFileSync, mkdirSync } from "fs";
 import { join, dirname } from "path";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const HOME = process.env.HOME || "";
 const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const IDEAL_DIR = join(LIFEOS_DIR, "USER", "TELOS", "IDEAL_STATE");

--- a/LifeOS/install/LIFEOS/TOOLS/ContextAudit.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/ContextAudit.ts
@@ -12,6 +12,13 @@ import { basename, dirname, join } from "path";
 import { CONTEXT_FRESHNESS_REGISTRY, parseFrontmatter, type ContextFile } from "./TelosFreshness";
 import { currentModel } from "./models";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const HOME = process.env.HOME || "";
 const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const CLAUDE_DIR = dirname(LIFEOS_DIR);

--- a/LifeOS/install/LIFEOS/TOOLS/FailureCapture.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/FailureCapture.ts
@@ -29,6 +29,13 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync } from
 import { join, basename } from 'path';
 import { inference } from './Inference';
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const LIFEOS_DIR = process.env.LIFEOS_DIR || join(process.env.HOME!, '.claude');
 
 interface FailureCaptureInput {

--- a/LifeOS/install/LIFEOS/TOOLS/FreshnessCache.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/FreshnessCache.ts
@@ -16,6 +16,13 @@ import { writeFileSync, renameSync, mkdirSync, existsSync } from "fs";
 import { join } from "path";
 import { readContextFreshness } from "./TelosFreshness";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const HOME = process.env.HOME || "";
 const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const CACHE_DIR = join(LIFEOS_DIR, "USER", "CACHE");

--- a/LifeOS/install/LIFEOS/TOOLS/GetCounts.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/GetCounts.ts
@@ -36,6 +36,13 @@
 import { readdirSync, existsSync, statSync } from "fs";
 import { join } from "path";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const HOME = process.env.HOME!;
 const CLAUDE_DIR = join(HOME, ".claude");
 // skills/, hooks/, settings.json live under CLAUDE_DIR.

--- a/LifeOS/install/LIFEOS/TOOLS/Grok.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/Grok.ts
@@ -41,6 +41,13 @@ import { readFileSync } from 'fs'
 import { homedir } from 'os'
 import { join } from 'path'
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const colors = {
   reset: '\x1b[0m', bold: '\x1b[1m', dim: '\x1b[2m',
   red: '\x1b[31m', green: '\x1b[32m', yellow: '\x1b[33m', cyan: '\x1b[36m',

--- a/LifeOS/install/LIFEOS/TOOLS/InterviewIdealState.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/InterviewIdealState.ts
@@ -18,6 +18,13 @@
 import { readFileSync, writeFileSync, existsSync, readdirSync } from "fs";
 import { join } from "path";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const HOME = process.env.HOME || "";
 const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const TELOS_DIR = join(LIFEOS_DIR, "USER", "TELOS");

--- a/LifeOS/install/LIFEOS/TOOLS/InterviewScan.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/InterviewScan.ts
@@ -20,6 +20,13 @@ import { readFileSync, existsSync } from "fs";
 import { join } from "path";
 import { readTelosFreshness, sectionSlug, type SectionFreshness } from "./TelosFreshness";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const HOME = process.env.HOME || "";
 const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const USER_DIR = join(LIFEOS_DIR, "USER");

--- a/LifeOS/install/LIFEOS/TOOLS/KnowledgeGraph.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/KnowledgeGraph.ts
@@ -27,6 +27,13 @@ import { parseArgs } from "util";
 import * as fs from "fs";
 import * as path from "path";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 // ============================================================================
 // Configuration
 // ============================================================================

--- a/LifeOS/install/LIFEOS/TOOLS/KnowledgeHarvester.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/KnowledgeHarvester.ts
@@ -22,6 +22,13 @@ import { parseArgs } from "util";
 import * as fs from "fs";
 import * as path from "path";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 // ============================================================================
 // Configuration
 // ============================================================================

--- a/LifeOS/install/LIFEOS/TOOLS/MemoryGraph.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/MemoryGraph.ts
@@ -28,6 +28,13 @@ import pagerank from "graphology-metrics/centrality/pagerank";
 import * as fs from "fs";
 import * as path from "path";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const HOME = process.env.HOME!;
 const LIFEOS_DIR = process.env.LIFEOS_DIR || path.join(HOME, ".claude", "LIFEOS");
 const MEMORY = path.join(LIFEOS_DIR, "MEMORY");

--- a/LifeOS/install/LIFEOS/TOOLS/MemoryRetriever.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/MemoryRetriever.ts
@@ -36,6 +36,13 @@ import * as fs from "fs";
 import * as path from "path";
 import { spawnSync } from "child_process";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 // ============================================================================
 // Configuration
 // ============================================================================

--- a/LifeOS/install/LIFEOS/TOOLS/MigrateApprove.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/MigrateApprove.ts
@@ -25,6 +25,13 @@
 import { readFileSync, writeFileSync, existsSync, appendFileSync, mkdirSync } from "fs";
 import { join, dirname } from "path";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const HOME = process.env.HOME || "";
 const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const QUEUE_FILE = join(LIFEOS_DIR, "MEMORY", "MIGRATION", "migration-proposals.jsonl");

--- a/LifeOS/install/LIFEOS/TOOLS/MigrateContextFreshness.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/MigrateContextFreshness.ts
@@ -18,6 +18,13 @@ import {
   type ContextFile,
 } from "./TelosFreshness";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const HOME = process.env.HOME || "";
 const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const CLAUDE_DIR = dirname(LIFEOS_DIR);

--- a/LifeOS/install/LIFEOS/TOOLS/MigrateScan.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/MigrateScan.ts
@@ -23,6 +23,13 @@ import { readFileSync, writeFileSync, existsSync, readdirSync, statSync, mkdirSy
 import { join, basename, dirname, extname } from "path";
 import { randomUUID } from "crypto";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const HOME = process.env.HOME || "";
 const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const QUEUE_FILE = join(LIFEOS_DIR, "MEMORY", "MIGRATION", "migration-proposals.jsonl");

--- a/LifeOS/install/LIFEOS/TOOLS/MigrateTelosFreshness.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/MigrateTelosFreshness.ts
@@ -23,6 +23,13 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync } from
 import { createHash } from "crypto";
 import { join } from "path";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const HOME = process.env.HOME || "";
 const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const TELOS_PATH = join(LIFEOS_DIR, "USER", "TELOS", "TELOS.md");

--- a/LifeOS/install/LIFEOS/TOOLS/PangramScore.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/PangramScore.ts
@@ -21,6 +21,13 @@ import { readFileSync, appendFileSync, mkdirSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { dirname, join } from "node:path";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const ENV_PATH = `${process.env.HOME}/.claude/.env`;
 
 // Run-record: proof the detector actually executed on a specific text. The

--- a/LifeOS/install/LIFEOS/TOOLS/ProposeCurrentStateEntry.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/ProposeCurrentStateEntry.ts
@@ -21,6 +21,13 @@ import { appendFileSync, mkdirSync, existsSync } from "fs";
 import { join, dirname } from "path";
 import { randomUUID } from "crypto";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const HOME = process.env.HOME || "";
 const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const QUEUE_FILE = join(LIFEOS_DIR, "USER", "TELOS", "CURRENT_STATE", "proposals.jsonl");

--- a/LifeOS/install/LIFEOS/TOOLS/Recommend.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/Recommend.ts
@@ -17,6 +17,13 @@
 import { readFileSync, existsSync } from "fs";
 import { join } from "path";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const HOME = process.env.HOME || "";
 const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const TELOS_DIR = join(LIFEOS_DIR, "USER", "TELOS");

--- a/LifeOS/install/LIFEOS/TOOLS/TelosFreshness.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/TelosFreshness.ts
@@ -25,6 +25,13 @@
 import { readFileSync, writeFileSync, existsSync } from "fs";
 import { basename, join } from "path";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const HOME = process.env.HOME || "";
 const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const TELOS_PATH = join(LIFEOS_DIR, "USER", "TELOS", "TELOS.md");

--- a/LifeOS/install/LIFEOS/TOOLS/UpdateLifeosState.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/UpdateLifeosState.ts
@@ -29,6 +29,13 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
 import { join, dirname } from "path";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const HOME = process.env.HOME || "";
 const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
 const IDEAL_DIR = join(LIFEOS_DIR, "USER", "TELOS", "IDEAL_STATE");

--- a/LifeOS/install/LIFEOS/TOOLS/WisdomCrossFrameSynthesizer.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/WisdomCrossFrameSynthesizer.ts
@@ -18,6 +18,13 @@ import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync } from 
 import { join, basename } from 'path';
 import { parseArgs } from 'util';
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const BASE_DIR = process.env.LIFEOS_DIR || join(process.env.HOME!, '.claude');
 const WISDOM_DIR = join(BASE_DIR, 'MEMORY', 'WISDOM');
 const FRAMES_DIR = join(WISDOM_DIR, 'FRAMES');

--- a/LifeOS/install/LIFEOS/TOOLS/WisdomDomainClassifier.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/WisdomDomainClassifier.ts
@@ -17,6 +17,13 @@ import { existsSync, readdirSync, readFileSync } from 'fs';
 import { join, basename } from 'path';
 import { parseArgs } from 'util';
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const BASE_DIR = process.env.LIFEOS_DIR || join(process.env.HOME!, '.claude');
 const FRAMES_DIR = join(BASE_DIR, 'MEMORY', 'WISDOM', 'FRAMES');
 

--- a/LifeOS/install/LIFEOS/TOOLS/WisdomFrameUpdater.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/WisdomFrameUpdater.ts
@@ -19,6 +19,13 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { parseArgs } from 'util';
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const BASE_DIR = process.env.LIFEOS_DIR || join(process.env.HOME!, '.claude');
 const FRAMES_DIR = join(BASE_DIR, 'MEMORY', 'WISDOM', 'FRAMES');
 

--- a/LifeOS/install/LIFEOS/TOOLS/WorkSweep.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/WorkSweep.ts
@@ -28,6 +28,13 @@ import { existsSync, readFileSync, writeFileSync, readdirSync, statSync, mkdirSy
 import { join } from "path";
 import { loadWorkConfig } from "../../hooks/lib/work-config";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 declare const Bun: { spawn: (cmd: string[], opts?: any) => any };
 
 const HOME = process.env.HOME || "";

--- a/LifeOS/install/LIFEOS/TOOLS/YouTubeApi.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/YouTubeApi.ts
@@ -23,6 +23,13 @@ import { readFileSync } from 'fs'
 import { homedir } from 'os'
 import { join } from 'path'
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 // ANSI colors
 const colors = {
   reset: '\x1b[0m',

--- a/LifeOS/install/LIFEOS/TOOLS/algorithm.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/algorithm.ts
@@ -52,6 +52,13 @@ import { spawnSync, spawn } from "child_process";
 import { randomUUID } from "crypto";
 import { generateISATemplate } from "../../../.claude/hooks/lib/isa-template";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 // ─── Paths ───────────────────────────────────────────────────────────────────
 
 const HOME = process.env.HOME || "~";

--- a/LifeOS/install/LIFEOS/TOOLS/llcli/llcli.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/llcli/llcli.ts
@@ -13,6 +13,13 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 // ============================================================================
 // Types
 // ============================================================================

--- a/LifeOS/install/hooks/DriftReminder.hook.ts
+++ b/LifeOS/install/hooks/DriftReminder.hook.ts
@@ -13,6 +13,13 @@ import { existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSyn
 import { dirname, join } from "node:path";
 import { firstBannedHit } from "./lib/banned-vocab";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 interface HookInput {
   prompt?: string;
   user_prompt?: string;

--- a/LifeOS/install/hooks/InstructionsLoadedHandler.hook.ts
+++ b/LifeOS/install/hooks/InstructionsLoadedHandler.hook.ts
@@ -26,6 +26,13 @@ import { existsSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 // ========================================
 // Configuration
 // ========================================

--- a/LifeOS/install/hooks/LastResponseCache.hook.ts
+++ b/LifeOS/install/hooks/LastResponseCache.hook.ts
@@ -15,6 +15,13 @@ import { readHookInput, parseTranscriptFromInput } from './lib/hook-io';
 import { writeFileSync } from 'fs';
 import { join } from 'path';
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 async function main() {
   const input = await readHookInput();
   if (!input) { process.exit(0); }

--- a/LifeOS/install/hooks/OutputFormatGate.hook.ts
+++ b/LifeOS/install/hooks/OutputFormatGate.hook.ts
@@ -30,6 +30,13 @@ import { scanAiSpeak } from "./lib/ai-speak-patterns";
 import { readFileSync, appendFileSync, mkdirSync } from "fs";
 import { dirname, join } from "path";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const OBS_PATH = join(
   process.env.LIFEOS_DIR || join(process.env.HOME!, ".claude", "LIFEOS"),
   "MEMORY",

--- a/LifeOS/install/hooks/PromptProcessing.hook.ts
+++ b/LifeOS/install/hooks/PromptProcessing.hook.ts
@@ -40,6 +40,13 @@ import { paiPath } from './lib/paths';
 import { updateSessionNameInWorkJson, upsertSession } from './lib/isa-utils';
 import { isDesktopChannel, logSkippedVoice, getNotificationChannel } from './lib/notification-channel';
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 // ── Types ──
 
 interface HookInput {

--- a/LifeOS/install/hooks/SatisfactionCapture.hook.ts
+++ b/LifeOS/install/hooks/SatisfactionCapture.hook.ts
@@ -32,6 +32,13 @@ import { getISOTimestamp, getPSTComponents } from './lib/time';
 import { captureFailure } from '../LIFEOS/TOOLS/FailureCapture';
 import { addRatingPulse } from './lib/isa-utils';
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 // ── Types ──
 
 interface HookInput {

--- a/LifeOS/install/hooks/SessionCleanup.hook.ts
+++ b/LifeOS/install/hooks/SessionCleanup.hook.ts
@@ -39,6 +39,13 @@ import { getISOTimestamp } from './lib/time';
 import { setTabState, cleanupKittySession } from './lib/tab-setter';
 import { readRegistry, writeRegistry, findArtifactPath, findActiveSessionByUUID } from './lib/isa-utils';
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const BASE_DIR = process.env.LIFEOS_DIR || join(process.env.HOME!, '.claude', 'LIFEOS');
 const MEMORY_DIR = join(BASE_DIR, 'MEMORY');
 const STATE_DIR = join(MEMORY_DIR, 'STATE');

--- a/LifeOS/install/hooks/SkillSurface.hook.ts
+++ b/LifeOS/install/hooks/SkillSurface.hook.ts
@@ -12,6 +12,13 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, statSync, writeFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 interface HookInput {
   prompt?: string;
   user_prompt?: string;

--- a/LifeOS/install/hooks/SuccessClaimGate.hook.ts
+++ b/LifeOS/install/hooks/SuccessClaimGate.hook.ts
@@ -39,6 +39,13 @@ import { readHookInput, parseTranscriptFromInput } from "./lib/hook-io";
 import { appendFileSync, mkdirSync } from "fs";
 import { dirname, join } from "path";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const OBS_PATH = join(
   process.env.LIFEOS_DIR || join(process.env.HOME!, ".claude", "LIFEOS"),
   "MEMORY",

--- a/LifeOS/install/hooks/WorkCompletionLearning.hook.ts
+++ b/LifeOS/install/hooks/WorkCompletionLearning.hook.ts
@@ -55,6 +55,13 @@ import { getISOTimestamp, getPSTDate } from './lib/time';
 import { getLearningCategory } from './lib/learning-utils';
 import { findArtifactPath, findActiveSessionByUUID } from './lib/isa-utils';
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const BASE_DIR = process.env.LIFEOS_DIR || join(process.env.HOME!, '.claude', 'LIFEOS');
 const MEMORY_DIR = join(BASE_DIR, 'MEMORY');
 const WORK_DIR = join(MEMORY_DIR, 'WORK');

--- a/LifeOS/install/hooks/WritingGate.hook.ts
+++ b/LifeOS/install/hooks/WritingGate.hook.ts
@@ -30,6 +30,13 @@ import { appendFileSync, mkdirSync, existsSync, readFileSync } from "fs";
 import { createHash } from "crypto";
 import { dirname, join } from "path";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const LIFEOS_DIR = process.env.LIFEOS_DIR || join(process.env.HOME!, ".claude", "LIFEOS");
 const OBS_PATH = join(LIFEOS_DIR, "MEMORY", "OBSERVABILITY", "writing-gate.jsonl");
 const RUNS_PATH = join(LIFEOS_DIR, "MEMORY", "OBSERVABILITY", "pangram-runs.jsonl");

--- a/LifeOS/install/hooks/lib/work-config.ts
+++ b/LifeOS/install/hooks/lib/work-config.ts
@@ -27,6 +27,13 @@
 import { existsSync, readFileSync, writeFileSync, chmodSync } from "fs";
 import { join } from "path";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 declare const Bun: { spawnSync: (cmd: string[], opts?: any) => any };
 
 const HOME = process.env.HOME || "";

--- a/LifeOS/install/skills/Art/Tools/Generate.ts
+++ b/LifeOS/install/skills/Art/Tools/Generate.ts
@@ -675,6 +675,13 @@ function enhancePromptForTransparency(prompt: string): string {
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const execAsync = promisify(exec);
 
 // ============================================================================

--- a/LifeOS/install/skills/Art/Tools/GenerateMidjourneyImage.ts
+++ b/LifeOS/install/skills/Art/Tools/GenerateMidjourneyImage.ts
@@ -17,6 +17,13 @@ import { MidjourneyClient, MidjourneyError } from '../lib/midjourney-client.js';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 // ============================================================================
 // Environment Loading
 // ============================================================================

--- a/LifeOS/install/skills/AudioEditor/Tools/Polish.ts
+++ b/LifeOS/install/skills/AudioEditor/Tools/Polish.ts
@@ -18,6 +18,13 @@ import { existsSync, readFileSync } from "fs";
 import { basename, dirname, extname, join, resolve } from "path";
 import { homedir } from "os";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 // ============================================================================
 // Environment Loading — keys from ~/.claude/.env
 // ============================================================================

--- a/LifeOS/install/skills/Daemon/Tools/DaemonAggregator.ts
+++ b/LifeOS/install/skills/Daemon/Tools/DaemonAggregator.ts
@@ -19,6 +19,13 @@ import { readFileSync, existsSync, writeFileSync, readdirSync, statSync } from "
 import { join, resolve } from "path";
 import { filterContent, filterDaemonData, loadSecurityOverrides } from "./SecurityFilter.ts";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 // ─── Path Resolution ───
 
 const HOME = process.env.HOME || process.env.USERPROFILE || "";

--- a/LifeOS/install/skills/LifeOS/Tools/LinkUser.ts
+++ b/LifeOS/install/skills/LifeOS/Tools/LinkUser.ts
@@ -13,6 +13,13 @@
 import { join } from "node:path";
 import { checkSymlinkContract, detectDevTree, setupUserSeparation } from "./InstallEngine";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 function main(): void {
   const a = process.argv.slice(2);
   const get = (f: string): string | undefined => {

--- a/LifeOS/install/skills/LifeOS/Tools/ScaffoldUser.ts
+++ b/LifeOS/install/skills/LifeOS/Tools/ScaffoldUser.ts
@@ -13,6 +13,13 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { copyMissing, detectDevTree } from "./InstallEngine";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 function main(): void {
   const a = process.argv.slice(2);
   const get = (f: string): string | undefined => {

--- a/LifeOS/install/skills/LifeOS/Tools/SeedPulse.ts
+++ b/LifeOS/install/skills/LifeOS/Tools/SeedPulse.ts
@@ -15,6 +15,13 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { detectDevTree } from "./InstallEngine";
 
+// Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
+for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
+  const v = process.env[k];
+  if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
+}
+
+
 const GENERATORS = ["GenerateTelosSummary.ts", "UpdateLifeosState.ts"];
 
 function main(): void {


### PR DESCRIPTION
## Problem (#1404)

Claude Code injects `settings.json` env values **verbatim — never shell-expanded** — so the shipped `settings.system.json` values

```json
"LIFEOS_DIR": "$HOME/.claude/LIFEOS",
"PROJECTS_DIR": "$HOME/Projects",
"LIFEOS_CONFIG_DIR": "$HOME/.claude/LIFEOS"
```

reach every hook/tool as literal strings. Since `$HOME/...` is a *relative* path, `fs` writes resolve under the process **cwd**: every working directory a session runs in silently grows a junk directory literally named `$HOME/` containing shadow `MEMORY`/`LEARNING`/`STATE` trees.

Beyond the junk directories, **this loses data**: on our install, `FailureCapture` wrote a full failure record (including a ~950 KB transcript) and `SatisfactionCapture` wrote sentiment notes and 27 rating lines into shadow trees instead of the real `MEMORY/LEARNING` — invisible to `MemoryRetriever`, the statusline ratings display, and the learning loop.

## Fix (consumer-side; `settings.system.json` stays portable)

- **64 TS consumers** of `process.env.LIFEOS_DIR` / `LIFEOS_CONFIG_DIR` / `PROJECTS_DIR` get a small normalization block at module load: if the value starts with a literal `$HOME`/`${HOME}`, expand it in `process.env` before any path math. Idempotent, no imports, no behavior change when the value is already absolute. `hooks/lib/paths.ts` (already expands via `expandPath`) and `Safety.hook.ts` (own inline expansion) are untouched.
- **`LIFEOS_StatusLine.sh`**: bash `${LIFEOS_DIR:-…}` keeps an already-set literal value without re-expanding it, so the script now expands `$HOME`/`${HOME}`/`~/` prefixes explicitly right after the default assignment. This is the offender that continuously regrows the junk trees on *established* installs (model/weather/location/version caches every statusline tick), as also reported in the #1404 comments.

Deliberately **not** changed: the `$HOME` form in `settings.system.json` (it's the portable template; expanding it at install time would also work and could be done as a complement — happy to add that if preferred). The consumer-side fix makes the code correct for **existing installs too**, which already have the literal value baked into their `settings.json`.

## Testing evidence

Tested on a live LifeOS v6.0.5 install (macOS, Claude Code, bun 1.2.x) carrying the same bug — three shadow `$HOME` trees had accumulated (in `~/code`, `~/Compass`, and `~/.claude`).

Reproduction of what Claude Code does — run offenders from a pristine cwd with the literal env value:

```bash
cd /tmp/proof-cwd
echo '{"model":{"display_name":"Test"},"workspace":{"current_dir":"/tmp/proof-cwd"},"session_id":"proof"}' \
  | env LIFEOS_DIR='$HOME/.claude/LIFEOS' bash LIFEOS_StatusLine.sh
env LIFEOS_DIR='$HOME/.claude/LIFEOS' bun LIFEOS/TOOLS/FreshnessCache.ts
echo '{"session_id":"proof","stop_hook_active":false,"last_assistant_message":"test"}' \
  | env LIFEOS_DIR='$HOME/.claude/LIFEOS' bun hooks/OutputFormatGate.hook.ts
```

- **Before the patch**: `/tmp/proof-cwd/$HOME/.claude/LIFEOS/...` appears, containing `MEMORY/STATE/model-cache.txt`, `USER/CACHE/freshness.json`, `OBSERVABILITY/format-gate.jsonl`.
- **After the patch**: test cwd stays empty; all three writes land at the real `~/.claude/LIFEOS/...` paths with fresh mtimes (verified for statusline caches, freshness cache, and format-gate telemetry).
- All 64 patched TS files pass a `Bun.Transpiler` parse check; `bash -n` passes on the statusline; the diff is insert-only (453 insertions, 0 deletions).

Fixes #1404 (fresh-install scaffold breakage has the same root cause; `ScaffoldUser.ts` / `LinkUser.ts` / `SeedPulse.ts` are among the patched consumers).
