### PR TITLE
Pulse: expand ${VAR} across all PULSE.toml string values, not just job.command

### DIFF
--- a/LifeOS/install/LIFEOS/PULSE/lib.test.ts
+++ b/LifeOS/install/LIFEOS/PULSE/lib.test.ts
@@ -1,0 +1,86 @@
+/**
+ * LifeOS Pulse — lib.ts config-layer tests
+ *
+ * Covers parseConfigToml()'s ${VAR} expansion: that env references resolve
+ * anywhere in the document, and — just as important — that plain literals are
+ * returned untouched so an existing install does not break on upgrade.
+ *
+ * Run from LIFEOS/PULSE (requires `bun install` for smol-toml):
+ *   bun test lib.test.ts
+ *
+ * Every credential-shaped value here is fake. Never put a real token in a test.
+ */
+
+import { test, expect } from "bun:test"
+import { parseConfigToml, resolveEnvVars } from "./lib.ts"
+
+process.env.FAKE_TEST_TOKEN = "fake-token-value"
+process.env.FAKE_TEST_HOOK = "https://example.invalid/hook"
+
+const TOML = `
+[discord]
+enabled = true
+bot_token = "\${FAKE_TEST_TOKEN}"
+channel_id = "1234567890"
+poll_interval_ms = 5000
+
+[notifications.discord]
+enabled = true
+webhook = "\${FAKE_TEST_HOOK}"
+
+[notifications.routing]
+error = ["ntfy", "discord"]
+
+[[job]]
+name = "literal-job"
+schedule = "*/5 * * * *"
+type = "script"
+command = "bun run checks/health.ts"
+output = "log"
+enabled = true
+
+[[job]]
+name = "env-job"
+schedule = "0 3 * * *"
+type = "script"
+command = "echo \${FAKE_TEST_TOKEN}"
+output = "log"
+enabled = true
+`
+
+test("expands ${VAR} in a nested section — the [discord] bot_token path", () => {
+  const c = parseConfigToml(TOML) as any
+  expect(c.discord.bot_token).toBe("fake-token-value")
+})
+
+test("expands ${VAR} in [notifications.discord] — upstream's previously dead webhook stub", () => {
+  const c = parseConfigToml(TOML) as any
+  expect(c.notifications.discord.webhook).toBe("https://example.invalid/hook")
+})
+
+test("literal string values pass through byte-identical (backward compatibility)", () => {
+  const c = parseConfigToml(TOML) as any
+  expect(c.discord.channel_id).toBe("1234567890")
+  expect(c.notifications.routing.error).toEqual(["ntfy", "discord"])
+  expect(c.job[0].command).toBe("bun run checks/health.ts")
+})
+
+test("non-string scalars keep their type", () => {
+  const c = parseConfigToml(TOML) as any
+  expect(c.discord.enabled).toBe(true)
+  expect(c.discord.poll_interval_ms).toBe(5000)
+})
+
+test("job.command still expands — the one field that worked before this change", () => {
+  const c = parseConfigToml(TOML) as any
+  expect(c.job[1].command).toBe("echo fake-token-value")
+})
+
+test("an undefined variable resolves to empty string (semantics unchanged)", () => {
+  expect(resolveEnvVars("${DEFINITELY_NOT_SET_XYZ}")).toBe("")
+})
+
+test("object keys are never rewritten, only values", () => {
+  const c = parseConfigToml(TOML) as any
+  expect(Object.keys(c.discord)).toContain("bot_token")
+})

--- a/LifeOS/install/LIFEOS/PULSE/lib.ts
+++ b/LifeOS/install/LIFEOS/PULSE/lib.ts
@@ -66,9 +66,55 @@ export interface DaemonState {
 }
 
 // ── Env Var Resolution ──
+//
+// Historically this was applied to exactly one field (a job's `command`), so
+// every other `${VAR}` in PULSE.toml was a dead literal. Two silent failures
+// followed from that: upstream ships `[notifications.discord] webhook =
+// "${DISCORD_WEBHOOK}"` that nothing ever expanded, and any module reading a
+// secret straight off the config would hand the literal string "${TOKEN}" to a
+// remote API and fail authentication with no local error.
+//
+// Expansion is now applied to every string value in the parsed config (see
+// parseConfigToml), so secrets can live in the environment instead of in the
+// file. Substitution semantics are deliberately unchanged from the original
+// single-field behaviour — both `$VAR` and `${VAR}` are recognised, and an
+// undefined variable resolves to the empty string.
+//
+// Backward compatibility: the regex only matches a `$` followed by an
+// uppercase identifier, so a plain literal value ("ntfy.sh", a cron
+// expression, a prose prompt) is returned byte-identical and existing installs
+// keep working across an upgrade.
 
