### PR TITLE
fix(pulse): resolve pai-root-relative targetFile in applyProposalEdit (memory-proposal apply fails)

### DIFF
--- a/LifeOS/install/LIFEOS/PULSE/lib/telegram-proposals.ts
+++ b/LifeOS/install/LIFEOS/PULSE/lib/telegram-proposals.ts
@@ -13,7 +13,7 @@
 
 import { appendFileSync, existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import {
   PENDING_PROPOSALS_PATH,
   inferProposalKind,
@@ -157,9 +157,14 @@ export function parseProposalReply(text: string): ProposalReply {
 }
 
 export function applyProposalEdit(targetFile: string, editText: string): { ok: true } | { ok: false; reason: string } {
-  if (!existsSync(targetFile)) return { ok: false, reason: `target file missing: ${targetFile}` };
+  // A proposal's targetFile is pai-root-relative (e.g. "LIFEOS/USER/CONFIG/OPERATIONAL_RULES.md").
+  // Resolve it against ~/.claude so it works regardless of the process CWD: the Telegram bot runs
+  // from LIFEOS/PULSE, so a bare relative path resolved to a nonexistent nested path and every apply
+  // failed with "target file missing" even though the file was present.
+  const resolved = isAbsolute(targetFile) ? targetFile : join(HOME, ".claude", targetFile);
+  if (!existsSync(resolved)) return { ok: false, reason: `target file missing: ${targetFile}` };
   try {
-    const current = readFileSync(targetFile, "utf8");
+    const current = readFileSync(resolved, "utf8");
     const sectionHeader = "## Memory-System Proposals";
     const ts = new Date().toISOString();
     const entry = `\n- ${editText} <!-- applied: ${ts} -->`;
@@ -169,9 +174,9 @@ export function applyProposalEdit(targetFile: string, editText: string): { ok: t
     } else {
       next = current.trimEnd() + `\n\n${sectionHeader}\n\n${entry.trim()}\n`;
     }
-    const tmp = `${targetFile}.tmp`;
+    const tmp = `${resolved}.tmp`;
     writeFileSync(tmp, next, "utf8");
-    renameSync(tmp, targetFile);
+    renameSync(tmp, resolved);
     return { ok: true };
   } catch (e) {
     return { ok: false, reason: (e as Error)?.message ?? String(e) };


### PR DESCRIPTION
## Problem

Applying a memory-system proposal from Telegram (`yes #<id>` / `edit #<id>`) always fails with:

```
❌ Couldn't apply: target file missing: LIFEOS/USER/CONFIG/OPERATIONAL_RULES.md
```

…even though the target file exists.

## Root cause

`applyProposalEdit(targetFile, editText)` receives a **pai-root-relative** `target_file` (e.g. `LIFEOS/USER/CONFIG/OPERATIONAL_RULES.md`, as stored on the proposal) and passes it straight to `existsSync` / `readFileSync` / `renameSync`, which resolve relative paths against `process.cwd()`. The Telegram bot runs from `LIFEOS/PULSE` (its launchd `WorkingDirectory`), so the path resolves to a nonexistent nested location and the existence check fails. This breaks proposal ratification for any standard install.

## Fix

Resolve `targetFile` against `~/.claude` when it isn't already absolute — matching the `HOME/.claude` convention this file already uses a few lines up (for `OBS_DIR`). One resolution line plus an `isAbsolute` import; all file ops use the resolved path.

## Repro

1. Let the memory loop surface an operational-rule proposal to Telegram.
2. Reply `yes #<id>`.
3. Before: `target file missing`. After: the rule is appended to `OPERATIONAL_RULES.md` under `## Memory-System Proposals`.

## Verified

Applied locally and called `applyProposalEdit("LIFEOS/USER/CONFIG/OPERATIONAL_RULES.md", …)` → `{ ok: true }`; the rule landed correctly under the section header.
