### PR TITLE
docs(TELOS): reconcile IDEAL_STATE/CURRENT_STATE READMEs with the code + document the scoring contract

### DIFF
--- a/LifeOS/install/USER/TELOS/CURRENT_STATE/CREATIVE.md
+++ b/LifeOS/install/USER/TELOS/CURRENT_STATE/CREATIVE.md
@@ -1,0 +1,18 @@
+---
+provenance: template
+dimension: creative
+classification: private
+auto_populated: partial
+last_updated: 2026-01-01
+last_updated_by: bootstrap-template
+convention: pai-freshness-v1
+---
+
+# Current State — Creative
+
+> 🎯 SAMPLE TEMPLATE — placeholder. Pulse reads the `status:` rows below to compute your creative coverage %. Run `/interview` to replace `missing` with your real state. Values: `have` | `partial` | `missing`.
+
+- Active practice: status: missing
+- Output: status: missing
+- Time for it: status: missing
+- Tools: status: missing

--- a/LifeOS/install/USER/TELOS/CURRENT_STATE/FREEDOM.md
+++ b/LifeOS/install/USER/TELOS/CURRENT_STATE/FREEDOM.md
@@ -1,0 +1,18 @@
+---
+provenance: template
+dimension: freedom
+classification: private
+auto_populated: partial
+last_updated: 2026-01-01
+last_updated_by: bootstrap-template
+convention: pai-freshness-v1
+---
+
+# Current State — Freedom
+
+> 🎯 SAMPLE TEMPLATE — placeholder. Pulse reads the `status:` rows below to compute your freedom coverage %. Run `/interview` to replace `missing` with your real state. Values: `have` | `partial` | `missing`.
+
+- Time control: status: missing
+- Location: status: missing
+- Commitments: status: missing
+- Optionality: status: missing

--- a/LifeOS/install/USER/TELOS/CURRENT_STATE/MONEY.md
+++ b/LifeOS/install/USER/TELOS/CURRENT_STATE/MONEY.md
@@ -1,0 +1,19 @@
+---
+provenance: template
+dimension: money
+classification: private
+auto_populated: partial
+last_updated: 2026-01-01
+last_updated_by: bootstrap-template
+convention: pai-freshness-v1
+---
+
+# Current State — Money
+
+> 🎯 SAMPLE TEMPLATE — placeholder. Pulse reads the `status:` rows below to compute your money coverage %. Run `/interview` to replace `missing` with your real state. Values: `have` | `partial` | `missing`.
+
+- Income: status: missing
+- Runway: status: missing
+- Fixed costs: status: missing
+- Savings rate: status: missing
+- Debt: status: missing

--- a/LifeOS/install/USER/TELOS/CURRENT_STATE/README.md
+++ b/LifeOS/install/USER/TELOS/CURRENT_STATE/README.md
@@ -4,32 +4,57 @@ provenance: template
 
 # Current State
 
-> 🎯 SAMPLE TEMPLATE — This directory ships empty except for this README. The files you'll create here describe where you ARE right now across the dimensions of your life. Run `/interview` (or talk to your DA) to populate them. Pulse will surface your current state here once it exists.
+> 🎯 SAMPLE TEMPLATES — This directory ships one template per dimension. They describe where you ARE right now. Run `/interview` (or talk to your DA) to replace them with your real state. Pulse reads the `status:` rows to compute coverage.
 
 ## Purpose
 
-Current State is the honest baseline. The DA can't help you move from A to B if it doesn't know what A is. This directory holds your snapshot of *where you actually are right now* — across health, finances, relationships, work, learning, energy, and anything else you want tracked.
+Current State is the honest baseline. The DA can't help you move from A to B if it doesn't know what A is. This directory holds your snapshot of *where you actually are right now*.
 
 It pairs with `../IDEAL_STATE/` (where you want to be). The gap between the two is what your TELOS goals, problems, and strategies are trying to close.
 
-## Suggested files
+## The seven dimensions
 
-You don't need all of these. Start with the dimensions you actually want the DA to factor into recommendations.
+**Filenames are UPPERCASE and fixed**, and they mirror `../IDEAL_STATE/` exactly. `LIFEOS/TOOLS/UpdateLifeosState.ts` and Pulse both read these exact names. On a case-sensitive filesystem (Linux), `Health.md` will **not** be found — it must be `HEALTH.md`.
 
 | File | What it captures |
 |------|------------------|
