### PR TITLE
fix(USMetrics): EIA gas-price facet typo and dollar-scale formatting in GenerateAnalysis

### DIFF
--- a/LifeOS/install/skills/USMetrics/Tools/GenerateAnalysis.ts
+++ b/LifeOS/install/skills/USMetrics/Tools/GenerateAnalysis.ts
@@ -165,7 +165,7 @@ function calculateTrend(observations: Observation[], years: number): TrendStat |
 async function fetchEIAGasPrice(): Promise<{ value: number; date: string } | null> {
   if (!EIA_API_KEY) return null;
 
-  const url = `https://api.eia.gov/v2/petroleum/pri/gnd/data/?api_key=${EIA_API_KEY}&frequency=weekly&data[0]=value&facets[product][]=EPMR&facets[duession][]=Y&sort[0][column]=period&sort[0][direction]=desc&length=1`;
+  const url = `https://api.eia.gov/v2/petroleum/pri/gnd/data/?api_key=${EIA_API_KEY}&frequency=weekly&data[0]=value&facets[product][]=EPMR&facets[duoarea][]=NUS&sort[0][column]=period&sort[0][direction]=desc&length=1`;
 
   try {
     const response = await fetch(url);
@@ -190,8 +190,13 @@ function formatValue(value: number, seriesId: string): string {
   if (["UNRATE", "CIVPART", "PSAVERT", "MORTGAGE30US", "FEDFUNDS", "DGS10", "DGS2", "DRCCLACBS"].includes(seriesId)) {
     return `${value.toFixed(1)}%`;
   }
-  if (["GDPC1", "GFDEBTN", "BOPGSTB", "TOTALSL"].includes(seriesId)) {
-    return value >= 1000000 ? `$${(value / 1000000).toFixed(2)}T` : `$${(value / 1000).toFixed(1)}B`;
+  if (seriesId === "GDPC1") {
+    // GDPC1 is reported in billions of dollars (not millions)
+    return `$${(value / 1000).toFixed(2)}T`;
+  }
+  if (["GFDEBTN", "BOPGSTB", "TOTALSL", "FYFSD"].includes(seriesId)) {
+    // these series are reported in millions of dollars; use abs() so negatives (deficit/trade) pick the right scale
+    return Math.abs(value) >= 1000000 ? `$${(value / 1000000).toFixed(2)}T` : `$${(value / 1000).toFixed(1)}B`;
   }
   if (["MSPUS"].includes(seriesId)) {
     return `$${(value / 1000).toFixed(0)}K`;


### PR DESCRIPTION
Three small correctness fixes in the USMetrics skill's `GenerateAnalysis.ts`, all verified against live API responses.

## 1. Gas prices were silently null (EIA facet typo)

The EIA petroleum endpoint was queried with `facets[duession][]=Y`, which is not a valid facet on `/v2/petroleum/pri/gnd/data/`. The API returns an empty series rather than an error, so the gas-price row silently dropped out of every report. Fixed to `facets[duoarea][]=NUS` (U.S. national average), which returns data.

## 2. Real GDP misformatted by three orders of magnitude

`GDPC1` is reported by FRED in **billions** of chained dollars, but it was grouped with series reported in millions. Real GDP of ~24,150 rendered as `$24.2B` instead of `$24.15T`. It now has its own scale branch.

## 3. Federal deficit picked the wrong scale

`FYFSD` is negative in deficit years, so the `value >= 1000000` threshold always failed and a ~$1.77T deficit rendered as `$-1774.0B`. The scale check now uses `Math.abs(value)`, and `FYFSD` is included in the millions-scale group.

## Testing

- EIA query with `duoarea=NUS` returns a populated weekly series (was empty with the old facet).
- `formatValue(24150, "GDPC1")` renders `$24.15T`.
- `formatValue(-1774000, "FYFSD")` renders `$-1.77T`.

No behavior changes outside these three code paths. Happy to adjust scope or style to match the v7 direction.
