### PR TITLE
Update workflow: version diff never fetches — make step 2 a real release check

### DIFF
--- a/LifeOS/Workflows/Update.md
+++ b/LifeOS/Workflows/Update.md
@@ -12,8 +12,15 @@ curl -s -X POST http://localhost:31337/notify -H "Content-Type: application/json
 ## Steps
 
 1. **DetectEnv** — `bun Tools/DetectEnv.ts`. If `isDevTree` → STOP (the source repo updates itself via git, not this workflow).
-2. **Version diff** — the skill carries no version field and there is no plugin manifest; versioning lives at the distribution layer (the GitHub release tag + `LIFEOS_RELEASES/<version>/` + the `install.sh` fetch's `LIFEOS_VERSION`). Compare the release version being updated to against the user's current install marker. If equal, report "already current" and exit.
-3. **Re-overlay system** — re-copy the system templates (CLAUDE, system prompt, `settings.system.json` minus hooks). These are system-owned and safe to overwrite.
+2. **Release check** — the skill carries no version field and there is no plugin manifest; versioning lives at the distribution layer, so BOTH sides of the diff must come from it:
+   - **Installed version**: read `<configRoot>/LIFEOS/VERSION` (the install marker, shipped since 7.1.1). Absent → the install predates the marker; treat it as behind and continue.
+   - **Latest version**: read `tag_name` from `https://api.github.com/repos/<LIFEOS_REPO>/releases/latest` — the same endpoint the bootstrap resolves against (`LIFEOS_REPO` defaults in `install/install.sh`).
+   - **Equal** → report "already current" and exit.
+   - **Behind** → fetch the newer payload FIRST: run the shipped bootstrap, `bash <skillRoot>/install/install.sh`. It is additive — it replaces only the LifeOS skill dir and backs up the prior one. Then re-read the NEW skill's `Workflows/Update.md` and continue from its step 3 (steps may have changed between versions).
+   - **Network unreachable** → say so and continue with the on-disk payload; re-applying the current version is safe, it just can't deliver anything newer.
+
+   Never diff the on-disk payload's version against the install marker — the payload is what wrote the marker, so that comparison always says "already current" and the update never fetches anything.
+3. **Re-overlay system** — re-copy the system templates (CLAUDE, system prompt, `settings.system.json` minus hooks), and overwrite `<configRoot>/LIFEOS/VERSION` with the payload's version — the copyMissing deploys never touch an existing marker, and a stale marker re-trips step 2 forever. These are system-owned and safe to overwrite.
 4. **Re-merge hooks** — `bun Tools/InstallHooks.ts` (idempotent): adds new hook entries, leaves existing ones, never duplicates (normalized-command dedup). Backs up `settings.json` first.
 5. **Scaffold new USER templates only** — `bun Tools/ScaffoldUser.ts` copyMissing: adds any NEW template files introduced by the version, never overwrites the user's existing files.
 6. **Re-activate imports** — `bun Tools/ActivateImports.ts` for any newly-shipped identity import lines.

--- a/LifeOS/install/skills/LifeOS/Workflows/Update.md
+++ b/LifeOS/install/skills/LifeOS/Workflows/Update.md
@@ -12,8 +12,15 @@ curl -s -X POST http://localhost:31337/notify -H "Content-Type: application/json
 ## Steps
 
 1. **DetectEnv** — `bun Tools/DetectEnv.ts`. If `isDevTree` → STOP (the source repo updates itself via git, not this workflow).
-2. **Version diff** — the skill carries no version field and there is no plugin manifest; versioning lives at the distribution layer (the GitHub release tag + `LIFEOS_RELEASES/<version>/` + the `install.sh` fetch's `LIFEOS_VERSION`). Compare the release version being updated to against the user's current install marker. If equal, report "already current" and exit.
-3. **Re-overlay system** — re-copy the system templates (CLAUDE, system prompt, `settings.system.json` minus hooks). These are system-owned and safe to overwrite.
+2. **Release check** — the skill carries no version field and there is no plugin manifest; versioning lives at the distribution layer, so BOTH sides of the diff must come from it:
+   - **Installed version**: read `<configRoot>/LIFEOS/VERSION` (the install marker, shipped since 7.1.1). Absent → the install predates the marker; treat it as behind and continue.
+   - **Latest version**: read `tag_name` from `https://api.github.com/repos/<LIFEOS_REPO>/releases/latest` — the same endpoint the bootstrap resolves against (`LIFEOS_REPO` defaults in `install/install.sh`).
+   - **Equal** → report "already current" and exit.
+   - **Behind** → fetch the newer payload FIRST: run the shipped bootstrap, `bash <skillRoot>/install/install.sh`. It is additive — it replaces only the LifeOS skill dir and backs up the prior one. Then re-read the NEW skill's `Workflows/Update.md` and continue from its step 3 (steps may have changed between versions).
+   - **Network unreachable** → say so and continue with the on-disk payload; re-applying the current version is safe, it just can't deliver anything newer.
+
+   Never diff the on-disk payload's version against the install marker — the payload is what wrote the marker, so that comparison always says "already current" and the update never fetches anything.
+3. **Re-overlay system** — re-copy the system templates (CLAUDE, system prompt, `settings.system.json` minus hooks), and overwrite `<configRoot>/LIFEOS/VERSION` with the payload's version — the copyMissing deploys never touch an existing marker, and a stale marker re-trips step 2 forever. These are system-owned and safe to overwrite.
 4. **Re-merge hooks** — `bun Tools/InstallHooks.ts` (idempotent): adds new hook entries, leaves existing ones, never duplicates (normalized-command dedup). Backs up `settings.json` first.
 5. **Scaffold new USER templates only** — `bun Tools/ScaffoldUser.ts` copyMissing: adds any NEW template files introduced by the version, never overwrites the user's existing files.
 6. **Re-activate imports** — `bun Tools/ActivateImports.ts` for any newly-shipped identity import lines.


### PR DESCRIPTION
## Problem

An installed user who runs the LifeOS skill's **Update** workflow always gets "already current", no matter how far behind their install is.

Step 2 says to compare "the release version being updated to" against the install marker — but nothing in the workflow ever *fetches* a release. The only version available on disk is the payload the skill itself shipped with, which is exactly what wrote the install marker. The comparison is self-referential, so it can never detect a newer release.

7.1.1 fixed the other half of this (`install.sh` now resolves the latest release dynamically), but no step tells an *existing* install to re-run the bootstrap — so the fix is unreachable from the update path. Hit in practice: an install on 7.0.0, with v7.1.1 published, reported "already current".

## Change (docs only, 2 files — the workflow + its nested payload mirror)

**Step 2 → a real release check:**
- installed version ← `<configRoot>/LIFEOS/VERSION` (the install marker, shipped since 7.1.1; absent → treat as behind)
- latest version ← `tag_name` from the same GitHub releases endpoint the bootstrap resolves against
- behind → run the shipped `install/install.sh` first (additive: replaces only the LifeOS skill dir, backs up the prior one), then continue from the **new** payload's workflow
- offline → degrade gracefully to re-applying the on-disk version
- plus an explicit note naming the anti-pattern (payload-vs-marker is not a release check)

**Step 3 additionally overwrites the `VERSION` marker** — the copyMissing deploys never touch an existing file, so without this the marker stays stale and step 2 re-trips on every future update.

## Possible follow-ups (intentionally not bundled)

- **Doctor.ts update awareness** — a capability-style line under `--network` ("installed 7.0.0, latest 7.1.1") would fit 7.1.1's install-awareness direction, but mapping "update available" onto the live/broken/declined states is a maintainer call, so it's left out here.
- **Changed-file delivery** — copyMissing delivers *new* files but leaves *changed* system-owned files stale after an update (adjacent to the concern in #650). Worth its own design pass; out of scope for this doc fix.