-| `Health.md` | Sleep, fitness, energy, recurring issues, medications, current routine. |
-| `Finances.md` | Rough income/runway, fixed costs, savings posture, money stress level. |
-| `Work.md` | What you spend the most hours on right now and whether it's working. |
-| `Relationships.md` | Key relationships in your life and how they're currently going. |
-| `Learning.md` | What you're actively studying or trying to get better at. |
-| `Energy.md` | When you're sharp, when you're flat, what drains you, what restores you. |
+| `HEALTH.md` | Sleep, fitness, energy, recurring issues, medications, current routine. |
+| `MONEY.md` | Income, runway, fixed costs, savings posture, money stress level. |
+| `FREEDOM.md` | How much control you actually have over your time and commitments. |
+| `CREATIVE.md` | What you're actually making right now, and what's lapsed. |
+| `RELATIONSHIPS.md` | Key relationships and how they're currently going. |
+| `RHYTHMS.md` | Your real weekly cadence, not the one you intend. |
+| `INFRASTRUCTURE.md` | The state of the tools, systems, and environment you depend on. |
+
+## How these are scored
+
+**A CURRENT_STATE file scores on coverage — how much of your ideal you are actually living:**
+
+```
+pct = (have + 0.5 × partial) / (have + partial + missing) × 100
+```
+
+You express this with `status:` rows, one per item you want counted:
+
+```markdown
+- Sleep: status: have
+- Movement: status: partial
+- Nutrition: status: missing
+```
+
+Three values only: `have`, `partial`, `missing`. The parser counts literal `status: <value>` occurrences, so the surrounding prose is yours to write freely.
+
+**⚠️ This score OVERRIDES the matching IDEAL_STATE file.** That is the whole point.
+
+An IDEAL_STATE file scores on *articulation* (`100 − TBD × 10`), which means a beautifully-written ideal you are nowhere near living still scores 100. Without a CURRENT_STATE file, your dashboard will flatter you. **Writing this file is what makes the number honest.**
+
+The gap between the two files is the real signal. A dimension at 95% ideal-articulation and 30% current-coverage is telling you something true and useful. Don't close that gap by editing prose — close it by changing your life, or by admitting the ideal was wrong.
 
 ## How to fill these in
 
 **Easiest:** run `/interview` and pick the Current State phase. It walks each dimension.
 
-**By hand:** create the files above as plain markdown. Bullets work fine. Be honest, not aspirational — that goes in `IDEAL_STATE/`.
+**By hand:** edit the templates in place. Be honest rather than generous — an inflated baseline produces a dashboard that congratulates you while nothing improves.
 
 ## Privacy
 

--- a/LifeOS/install/USER/TELOS/CURRENT_STATE/RELATIONSHIPS.md
+++ b/LifeOS/install/USER/TELOS/CURRENT_STATE/RELATIONSHIPS.md
@@ -1,0 +1,18 @@
+---
+provenance: template
+dimension: relationships
+classification: private
+auto_populated: partial
+last_updated: 2026-01-01
+last_updated_by: bootstrap-template
+convention: pai-freshness-v1
+---
+
+# Current State — Relationships
+
+> 🎯 SAMPLE TEMPLATE — placeholder. Pulse reads the `status:` rows below to compute your relationships coverage %. Run `/interview` to replace `missing` with your real state. Values: `have` | `partial` | `missing`.
+
+- Partner: status: missing
+- Family: status: missing
+- Close friends: status: missing
+- Community: status: missing

--- a/LifeOS/install/USER/TELOS/CURRENT_STATE/RHYTHMS.md
+++ b/LifeOS/install/USER/TELOS/CURRENT_STATE/RHYTHMS.md
@@ -1,0 +1,18 @@
+---
+provenance: template
+dimension: rhythms
+classification: private
+auto_populated: partial
+last_updated: 2026-01-01
+last_updated_by: bootstrap-template
+convention: pai-freshness-v1
+---
+
+# Current State — Rhythms
+
+> 🎯 SAMPLE TEMPLATE — placeholder. Pulse reads the `status:` rows below to compute your rhythms coverage %. Run `/interview` to replace `missing` with your real state. Values: `have` | `partial` | `missing`.
+
+- Weekly cadence: status: missing
+- Deep work: status: missing
+- Rest: status: missing
+- Recovery: status: missing

