### PR TITLE
ci: run ReferenceCheck against the shipped payload (report-only)

### DIFF
--- a/.github/workflows/reference-check.yml
+++ b/.github/workflows/reference-check.yml
@@ -1,0 +1,45 @@
+name: Reference Check
+
+on:
+  pull_request:
+    paths:
+      - 'LifeOS/install/**'
+  push:
+    branches: [main]
+    paths:
+      - 'LifeOS/install/**'
+  workflow_dispatch:
+
+jobs:
+  reference-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      # ReferenceCheck resolves its root as $HOME/.claude, so stage the release
+      # payload in the shape it ships as. No source change required.
+      - name: Stage payload as an install
+        run: cp -R LifeOS/install "$HOME/.claude"
+
+      - name: Run ReferenceCheck against the shipped tree
+        id: refcheck
+        continue-on-error: true
+        run: |
+          cd "$HOME/.claude/LIFEOS/TOOLS"
+          bun ReferenceCheck.ts --quiet | tee "$RUNNER_TEMP/refcheck.txt"
+
+      - name: Summarise
+        run: |
+          {
+            echo '## Reference check — shipped payload'
+            echo
+            echo '```'
+            tail -1 "$RUNNER_TEMP/refcheck.txt"
+            echo '```'
+            echo
+            echo 'Report-only. See the PR description for why this does not gate yet.'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Makes the number in #1541 visible on every PR that touches the payload.

## What this does

`ReferenceCheck.ts` resolves its root as `$HOME/.claude`, so the job stages `LifeOS/install` in the shape it ships as and runs the validator there. No source change required.

```yaml
- run: cp -R LifeOS/install "$HOME/.claude"
- run: cd "$HOME/.claude/LIFEOS/TOOLS" && bun ReferenceCheck.ts --quiet
```

Triggers on `pull_request` and `push` to main, both filtered to `LifeOS/install/**`, plus `workflow_dispatch`.

## Report-only, deliberately

`continue-on-error: true`. It prints the summary line to the job summary and does not gate.

Against the current payload it reports:

```
ReferenceCheck: 1174 files, 1558 refs, 223 missing, 0 stale, 0 orphan — 231ms
```

Of those 223, roughly 118 are expected: 90 runtime-created paths under `MEMORY/{STATE,OBSERVABILITY,DATA,LEARNING,RESEARCH}` and 28 `USER/` files populated at interview. Gating on the raw count would be more than half false positives, and a check that cries wolf gets switched off — so this lands as report-only.

Making it blocking needs an ignore-list for runtime-created paths first. Happy to do that as a follow-up if you want it, or to fold it into this PR.

## Testing

Ran both `run` steps locally against a fresh clone at `4e33cc8` — staged the payload into a scratch `$HOME` and executed the validator, output above is verbatim. Workflow YAML parsed and validated.

I haven't been able to exercise it as a real Actions run (it has to be on the repo to trigger), so the first run on merge is the real test. `oven-sh/setup-bun@v2` is the only external action beyond `actions/checkout@v4`; swap it if you'd rather not add a dependency — `curl -fsSL https://bun.sh/install | bash` works equally well.
