### PR TITLE
fix(skills): remove unresolvable bun-types pin from Apify and Remotion tsconfigs

### DIFF
--- a/LifeOS/install/skills/Apify/tsconfig.json
+++ b/LifeOS/install/skills/Apify/tsconfig.json
@@ -14,9 +14,6 @@
     "jsx": "react-jsx",
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
-    "allowJs": true,
-    "types": [
-      "bun-types"
-    ]
+    "allowJs": true
   }
 }

--- a/LifeOS/install/skills/Remotion/Tools/package.json
+++ b/LifeOS/install/skills/Remotion/Tools/package.json
@@ -22,7 +22,7 @@
     "remotion": ">=4.0.0"
   },
   "devDependencies": {
-    "bun-types": "latest",
+    "@types/bun": "latest",
     "typescript": "^5.0.0"
   }
 }

--- a/LifeOS/install/skills/Remotion/Tools/tsconfig.json
+++ b/LifeOS/install/skills/Remotion/Tools/tsconfig.json
@@ -12,8 +12,7 @@
     "declarationMap": true,
     "sourceMap": true,
     "outDir": "./dist",
-    "rootDir": "./",
-    "types": ["bun-types"]
+    "rootDir": "./"
   },
   "include": ["*.ts"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Problem

`skills/Apify/tsconfig.json` and `skills/Remotion/Tools/tsconfig.json` both pin `"types": ["bun-types"]`. On a fresh install these skill folders have no `node_modules`, so any editor that opens them immediately reports:

```
error TS2688: Cannot find type definition file for 'bun-types'.
```

and paints the tsconfig red before the user has done anything wrong. (Found while chasing exactly this red-file report on an installed system; `bunx tsc --noEmit` in either folder reproduces it.)

## Fix

- Remove the explicit `types` pin from both tsconfigs. The types package is already declared in each skill's `devDependencies`, and once `bun install` has run, installed `@types` packages are included automatically — the pin adds nothing in the installed state and guarantees an error in the fresh state. After this change both states are clean.
- Align `Remotion/Tools` on `@types/bun` (the canonical Bun types package, matching Apify; `bun-types` remains its transitive dependency).

## Verification

- Fresh checkout (no node_modules): `bunx tsc --noEmit` no longer reports TS2688 in either folder.
- After `bun install`: full Bun + node typings resolve as before.
- Runtime is unaffected either way — bun provides the real globals regardless of editor typings.