--- a/LifeOS/install/USER/TELOS/IDEAL_STATE/README.md
+++ b/LifeOS/install/USER/TELOS/IDEAL_STATE/README.md
@@ -4,7 +4,7 @@ provenance: template
 
 # Ideal State
 
-> 🎯 SAMPLE TEMPLATE — This directory ships empty except for this README. The files you'll create here describe where you WANT TO BE across the dimensions of your life. Run `/interview` (or talk to your DA) to populate them. Pulse will surface your ideal state here once it exists.
+> 🎯 SAMPLE TEMPLATES — This directory ships one template per dimension. They describe where you WANT TO BE. Run `/interview` (or talk to your DA) to replace them with your real targets. Pulse reads these files to render the life-dimension rings.
 
 ## Purpose
 
@@ -12,24 +12,41 @@ Ideal State is the destination. It pairs with `../CURRENT_STATE/` to define the 
 
 This is not a fantasy doc and not a vision-board exercise. It's a concrete description of what your life looks like when the work is paying off — specific enough that you'd recognize it if you got there.
 
-## Suggested files
+## The seven dimensions
 
-Mirror whatever you wrote in `../CURRENT_STATE/`. You don't need all of these.
+**Filenames are UPPERCASE and fixed.** `LIFEOS/TOOLS/UpdateLifeosState.ts` and Pulse both read these exact names. On a case-sensitive filesystem (Linux), `Health.md` will **not** be found — it must be `HEALTH.md`.
 
 | File | What it captures |
 |------|------------------|
-| `Health.md` | The energy level, fitness, sleep quality, and routine you'd consider "dialed in." |
-| `Finances.md` | The financial posture that would let you operate without money stress. |
-| `Work.md` | What your weeks look like when work is genuinely going well. |
-| `Relationships.md` | The kind of presence you want to have in your key relationships. |
-| `Learning.md` | The level of mastery or fluency you're aiming at, and by when. |
-| `Energy.md` | What a high-energy week looks like — sleep, movement, focus blocks, recovery. |
+| `HEALTH.md` | The energy level, fitness, sleep quality, and routine you'd consider "dialed in." |
+| `MONEY.md` | The financial posture that would let you operate without money stress. |
+| `FREEDOM.md` | The autonomy you're after — over your time, your work, and your commitments. |
+| `CREATIVE.md` | What you want to be making, and the practice that sustains it. |
+| `RELATIONSHIPS.md` | The kind of presence you want to have in your key relationships. |
+| `RHYTHMS.md` | The weekly and daily cadence that keeps the rest of it working. |
+| `INFRASTRUCTURE.md` | The tools, systems, and environment you want holding it all up. |
+
+You don't need all seven. Any file you omit simply doesn't score, and its ring stays dark.
+
+## How these are scored
+
+Pulse and the statusline read `USER/TELOS/LIFEOS_STATE.json`, which `UpdateLifeosState.ts` writes from these files.
+
+**An IDEAL_STATE file scores on articulation — how completely you've said what "good" looks like:**
+
+```
+pct = 100 − (number of `TBD` markers × 10)     # clamped to 0..100
+```
+
+Every literal `TBD` in the file costs 10 points. This is deliberate: the file is *meant* to be written with honest gaps in it, and the score tells you how much of your ideal you've actually articulated. A file with no TBDs scores 100.
+
+**⚠️ Articulation is not attainment.** A beautifully-written ideal you are nowhere near living still scores 100. That's what `../CURRENT_STATE/` is for — when a matching CURRENT_STATE file exists, **it overrides this score** with real coverage. See that README for the `status:` contract.
 
 ## How to fill these in
 
 **Easiest:** run `/interview` and pick the Ideal State phase. The DA will ask "if this dimension were going great in 12 months, what would be true?" for each one.
 
-**By hand:** create the files above as plain markdown. Be specific — vague ideals don't help the DA prioritize. "Sleeping 7+ hours, lifting 3x/week, no afternoon crash" beats "in shape."
+**By hand:** edit the templates in place. Be specific — vague ideals don't help the DA prioritize. "Sleeping 7+ hours, lifting 3x/week, no afternoon crash" beats "in shape." Leave `TBD` wherever you genuinely don't know yet; an honest gap is more useful than an invented target, and the score will reflect it.
 
 ## Privacy
 