-function resolveEnvVars(value: string): string {
+export function resolveEnvVars(value: string): string {
   return value.replace(/\$\{?([A-Z_][A-Z0-9_]*)\}?/g, (_, name) => process.env[name] ?? "")
+}
+
+// Recursively expand env vars in every string reachable from a parsed TOML
+// document. Non-string scalars (numbers, booleans, dates) pass through
+// untouched; object keys are never rewritten, only values.
+function resolveEnvVarsDeep<T>(value: T): T {
+  if (typeof value === "string") return resolveEnvVars(value) as unknown as T
+  if (Array.isArray(value)) return value.map(resolveEnvVarsDeep) as unknown as T
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = resolveEnvVarsDeep(v)
+    }
+    return out as unknown as T
+  }
+  return value
+}
+
+/**
+ * Parse a Pulse TOML document and expand `${VAR}` / `$VAR` references in all
+ * string values against the process environment.
+ *
+ * This is the single entry point for reading PULSE.toml — both the job loader
+ * here and loadPulseConfig() in pulse.ts go through it, so env expansion is a
+ * property of the config layer rather than of any one consumer.
+ */
+export function parseConfigToml(raw: string): Record<string, unknown> {
+  return resolveEnvVarsDeep(parse(raw) as Record<string, unknown>)
 }
 
 // ── Config Loading ──
@@ -82,12 +128,15 @@ function resolveEnvVars(value: string): string {
 // jobs until the user adds something via the API.
 
 function jobsFromToml(raw: string, source: JobSource): Job[] {
-  const parsed = parse(raw) as { job?: Array<Record<string, unknown>> }
+  // parseConfigToml already expanded env vars in every string, including
+  // `command` — which is why there is no per-field resolveEnvVars call here
+  // any more.
+  const parsed = parseConfigToml(raw) as { job?: Array<Record<string, unknown>> }
   return (parsed.job ?? []).map((j) => ({
     name: j.name as string,
     schedule: j.schedule as string,
     type: (j.type as "script" | "claude") ?? "script",
-    command: j.command ? resolveEnvVars(j.command as string) : undefined,
+    command: j.command as string | undefined,
     prompt: j.prompt as string | undefined,
     model: (j.model as string) ?? modelForEffort('medium'),
     output: (j.output ?? "log") as OutputTarget | OutputTarget[],

--- a/LifeOS/install/LIFEOS/PULSE/pulse.ts
+++ b/LifeOS/install/LIFEOS/PULSE/pulse.ts
@@ -16,7 +16,6 @@
 
 import { join } from "path"
 import { readFileSync, existsSync } from "fs"
-import { parse } from "smol-toml"
 import { loadLifeosConfig } from "../TOOLS/LifeosConfig"
 import { isLoopbackHostHeader } from "./lib/host-guard.ts"
 
@@ -68,6 +67,7 @@ import {
   isSentinel,
   spawnScript,
   spawnClaude,
+  parseConfigToml,
 } from "./lib"
 
 import { startHooks, handleHooksRequestAsync, hooksHealth } from "./modules/hooks"
@@ -316,7 +316,10 @@ interface PulseConfig {
 
 async function loadPulseConfig(): Promise<PulseConfig> {
   const raw = await Bun.file(join(PULSE_DIR, "PULSE.toml")).text()
-  const parsed = parse(raw) as Record<string, unknown>
+  // parseConfigToml expands ${VAR} in every string value, so config sections
+  // can carry secrets by reference (e.g. [discord] bot_token) instead of
+  // literal values checked into the file.
+  const parsed = parseConfigToml(raw)
 
   const daemonConfig = await loadConfig(PULSE_DIR)
 


### PR DESCRIPTION
`PULSE.toml` declares environment references in three places — `${NTFY_TOPIC}`, `${DISCORD_WEBHOOK}`, `${TWILIO_TO_NUMBER}` — but `resolveEnvVars()` is only applied to a job's `command`, so none of them are expanded. Consumers currently work around this by reading `process.env` directly in `dispatchSingle()`, so nothing is broken at runtime today; the config simply doesn't behave the way it reads.

Any module that trusts the config instead receives the literal string `"${VAR}"`. For a credential that means an authentication failure with no local error.

This moves expansion into the config layer via a new `parseConfigToml()`, so both readers of `PULSE.toml` — the job loader in `lib.ts` and `loadPulseConfig()` in `pulse.ts` — go through it, and the declared convention becomes real.

Substitution semantics are deliberately unchanged from the existing single-field behaviour: both `$VAR` and `${VAR}` are recognised, and an undefined variable resolves to the empty string. The pattern only matches `$` followed by an uppercase identifier, so a plain literal value (a hostname, a cron expression, a prose prompt) is returned byte-identical and existing installs are unaffected.

Includes tests covering nested-section expansion, literal pass-through, non-string scalars, `job.command` still expanding, undefined-variable semantics, and keys never being rewritten.

Note this is the repo's first tracked test file — there's no existing test convention or runner config, so it's colocated and run with `bun test`. Happy to move it if you'd prefer a different location or setup.
