### PR TITLE
InstallHooks: reconcile copied hooks against registered hooks after apply

### DIFF
--- a/LifeOS/Tools/InstallHooks.ts
+++ b/LifeOS/Tools/InstallHooks.ts
@@ -15,6 +15,7 @@
  */
 
 import { copyFileSync, cpSync, existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { detectDevTree, mergeHooks } from "./InstallEngine";
 
@@ -101,7 +102,28 @@ function main(): void {
   cpSync(hooksPayloadDir, hooksDestDir, { recursive: true });
   const hookFilesCopied = countFilesRec(hooksDestDir);
 
-  console.log(JSON.stringify({ ...report, written: true, backup, hookFilesCopied }, null, 2));
+  // Copying hook scripts and merging the manifest are two independent operations;
+  // a hook can land on disk without any settings entry naming it. Ask the shipped
+  // reconciler whether every copied hook is actually reachable, so an unwired hook
+  // is loud at install time rather than silent until someone runs Doctor by hand.
+  const doctorPath = join(configRoot, "LIFEOS", "TOOLS", "Doctor.ts");
+  let unwired: string[] | undefined;
+  let reconcile: string | undefined;
+  if (existsSync(doctorPath)) {
+    try {
+      const out = execFileSync("bun", [doctorPath, "--reconcile"], {
+        encoding: "utf-8",
+        env: { ...process.env, CLAUDE_CONFIG_DIR: configRoot },
+      });
+      unwired = JSON.parse(out).unwired ?? [];
+    } catch (err) {
+      reconcile = `reconciler failed: ${err instanceof Error ? err.message : String(err)}`;
+    }
+  } else {
+    reconcile = `Doctor.ts not found at ${doctorPath} — hooks copied but not reconciled`;
+  }
+
+  console.log(JSON.stringify({ ...report, written: true, backup, hookFilesCopied, unwired, reconcile }, null, 2));
   process.exit(0);
 }
 


### PR DESCRIPTION
Fixes the detection gap in #1539.

## What this changes

`InstallHooks.ts` does two independent things and verifies each on its own: it `cpSync`s the payload `hooks/` tree onto disk (checked by file count), and it merges `hooks.json` into `settings.json` (checked by `added`/`skipped`/`events`). Both succeed. Nothing compares the set of files copied against the set of hooks registered, so a hook can land on disk with no settings entry naming it and the install still reports success — accurately.

After `--apply`, this shells `Doctor.ts --reconcile` (already on disk at that point, copied by the same install) with `CLAUDE_CONFIG_DIR` pointed at the target config root, and includes its `unwired` list in the existing report JSON.

No logic is duplicated — the reconciler you shipped in v7.1.1 already does the transitive closure through dispatcher imports correctly. This just asks it.

## Behaviour

On a clean v7.1.1 payload into an empty config root:

```json
{
  "ok": true,
  "added": 45,
  "events": 11,
  "hookFilesCopied": 72,
  "unwired": [
    "LoopDetector.hook.ts",
    "DriftReminder.hook.ts",
    "PostToolObserver.hook.ts"
  ]
}
```

If `Doctor.ts` isn't present at that path, the report carries a `reconcile` string saying so rather than skipping silently — matching the "LOUD blocker, never a silent no-op" rule in `Workflows/Setup.md`.

## Testing

Ran the patched installer against a scratch config root containing only `settings.json` (`{}`) and `LIFEOS/TOOLS/Doctor.ts`, with `--skill-root` pointed at this repo's `LifeOS/`. Output above is verbatim from that run. Existing report fields are unchanged; the two new keys are additive.

## Note

`unwired` is reported, not enforced — this doesn't fail the install or change exit codes. Happy to make it a blocker instead, or to drop the subprocess and inline the comparison, whichever you'd prefer.
