### PR TITLE
tools(forge): prevent orphaned codex writers — ppid watchdog + per-slug pid reaper

### DIFF
--- a/LifeOS/install/LIFEOS/TOOLS/ForgeProgress.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/ForgeProgress.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { createInterface } from "node:readline";
-import { accessSync, constants, createWriteStream, existsSync, type WriteStream } from "node:fs";
+import { accessSync, constants, createWriteStream, existsSync, readFileSync, unlinkSync, writeFileSync, type WriteStream } from "node:fs";
 import { mkdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import process from "node:process";
@@ -13,7 +13,7 @@ type RunState = { startMs: number; childAlive: boolean; timedOut: boolean; inter
 type ExitInfo = { code: number | null; signal: NodeJS.Signals | null; error?: Error };
 type TimeoutControl = { clearNaturalExit: () => void; clearAll: () => void };
 type SignalControl = { clear: () => void };
-type Paths = { eventsFile: string; finalFile: string };
+type Paths = { eventsFile: string; finalFile: string; pidFile: string };
 type FinalInput = { verdict: "success" | "error" | "timeout"; exitCode: number | null; eventsFile: string; finalFile: string; durationMs: number; finalMessage: string };
 const RING_SIZE = 5;
 const PULSE_TIMEOUT_MS = 2000;
@@ -69,7 +69,44 @@ function preflightCodex(home: string): string | null {
 async function ensureSlugDir(home: string, slug: string): Promise<Paths> {
   const slugDir = join(home, ".claude", "LIFEOS", "MEMORY", "WORK", slug);
   await mkdir(slugDir, { recursive: true }); // Local artifact I/O is unbounded so errors can surface naturally.
-  return { eventsFile: join(slugDir, "forge-events.jsonl"), finalFile: join(slugDir, "forge-final.txt") };
+  return { eventsFile: join(slugDir, "forge-events.jsonl"), finalFile: join(slugDir, "forge-final.txt"), pidFile: join(slugDir, "forge-codex.pid") };
+}
+function pidAlive(pid: number): boolean { try { process.kill(pid, 0); return true; } catch (_error: unknown) { return false; } }
+function reapStaleCodex(pidFile: string): void {
+  // WHY: a hard-killed wrapper (SIGKILL / group teardown) cannot signal its detached codex child, leaving an
+  // orphan writer loose in the workspace. Each new run reaps its slug's stale group first.
+  if (!existsSync(pidFile)) return;
+  try {
+    const parsed = JSON.parse(readFileSync(pidFile, "utf8")) as { wrapperPid?: unknown; childPid?: unknown };
+    const wrapperPid = typeof parsed.wrapperPid === "number" ? parsed.wrapperPid : null;
+    const childPid = typeof parsed.childPid === "number" ? parsed.childPid : null;
+    if (wrapperPid !== null && pidAlive(wrapperPid)) { console.error(`ForgeProgress: another wrapper (pid ${wrapperPid}) is still alive on this slug; not reaping`); return; }
+    if (childPid !== null && pidAlive(childPid)) {
+      console.error(`ForgeProgress: reaping orphaned codex group ${childPid} left by dead wrapper ${wrapperPid ?? "unknown"}`);
+      try { process.kill(-childPid, "SIGTERM"); } catch (_error: unknown) { /* group already gone */ }
+      setTimeout(() => { if (pidAlive(childPid)) { try { process.kill(-childPid, "SIGKILL"); } catch (_error: unknown) { /* gone */ } } }, ESCALATE_MS);
+    }
+  } catch (error: unknown) { console.error(`ForgeProgress: stale pid file unreadable, removing: ${String(error)}`); }
+  try { unlinkSync(pidFile); } catch (_error: unknown) { /* already gone */ }
+}
+function writePidFile(pidFile: string, childPid: number | undefined): void {
+  if (childPid === undefined) return;
+  try { writeFileSync(pidFile, JSON.stringify({ wrapperPid: process.pid, childPid })); }
+  catch (error: unknown) { console.error(`ForgeProgress: failed to write pid file: ${String(error)}`); }
+}
+function startOrphanWatchdog(child: ChildProcessWithoutNullStreams, state: RunState, cleanupPoller: () => void): () => void {
+  // WHY: if the spawning agent/shell dies, this wrapper reparents to launchd (ppid 1). Without this check the
+  // detached codex group keeps writing to the workspace with no supervisor able to kill, commit, or report it.
+  let cleaned = false;
+  const timer = setInterval(() => {
+    if (process.ppid !== 1) return;
+    cleaned = true; clearInterval(timer); cleanupPoller();
+    console.error("ForgeProgress: parent process died; terminating codex group to prevent an orphan writer");
+    sendChildSignal(child, "SIGTERM", "orphan watchdog");
+    setTimeout(() => { if (state.childAlive) sendChildSignal(child, "SIGKILL", "orphan watchdog escalation"); }, ESCALATE_MS);
+    setTimeout(() => process.exit(1), ESCALATE_MS * 2);
+  }, 2000);
+  return () => { if (cleaned) return; cleaned = true; clearInterval(timer); };
 }
 async function readPrompt(prompt: string | undefined): Promise<string> {
   if (prompt !== undefined) return prompt;
@@ -226,13 +263,16 @@ export default async function main(argv: string[]): Promise<number> {
     const prompt = await readPrompt(args.prompt);
     if (prompt.length === 0) throw new Error("no prompt provided; pass --prompt or pipe stdin data");
     const paths = await ensureSlugDir(home, args.slug), state: RunState = { startMs: Date.now(), childAlive: true, timedOut: false, interrupted: false }, ring: RingEntry[] = [];
+    reapStaleCodex(paths.pidFile);
     const child = spawnCodex(codexPath, args, paths.finalFile, prompt);
+    writePidFile(paths.pidFile, child.pid);
     child.stderr.pipe(process.stderr);
-    const cleanupPoller = startProgressPoller(ring, args), timeoutControl = wireTimeout(child, state, args, cleanupPoller), signalControl = wireSignals(child, state, timeoutControl, cleanupPoller);
+    const cleanupPoller = startProgressPoller(ring, args), timeoutControl = wireTimeout(child, state, args, cleanupPoller), signalControl = wireSignals(child, state, timeoutControl, cleanupPoller), cleanupWatchdog = startOrphanWatchdog(child, state, cleanupPoller);
     let stdoutError: Error | null = null;
     const stdoutTask = wireStdout(child, paths.eventsFile, ring, args).catch((error: unknown) => { stdoutError = error instanceof Error ? error : new Error(String(error)); console.error(`ForgeProgress: stdout wiring failed: ${String(error)}`); sendChildSignal(child, "SIGTERM", "stdout failure"); });
     const exitInfo = await waitForChild(child);
-    state.childAlive = false; timeoutControl.clearNaturalExit(); cleanupPoller(); signalControl.clear(); await stdoutTask;
+    state.childAlive = false; timeoutControl.clearNaturalExit(); cleanupPoller(); cleanupWatchdog(); signalControl.clear(); await stdoutTask;
+    try { unlinkSync(paths.pidFile); } catch (_error: unknown) { /* already gone */ }
     const durationMs = Date.now() - state.startMs;
     void sendNotify(args.pulseUrl, { message: `Forge: codex complete (${durationMs}ms, exit ${exitInfo.code})`, voice_enabled: false, agent: "Forge", slug: args.slug });
     if (exitInfo.error) console.error(`ForgeProgress: codex spawn failed: ${exitInfo.error.message}`);


### PR DESCRIPTION

## Problem

`ForgeProgress.ts` spawns codex with `detached: true` — its own process group, which is what lets the wrapper signal the whole group on timeout. But detachment cuts both ways. If the **wrapper itself** dies hard — SIGKILL, parent shell teardown, an agent session that gets reaped — the SIGTERM/SIGKILL escalation never fires, because that escalation only runs on graceful teardown (timeout or a signal the wrapper lives to handle). The detached `codex exec --sandbox workspace-write` group survives, reparents to launchd, and keeps **writing to the workspace unsupervised**, with nothing left to kill it, commit its work, or report what it did.

Reproduction narrative (how this was found): start a run, hard-kill the wrapper mid-flight, then look for the child.

```bash
# 1. Start a run against any workspace
echo "multi-file refactor prompt" | bun ForgeProgress.ts --slug repro-orphan &
WRAPPER=$!

# 2. Simulate a hard wrapper death (closed terminal, agent teardown, OOM kill)
sleep 10 && kill -9 "$WRAPPER"

# 3. Observe: codex is still alive and still writing
pgrep -fl "codex exec"                                            # orphan present
ps -o pid,ppid,command -p "$(pgrep -f 'codex exec' | head -1)"    # ppid = 1 (launchd)
```

SIGKILL is unhandleable by design, and `detached: true` means the group doesn't inherit the death — so no amount of signal handling inside the current code can cover this path.

## The fix — two mechanisms, belt and suspenders

**1. ppid orphan watchdog** (`startOrphanWatchdog`). A 2s interval checks `process.ppid`; reparenting to launchd (ppid 1) means the parent is gone. The wrapper then SIGTERMs the codex group, escalates to SIGKILL after 5s (reusing the existing `ESCALATE_MS`), and exits nonzero. This covers the case where the *parent* dies but the wrapper itself survives to act.

**2. Per-slug pid sidecar + stale reaper** (`writePidFile` / `reapStaleCodex`). Each run writes `forge-codex.pid` (`{wrapperPid, childPid}`) next to the slug's event log and unlinks it on clean exit. The next run on the same slug reads the sidecar first: recorded wrapper dead + recorded child alive means an orphaned group, which gets SIGTERM → SIGKILL before the new codex spawns. If the recorded wrapper is still alive, the reaper backs off with a stderr notice — no friendly fire on concurrent runs.

The two are deliberately redundant: the watchdog handles parent-death-while-the-wrapper-lives, and the reaper backstops the one case the watchdog can't — the wrapper itself being SIGKILLed — by letting the *next* run clean up what the dead one couldn't.

## Scope

Minimal diff to one file: `LifeOS/install/LIFEOS/TOOLS/ForgeProgress.ts` (+45/−5). No change to the timeout default, model default, CLI flags, event streaming, Pulse notifications, or the final JSON contract. New output is stderr diagnostics only. The pid sidecar is a new per-slug artifact alongside the existing `forge-events.jsonl` / `forge-final.txt`.

## Testing

Per the contributing bar ("Test thoroughly — install in a fresh system to verify"): this was verified end-to-end on a live install running exactly this patched file, not just in isolation.

- **Stale-pid reap cycle**: seeded a `forge-codex.pid` recording a dead wrapper pid with a live detached child; the next run logged the reap on stderr, SIGTERMed the group, spawned fresh codex, wrote its own sidecar, ran to `verdict: "success"`, and removed the sidecar on exit. Sidecar present and accurate during the run, absent after.
- **Concurrent-run guard**: with a live wrapper recorded on the same slug, a second run refused to reap and said so on stderr.
- **Corrupt sidecar**: unparseable pid file is logged and unlinked; the run proceeds normally.
- **Arg validation**: existing flag parsing, duplicate-flag rejection, and `--timeout-ms` behavior unchanged (timeout path still returns `verdict: "timeout"` with the existing escalation).
- **Parse/import checks**: patched file passes `bun build --no-bundle` and dynamic-imports cleanly (default export is a function).

- **Orphan watchdog, live**: launched the patched helper through a subshell that exits immediately, orphaning the wrapper to launchd (`ppid == 1`) mid-codex-run — the watchdog fired within its 2s poll (`parent process died; terminating codex group to prevent an orphan writer` on stderr) and no codex process survived. This reproduces, deliberately, the exact field scenario that motivated the fix; the reaper additionally backstops the case where the wrapper itself is SIGKILLed.

All of the above was run against this patch applied to a pristine clone of this repository's HEAD (not against our local variant).

## Follow-up question: the 300s default timeout

While working in this file I observed that the 300000ms default kills healthy multi-file runs mid-flight — a `reasoning_effort=high` agentic run over several files routinely needs more than five minutes, and the timeout kill is indistinguishable from a failure. I deliberately did **not** touch it in this PR: it's a cost/behavior default for your users (Sol pricing), and that call is yours to make. Would you take a follow-up making it env-configurable (e.g. `FORGE_TIMEOUT_MS`, falling back to the current 300000), or would you rather raise the default outright? Happy to cut it either way.

Separately, a doctrine-docs follow-up (foreground-execution discipline for `Forge.md` / `ForgeContext.md` — why the helper should never be launched fire-and-forget, which is how orphans get made in the first place) is prepared and can come as its own PR if wanted, once this one lands.
