### PR TITLE
fix(Interceptor): test-profile auto-launch fails while Chrome is already running

### DIFF
--- a/LifeOS/install/skills/Interceptor/Tools/LaunchTestProfile.sh
+++ b/LifeOS/install/skills/Interceptor/Tools/LaunchTestProfile.sh
@@ -56,10 +56,22 @@ fi
 
 case "$(uname -s)" in
     Darwin)
-        # No -n flag here — we want to reuse the existing Chrome process so the new
-        # window shares the user-data-dir lock with Default. Chrome handles
-        # --profile-directory by opening a window for that profile in the existing
-        # instance.
+        # Direct binary, not `open -a … --args`: when the browser is ALREADY
+        # RUNNING, `open` silently drops the --args (macOS behavior), so the
+        # profile window never opens and the isolation gate times out waiting
+        # for the context. Invoking the binary directly forwards the args to
+        # the running instance via Chrome's process singleton — the profile
+        # window opens whether or not the browser was already up.
+        CHROME_BIN="${INTERCEPTOR_TEST_BROWSER_BIN:-/Applications/${BROWSER}.app/Contents/MacOS/${BROWSER}}"
+        if [ -x "$CHROME_BIN" ]; then
+            "$CHROME_BIN" \
+                --profile-directory="$CHROME_PROFILE" \
+                --new-window \
+                "$START_URL" >/dev/null 2>&1 &
+            exit 0
+        fi
+        # Fallback (binary not at the expected path): reliable only when the
+        # browser is not already running.
         exec open -a "$BROWSER" --args \
             --profile-directory="$CHROME_PROFILE" \
             --new-window \

--- a/LifeOS/install/skills/Interceptor/preferences.env.example
+++ b/LifeOS/install/skills/Interceptor/preferences.env.example
@@ -1,0 +1,31 @@
+# Interceptor per-machine preferences — the contract read by
+# Tools/PreflightIsolation.sh, Tools/EnsureTestProfile.sh, and
+# Tools/LaunchTestProfile.sh.
+#
+# Copy to:
+#   ~/.claude/LIFEOS/USER/CUSTOMIZATIONS/SKILLS/Interceptor/preferences.env
+# and fill in the two required values.
+
+# REQUIRED — the pinned test context the agent is allowed to drive.
+# Set this friendly name ONCE in the extension popup's Context ID field
+# (click the Interceptor toolbar icon → Context ID → Save). Friendly names
+# survive extension reloads; raw UUIDs rot on every reload.
+INTERCEPTOR_TEST_CONTEXT_ID="interceptor-test"
+
+# REQUIRED for auto-launch — the dedicated test profile's on-disk directory
+# name (e.g. "Profile 2"). Map directory → profile name via Chrome's
+# "Local State" file (profile.info_cache), or chrome://version → Profile Path.
+# There is deliberately no default: guessing a profile could open the
+# operator's working window.
+INTERCEPTOR_TEST_CHROME_PROFILE=""
+
+# Optional — browser app name (default "Google Chrome").
+#INTERCEPTOR_TEST_BROWSER="Google Chrome"
+
+# Optional — direct path to the browser binary, used so launches work while
+# the browser is already running (macOS `open -a … --args` drops the args).
+#INTERCEPTOR_TEST_BROWSER_BIN="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+
+# Optional — comma-separated context IDs of the operator's WORKING profiles;
+# the preflight gate hard-denies driving any of these.
+#INTERCEPTOR_WORKING_PROFILE_IDS=""


### PR DESCRIPTION
## Problem

`Tools/LaunchTestProfile.sh` (Darwin branch) launches the isolated test profile with `open -a "$BROWSER" --args …`. macOS silently **drops `--args` when the target app is already running** — `open` just activates the existing window. Since the operator's working Chrome is normally open, the test-profile window never opens, `EnsureTestProfile.sh` polls until timeout, and every browser workflow stops at the isolation gate with the context-not-connected remediation. The skill's own gotchas describe this `open`-already-running behavior, but the shipped launcher still uses the affected form.

## Fix

Invoke the browser binary directly (`/Applications/<Browser>.app/Contents/MacOS/<Browser> --profile-directory=… --new-window <url>`): Chrome's process singleton forwards the arguments to the running instance, so the profile window opens whether or not the browser was already up. `open -a` is kept as a fallback when the binary isn't at the expected path (reliable only when the browser isn't running). New optional override: `INTERCEPTOR_TEST_BROWSER_BIN`.

Also adds `preferences.env.example` documenting the contract variables the three gate/launch tools source (`INTERCEPTOR_TEST_CONTEXT_ID`, `INTERCEPTOR_TEST_CHROME_PROFILE`, optional browser overrides, working-profile deny-list). Today these are discoverable only by reading the scripts, and a wrong variable-name guess fails as "no test profile configured."

## Testing

With Chrome already running (working profile window open): before the patch, `EnsureTestProfile.sh` launches, no window appears, gate times out. After the patch, the test-profile window opens and `interceptor contexts` shows the pinned context connected in ~6s; the gate prints READY. Fallback path unchanged when the binary is absent. `bash -n` clean.