### PR TITLE
fix(LifeosUpgrade): m-005 detect can never match on a case-sensitive filesystem

### DIFF
--- a/LifeOS/install/LIFEOS/TOOLS/LifeosUpgrade.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/LifeosUpgrade.ts
@@ -117,7 +117,7 @@ const MIGRATIONS: Migration[] = [
       // policy gitignores LEARNING/, OBSERVABILITY/, STATE/, etc. selectively;
       // Phase G may broaden this. For now, we detect "any LIFEOS/MEMORY/ rule" as
       // applied.
-      return /^LifeOS\/MEMORY\//m.test(content);
+      return /^LIFEOS\/MEMORY\//m.test(content);
     },
     apply: () => {
       throw new Error("m-005 apply not implemented — modify .gitignore in source PR rather than via tool. The detect-only check surfaces missing state.");


### PR DESCRIPTION
`LifeosUpgrade.ts` m-005 detects whether `LIFEOS/MEMORY/` is gitignored, but tests a mixed-case pattern:

```ts
// Already-applied if any LIFEOS/MEMORY/ subpath is gitignored. The current
// policy gitignores LEARNING/, OBSERVABILITY/, STATE/, etc. selectively;
// Phase G may broaden this. For now, we detect "any LIFEOS/MEMORY/ rule" as
// applied.
return /^LifeOS\/MEMORY\//m.test(content);
```

The three comment lines directly above the regex say `LIFEOS/MEMORY/`, the migration's own `name` field says `Phase G — LIFEOS/MEMORY/ in .gitignore`, and the installed tree uses `LIFEOS/`. Only the pattern disagrees.

On a case-sensitive filesystem the check can therefore never match, so a correctly configured install reports m-005 as MISSING permanently — and re-reports it on every `--diagnose` run, with no edit to `.gitignore` able to satisfy it.

### Reproduce

On Linux, with the standard rule present in `.gitignore`:

```
$ grep -n '^LIFEOS/MEMORY/' ~/.claude/.gitignore
265:LIFEOS/MEMORY/

$ bun LIFEOS/TOOLS/LifeosUpgrade.ts --diagnose
  ...
  ✗ MISSING  m-005  Phase G — LIFEOS/MEMORY/ in .gitignore
```

Measured against the same file:

```
lines matching ^LifeOS/MEMORY/   0
lines matching ^LIFEOS/MEMORY/   1
```

macOS hides this: HFS+ and APFS are case-insensitive by default, so the pattern matches there and the migration reports APPLIED.

### Fix

One line — align the pattern with the directory the project actually uses:

```diff
-      return /^LifeOS\/MEMORY\//m.test(content);
+      return /^LIFEOS\/MEMORY\//m.test(content);
```

No behaviour change on macOS, where both forms already match. Detection-only code path; `apply()` is untouched.

Related casing fixes: #1273, #1259, #1175.
