### PR TITLE
fix(ContextSearch): resolve ripgrep when no real rg binary exists

### DIFF
--- a/LifeOS/install/skills/ContextSearch/Tools/ContextSearch.ts
+++ b/LifeOS/install/skills/ContextSearch/Tools/ContextSearch.ts
@@ -299,10 +299,28 @@ function searchWorkDirs(tokens: string[], since: Date | null, until: Date | null
   return out.slice(0, 50);
 }
 
+/**
+ * Resolve a runnable ripgrep. On machines without a real `rg` binary, Claude
+ * Code's shell integration aliases rg to its embedded ripgrep via a shell
+ * FUNCTION — invisible to Bun.spawn, so every rg-backed source (ISA bodies,
+ * conversation logs) dies with "Executable not found in $PATH". Fall back to
+ * running the Claude Code executable with argv0="rg", the same trick the shell
+ * function uses.
+ */
+function rgCommand(): { exe: string; argv0?: string } {
+  const onPath = typeof Bun.which === "function" ? Bun.which("rg") : null;
+  if (onPath) return { exe: onPath };
+  const cc = process.env.CLAUDE_CODE_EXECPATH || join(HOME, ".local", "bin", "claude");
+  if (existsSync(cc)) return { exe: cc, argv0: "rg" };
+  return { exe: "rg" };
+}
+
 async function ripgrep(pattern: string, dir: string, extra: string[] = []): Promise<string> {
-  const proc = Bun.spawn(["rg", "--no-heading", "--line-number", "-i", ...extra, pattern, dir], {
+  const { exe, argv0 } = rgCommand();
+  const proc = Bun.spawn([exe, "--no-heading", "--line-number", "-i", ...extra, pattern, dir], {
     stdout: "pipe",
     stderr: "pipe",
+    ...(argv0 ? { argv0 } : {}),
   });
   const out = await new Response(proc.stdout).text();
   await proc.exited;


### PR DESCRIPTION
## Problem

ContextSearch's `ripgrep()` helper spawns `rg` via `Bun.spawn`. Claude Code's shell integration provides `rg` as a **shell function** wrapping the CLI's embedded ripgrep (`ARGV0=rg "$CLAUDE_CODE_EXECPATH"`), which `Bun.spawn` cannot see. On machines without a standalone ripgrep install this makes every rg-backed source (ISA bodies, conversation logs) die with:

```
ContextSearch error: Executable not found in $PATH: "rg"
```

— so the tool exits 1 on every query, silently losing two of its five sources' coverage. Easy to miss because machines with `brew install ripgrep` never hit it.

## Fix

Resolve the binary at spawn time:

1. A real `rg` on PATH (`Bun.which`) — used as before; zero behavior change for machines that have ripgrep.
2. Fallback: run the Claude Code executable (`CLAUDE_CODE_EXECPATH` or `~/.local/bin/claude`) with `argv0: "rg"` — the same mechanism the shell function uses to expose the embedded ripgrep.
3. Last resort: original `"rg"` literal, preserving the original error if neither exists.

## Testing

On a machine with no ripgrep binary (only the shell function): before the patch, every query exits 1 with the error above; after the patch, all five sources return results (verified against live `MEMORY/WORK` ISAs and conversation JSONLs, ~1s wall time). On a machine with real ripgrep, `Bun.which("rg")` short-circuits and behavior is byte-identical.