### PR DESCRIPTION
Hi Daniel — first, thank you for LifeOS. I've been running it daily and the Current→Ideal framing is genuinely the best articulation of this idea I've seen. This PR comes out of actually populating the life dimensions end-to-end for the first time, which surfaced a small documentation/code drift. Happy to reshape any of it to your taste.

## The issue

The READMEs in `USER/TELOS/IDEAL_STATE/` and `USER/TELOS/CURRENT_STATE/` tell users to create files that `UpdateLifeosState.ts` and Pulse can't read.

**Both READMEs say:**
```
Health.md · Finances.md · Work.md · Relationships.md · Learning.md · Energy.md
```

**But `LIFEOS/TOOLS/UpdateLifeosState.ts` reads:**
```ts
{ id: "health",         file: "HEALTH.md" },
{ id: "money",          file: "MONEY.md" },
{ id: "freedom",        file: "FREEDOM.md" },
{ id: "creative",       file: "CREATIVE.md" },
{ id: "relationships",  file: "RELATIONSHIPS.md" },
{ id: "rhythms",        file: "RHYTHMS.md" },
{ id: "infrastructure", file: "INFRASTRUCTURE.md" },
```

Two independent failures stack:

1. **Case.** `Health.md` ≠ `HEALTH.md` on a case-sensitive filesystem, which is every Linux install.
2. **Taxonomy.** `Work`, `Learning`, and `Energy` don't exist in the code. The code's `Freedom`, `Creative`, `Rhythms`, and `Infrastructure` don't appear in the READMEs. The two describe different models of a life.

A Linux user who follows the docs exactly gets **zero dimensions scored**, silently, with no error. Pulse keeps rendering "No life-area dimensions populated yet" while their files sit right there in the directory.

The good news is the **shipped templates are already correct** — `IDEAL_STATE/` contains `HEALTH.md`, `MONEY.md`, `FREEDOM.md` and friends. Only the READMEs are stale, and they appear to predate the seven-dimension model. (The `IDEAL_STATE` README also says the directory "ships empty except for this README" while sitting next to those seven templates.)

## The undocumented part

The scoring contract isn't written down anywhere, so "drop files into IDEAL_STATE/" is currently an instruction to guess at a format. From the parser:

- **`IDEAL_STATE/<DIM>.md`** → `pct = 100 − (TBD count × 10)`. Scores **articulation**: how completely you've said what "good" looks like.
- **`CURRENT_STATE/<DIM>.md`** → `pct = (have + 0.5 × partial) / total`, from literal `status: have|partial|missing` rows. Scores **coverage**, and **overrides** the ideal-state score.

That override is the subtle and important bit, and it bit me in a way I think is worth surfacing: I wrote a thorough `CREATIVE.md` ideal and it scored **90%**, which pushed the ring to 70% — while I was in fact doing almost none of it. A well-written ideal you aren't living still scores high. **Writing the `CURRENT_STATE` file is what makes the dashboard honest** (mine dropped to 30%, which was the true number). That behavior is correct and rather elegant, it just isn't discoverable without reading the parser.

## Changes

- Both READMEs list the seven UPPERCASE filenames the code actually reads, with an explicit case-sensitivity note.
- Both document the scoring contract, including the `status:` row syntax and the override semantics.
- Added the five missing `CURRENT_STATE` templates (`MONEY`, `FREEDOM`, `CREATIVE`, `RELATIONSHIPS`, `RHYTHMS`) so both directories carry all seven dimensions. `CURRENT_STATE/` previously shipped only `HEALTH` and `INFRASTRUCTURE`.

Docs and templates only. No code, no behavior change.

## One thing I left alone

Both READMEs, and Pulse's empty state, point users at `/interview` — "run `/interview` and pick the Ideal State phase." The `Interview` skill's workflows are `ContextCheckin`, `Phase0Setup`, and `TelosCheckin`; there's no ideal-state or current-state phase, so that instruction currently dead-ends.

I didn't touch it, since how that flow should work is a design call that's yours to make. **If it'd be useful, I'm glad to follow up with a PR adding those workflows** — just say the word and I'll build it to whatever shape you prefer.

Thanks again. Happy to revise anything here.