### PR TITLE
fix(skill): route `doctor` in the LifeOS skill

### DIFF
--- a/LifeOS/SKILL.md
+++ b/LifeOS/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: LifeOS
 version: 1.4.19
-description: Install and onboard a user into LifeOS — the Life Operating System (current state → ideal state via TELOS + the Algorithm). The agentic installer detects your OS + harness, wires hooks with permission, scaffolds your USER tree, pulls in sources you provide, and runs the TELOS / current→ideal interview that seeds your Pulse dashboard. USE WHEN install LifeOS, set up LifeOS, lifeos setup, lifeos-setup, lifeos interview, onboard me, run the interview, integrate LifeOS into my harness, update LifeOS, uninstall LifeOS, first-time setup. NOT FOR building or cutting a LifeOS release (private release tooling), editing TELOS after onboarding (use Telos / Interview), or LifeOS system maintenance (use the private maintenance skill).
+description: Install and onboard a user into LifeOS — the Life Operating System (current state → ideal state via TELOS + the Algorithm). The agentic installer detects your OS + harness, wires hooks with permission, scaffolds your USER tree, pulls in sources you provide, and runs the TELOS / current→ideal interview that seeds your Pulse dashboard. USE WHEN install LifeOS, set up LifeOS, lifeos setup, lifeos-setup, lifeos interview, onboard me, run the interview, integrate LifeOS into my harness, update LifeOS, uninstall LifeOS, first-time setup, lifeos doctor, check my install, what capabilities are broken. NOT FOR building or cutting a LifeOS release (private release tooling), editing TELOS after onboarding (use Telos / Interview), or LifeOS system maintenance (use the private maintenance skill).
 disable-model-invocation: true
-argument-hint: "[setup|interview|update|uninstall]"
+argument-hint: "[setup|interview|doctor|update|uninstall]"
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 
@@ -27,12 +27,15 @@ Both are served from the skill's own single sources of truth — `INSTALL.md` at
 
 ## Workflow Routing
 
-| Trigger | Workflow |
-|---------|----------|
+| Trigger | Target |
+|---------|--------|
 | `setup`, `/lifeos-setup`, "install LifeOS", "integrate into my harness" | `Workflows/Setup.md` |
 | `interview`, "onboard me", "run the interview", TELOS capture | `Workflows/Interview.md` |
+| `doctor`, "check my install", "what's broken", "what capabilities are live" | run `bun <configRoot>/LIFEOS/TOOLS/Doctor.ts` (see `INSTALL.md` § 8.5) |
 | `update`, "update LifeOS", after a version bump | `Workflows/Update.md` |
 | `uninstall`, "remove LifeOS" | `Workflows/Uninstall.md` |
+
+`doctor` is the one tool-backed route — it needs no workflow because `Doctor.ts` is self-describing: it prints the four capability states (live / broken / declined / stale) and the exact fix command for anything broken. Relay its table, offer the fix it names, and honor `decline` — a declined capability is a legitimate way to run LifeOS, never a defect to nag about.
 
 Default flow (`/lifeos-setup`): **Setup phase** (system integration) → transitions into **Interview phase** (life onboarding). One continuous experience, two clearly-marked phases — setup is logistics, interview is meaning. Setup ALWAYS runs first; hooks must be wired before the interview seeds anything.
 
@@ -62,4 +65,5 @@ Default flow (`/lifeos-setup`): **Setup phase** (system integration) → transit
 
 - "install LifeOS" → `install.sh` drops the skill, then `/lifeos-setup` runs: detect env, surface conflicts, wire hooks with permission, scaffold the USER tree, then roll into the interview.
 - "run the lifeos interview" → Interview workflow: capture TELOS + current/ideal state, pull in the user's sources, seed Pulse.
+- "lifeos doctor" → run `Doctor.ts`, relay the capability table, offer the fix command for anything broken.
 - "update LifeOS" → Update workflow: idempotent re-overlay after a version bump, non-destructive.


### PR DESCRIPTION
## Problem

`Doctor.ts` ships in the install payload (`LifeOS/install/LIFEOS/TOOLS/Doctor.ts`) and `INSTALL.md` documents it at step 8.5 — but `SKILL.md` never routes it.

Three places in `SKILL.md` omit `doctor`:

- the **Workflow Routing** table lists only `setup` / `interview` / `update` / `uninstall`
- `argument-hint` is `"[setup|interview|update|uninstall]"`
- the `USE WHEN` triggers in `description` carry no doctor phrasing

Net effect: after a successful install the capability prober exists on disk and is referenced by the install doc, but is unreachable through the skill. `/LifeOS doctor` falls through to no route, and the model has to go find `Doctor.ts` by search to honor the request. A capability checker you can't reach is exactly the silent degradation Doctor was built to prevent (the tool's own header cites LifeOS discussion #1461 — "capabilities that are assumed but never verified degrade silently").

## Fix

Single-file change to `LifeOS/SKILL.md`:

1. Add the `doctor` row to the routing table.
2. Add `doctor` to `argument-hint`.
3. Add doctor triggers to the `USE WHEN` list.
4. Add a `doctor` line to Examples.

`doctor` is the only **tool-backed** route — every other row points at a `Workflows/*.md`. Rather than add a workflow doc that would only say "run the tool and read the output" (dead scaffolding — `Doctor.ts` is already self-describing), the row points straight at the tool and a short note under the table explains why. The table's second column is renamed `Workflow` → `Target` to stay honest about that.

The note also carries Doctor's **declined-is-silent** contract, so the new route can't reintroduce nagging about capabilities the user has deliberately opted out of:

> Relay its table, offer the fix it names, and honor `decline` — a declined capability is a legitimate way to run LifeOS, never a defect to nag about.

The route target uses the `<configRoot>` placeholder, matching the convention `INSTALL.md` already uses throughout.

## Testing evidence

Claims in the new note are grounded in the shipped tool's source, not paraphrase:

- `LifeOS/install/LIFEOS/TOOLS/Doctor.ts:16` — `Four states: live | broken | declined | stale. Declined is first-class` / `and permanently silent — opted-out is not a defect.`
- `LifeOS/install/LIFEOS/TOOLS/Doctor.ts:31` — `bun Doctor.ts decline <cap>    # mark capability declined (silent forever)`
- `LifeOS/install/LIFEOS/TOOLS/Doctor.ts:28` — `bun Doctor.ts                  # probe (offline checks), table output`

Ran `bun LIFEOS/TOOLS/Doctor.ts` against an installed LifeOS instance: the tool executes clean, prints the capability table, and emits a concrete `fix:` line per broken capability — confirming the route target resolves and needs no workflow wrapper to be useful. (Output not pasted: it's a report of a specific machine's capability and key state.)

Docs-only change — no runtime code touched, nothing to regress in the installer.

## Notes

Deliberately left alone, as out of scope for this fix: `SKILL.md` still carries `version: 1.4.19` in frontmatter while its own Gotchas section says *"No `version:` in SKILL.md. Claude Code ignores it."* Happy to fix that separately if you want it.
