### PR TITLE
fix(telegram): add explicit config switch for voice summaries

### DIFF
--- a/LifeOS/install/LIFEOS/PULSE/PULSE.toml
+++ b/LifeOS/install/LIFEOS/PULSE/PULSE.toml
@@ -15,6 +15,9 @@ enabled = true
 
 [telegram]
 enabled = true
+# Send a spoken summary of each text reply as a Telegram voice note. Requires
+# ELEVENLABS_API_KEY. Set false to keep text replies but suppress voice notes.
+voice_summaries = true
 
 [imessage]
 enabled = false

--- a/LifeOS/install/LIFEOS/PULSE/modules/telegram.ts
+++ b/LifeOS/install/LIFEOS/PULSE/modules/telegram.ts
@@ -58,6 +58,11 @@ export interface TelegramConfig {
   max_turns?: number
   sdk_timeout_ms?: number
   edit_interval_ms?: number
+  // Send a spoken summary of each text reply as a Telegram voice note.
+  // Defaults to enabled (undefined ⇒ on) so existing installs are unchanged;
+  // set `voice_summaries = false` under [telegram] in PULSE.toml to opt out
+  // even when ELEVENLABS_API_KEY is present.
+  voice_summaries?: boolean
 }
 
 // ── Constants ──
@@ -570,6 +575,9 @@ export function sendVoiceSummary(
   fullText: string,
 ): void {
   if (!ELEVENLABS_API_KEY) return
+  // Explicit opt-out: a principal can keep text replies but suppress voice
+  // notes via [telegram] voice_summaries = false, even with an API key present.
+  if (activeConfig?.voice_summaries === false) return
   const wordCount = fullText.trim().split(/\s+/).length
   if (wordCount < SHORT_REPLY_WORDS) {
     log("info", "voice summary skipped — short reply", { wordCount, chatId: ctx.chat.id })
@@ -1084,7 +1092,10 @@ export function telegramHealth(): {
   last_session_id?: string
   voice_summary: { enabled: boolean; last_send_ms: number | null }
 } {
-  const voice_summary = { enabled: ELEVENLABS_API_KEY !== "", last_send_ms: lastVoiceSendMs }
+  const voice_summary = {
+    enabled: ELEVENLABS_API_KEY !== "" && activeConfig?.voice_summaries !== false,
+    last_send_ms: lastVoiceSendMs,
+  }
 
   if (!bot) {
     return {


### PR DESCRIPTION
`sendVoiceSummary` was gated only by the presence of `ELEVENLABS_API_KEY`. Because the Telegram module and the CLI `/notify` VoiceServer share that one env var, an install that wants ElevenLabs for the CLI channel but *not* spoken Telegram notes had no way to turn the latter off short of unsetting the key (which kills both).

This adds a `[telegram] voice_summaries` flag, threaded through the existing `loadPulseConfig → startTelegram → activeConfig` path — no new plumbing (`loadPulseConfig` already passes the whole `[telegram]` table through). Defaults to enabled (undefined ⇒ on) so existing installs are unchanged; set `voice_summaries = false` to keep text replies but suppress the voice note. `telegramHealth()` reflects the switch.

Design note: a dedicated `[telegram]` flag was chosen over reusing the top-level `[voice] enabled` because `[voice]` gates the separate CLI VoiceServer/`/notify` channel — conflating the two surfaces would be wrong.
