### PR TITLE
Fix dead CONTEXT_ROUTING references in BitterPillEngineering

### DIFF
--- a/LifeOS/install/skills/BitterPillEngineering/SKILL.md
+++ b/LifeOS/install/skills/BitterPillEngineering/SKILL.md
@@ -109,7 +109,7 @@ Exception — four keep-classes are legitimate HOW, never cut them: **safety-gat
 | Duplicates another rule | **MERGE** — one location, one statement |
 | One-off fix for past mistake | **EVALUATE** — still relevant or already learned? |
 | Vague / unquantifiable | **SHARPEN** — add specific DO/DON'T examples, or cut |
-| Loaded but rarely actionable | **MOVE to on-demand** — load via CONTEXT_ROUTING when needed |
+| Loaded but rarely actionable | **MOVE to on-demand** — load via the CLAUDE.md routing table when needed |
 | Specific, actionable, non-default | **KEEP** — this is what good instructions look like |
 
 ## Anti-Fragile vs Fragile

--- a/LifeOS/install/skills/BitterPillEngineering/Workflows/Audit.md
+++ b/LifeOS/install/skills/BitterPillEngineering/Workflows/Audit.md
@@ -42,7 +42,7 @@ Compare rules across all files for:
 For each force-loaded file, estimate:
 - How many tokens it consumes
 - How often its content actually affects output quality
-- Whether it could be on-demand (via CONTEXT_ROUTING) instead of always-loaded
+- Whether it could be on-demand (via the CLAUDE.md routing table) instead of always-loaded
 
 ### 6. Produce the report
 


### PR DESCRIPTION
## Problem

`LifeOS/install/skills/BitterPillEngineering/SKILL.md` (classification table, "MOVE to on-demand" row) and `Workflows/Audit.md` (step 5) both instruct the model to move rarely used context to on-demand loading "via CONTEXT_ROUTING". No file or mechanism named CONTEXT_ROUTING exists anywhere in the repo, so the instruction points at nothing. The actual on-demand lookup mechanism is the routing table in CLAUDE.md; `LifeOS/install/CLAUDE.template.md` describes itself as "the routing table" and holds the on-demand path listings.

## Fix

Repoint both references to "the CLAUDE.md routing table" so the instruction resolves to the mechanism that actually ships. Two one-line edits, no behavior change beyond making the reference real.

## Testing

- `rg -n "CONTEXT_ROUTING"` over the tree returns no remaining occurrences after the change (the only two hits before the change were these two lines).
- Verified absence of any CONTEXT_ROUTING file with `git grep` and `fd` against the current main tree before editing.
- Both markdown files render correctly; the table row keeps its existing column structure.
