### PR TITLE
fix(ISA): remove stale TheRouter.hook.ts classifier references

### DIFF
--- a/LifeOS/install/skills/ISA/Workflows/CheckCompleteness.md
+++ b/LifeOS/install/skills/ISA/Workflows/CheckCompleteness.md
@@ -109,7 +109,7 @@ Walk every ISC in `## Criteria`:
 
 If invoked during OBSERVE-end or VERIFY AND the ISA is v6.4.0+ scaffolded:
 
-- If session additionalContext contains `GOAL_SIGNAL: <1|2|3|4>` (non-`none`) AND `principal_stated_goal:` in ISA frontmatter is empty/null → hard failure: "literal capture missed — classifier detected goal-signal but Scaffold did not preserve."
+- If `principal_stated_goal_signal:` in the ISA frontmatter is set (the four-signal detector fired at scaffold) AND `principal_stated_goal:` is empty/null → hard failure: "literal capture missed — the detector fired but Scaffold did not preserve the literal." (Formerly checked the retired classifier's `GOAL_SIGNAL` line; now an ISA-internal consistency check between the recorded signal and the recorded literal.)
 - If `principal_stated_goal:` is set to a non-null string but the string is < 6 tokens or fails the minimum-content rule → hard failure: "literal violates minimum-content rule — should have been `null`."
 
 ### Step 5b — Artifact-Presence Check (NEW v6.4.0 — Cato 2026-05-11 lesson)

--- a/LifeOS/install/skills/ISA/Workflows/Scaffold.md
+++ b/LifeOS/install/skills/ISA/Workflows/Scaffold.md
@@ -58,7 +58,7 @@ Run the four-signal detector on the prompt:
 
 **Multi-literal:** if multiple candidates ("do X and Y by Z"), **first wins as `principal_stated_goal:`**; others demote to derived Constraints with `derived_from: principal_stated_goal compound` annotation.
 
-**Classifier handshake:** `TheRouter.hook.ts` may emit `GOAL_SIGNAL: <1|2|3|4|none>` in additionalContext. Trust as hint, re-validate via the detector above.
+**Goal-signal detection:** no classifier hook emits `GOAL_SIGNAL` anymore (`TheRouter.hook.ts` was retired with the modes/tiers system) — the four-signal detector above is the only mechanism.
 
 When detection fires + min-content passes, write the four frontmatter fields:
 
@@ -89,7 +89,7 @@ One rule, replacing the deleted v6.x density-formula machinery: **could I be wro
 If materially ambiguous — the goal supports ≥2 interpretations leading to materially different builds, or required content can't be scaffolded without speculation — ask up to 3 targeted questions (E3+) or prepend the ambiguity flag (E1/E2): `⚠️ Picking X over Y because R; redirect if wrong.` Literal whole-response `proceed` accepts reasoned defaults.
 
 **Skip conditions (do not run the check):**
-- `INTERVIEW_ELIGIBLE: false` in the most recent `TheRouter.hook.ts` additionalContext block (the hook decided this is fast-path work). Line absent — e.g. a continuation prompt where the hook didn't re-fire — → infer eligibility from the running tier: `true` iff tier ≥ E3. This handoff is explicit text-passing; no shared state, no subprocess IPC. The model is the carrier.
+- Interview eligibility is inferred from the running tier: `true` iff tier ≥ E3 (below E3 is fast-path work, so the check is skipped). (`TheRouter.hook.ts`, which used to emit `INTERVIEW_ELIGIBLE` hints, was retired with the modes/tiers system — the tier rule, formerly the line-absent fallback, is now the sole determinant.)
 - The scaffold call has `ephemeral_feature` set (ephemeral mode operates on an already-scaffolded master).
 
 **Record the outcome in frontmatter** — `context_sufficient: true|false` and `interview_invoked: true|false` (the only two keys v7 ISAs carry for this check; the v6.x density/divergence/acknowledgment ceremony keys are deleted).


### PR DESCRIPTION
`TheRouter.hook.ts` was retired with the modes/tiers system (`HookSystem.md`: "retired entirely (commit `4dd0fbe19`)… There is no successor classifier"), but the ISA skill still instructs the model to expect its `GOAL_SIGNAL` / `INTERVIEW_ELIGIBLE` emissions. This promotes each workflow's own already-designed fallback to primary, so the guidance matches reality with no behavior change.

**Scope is deliberately ISA-only.** The ~48 other "TheRouter" mentions across the repo are historical records (CHANGELOG, `HookSystem.md`, `RouterSystem.md`) that correctly document the retirement and are left untouched. Only the three operational instructions that tell the model to act on the dead signals are changed.

### Changes

**`LifeOS/install/skills/ISA/Workflows/Scaffold.md:61`**
Before:
> **Classifier handshake:** `TheRouter.hook.ts` may emit `GOAL_SIGNAL: <1|2|3|4|none>` in additionalContext. Trust as hint, re-validate via the detector above.

After:
> **Goal-signal detection:** no classifier hook emits `GOAL_SIGNAL` anymore (`TheRouter.hook.ts` was retired with the modes/tiers system) — the four-signal detector above is the only mechanism.

**`LifeOS/install/skills/ISA/Workflows/Scaffold.md:92`**
Before:
> - `INTERVIEW_ELIGIBLE: false` in the most recent `TheRouter.hook.ts` additionalContext block (the hook decided this is fast-path work). Line absent — e.g. a continuation prompt where the hook didn't re-fire — → infer eligibility from the running tier: `true` iff tier ≥ E3. This handoff is explicit text-passing; no shared state, no subprocess IPC. The model is the carrier.

After:
> - Interview eligibility is inferred from the running tier: `true` iff tier ≥ E3 (below E3 is fast-path work, so the check is skipped). (`TheRouter.hook.ts`, which used to emit `INTERVIEW_ELIGIBLE` hints, was retired with the modes/tiers system — the tier rule, formerly the line-absent fallback, is now the sole determinant.)

**`LifeOS/install/skills/ISA/Workflows/CheckCompleteness.md:112`**
Before:
> - If session additionalContext contains `GOAL_SIGNAL: <1|2|3|4>` (non-`none`) AND `principal_stated_goal:` in ISA frontmatter is empty/null → hard failure: "literal capture missed — classifier detected goal-signal but Scaffold did not preserve."

After:
> - If `principal_stated_goal_signal:` in the ISA frontmatter is set (the four-signal detector fired at scaffold) AND `principal_stated_goal:` is empty/null → hard failure: "literal capture missed — the detector fired but Scaffold did not preserve the literal." (Formerly checked the retired classifier's `GOAL_SIGNAL` line; now an ISA-internal consistency check between the recorded signal and the recorded literal.)

Fixes #1524
