### PR TITLE
fix(voice): honour the volume argument on Linux players

### DIFF
--- a/LifeOS/install/LIFEOS/PULSE/VoiceServer/voice.ts
+++ b/LifeOS/install/LIFEOS/PULSE/VoiceServer/voice.ts
@@ -356,6 +356,15 @@ interface AudioPlayer {
   buildArgs: (file: string, volume: number) => string[]
 }
 
+// `volume` is a multiplier where 1.0 is normal, matching afplay's -v. Each Linux
+// player expresses volume on its own integer scale, so map onto that range and
+// clamp. A non-finite or negative value falls back to the player's normal level
+// rather than silencing playback.
+function scaleVolume(volume: number, max: number): number {
+  if (!Number.isFinite(volume) || volume < 0) return max
+  return Math.min(max, Math.round(volume * max))
+}
+
 let resolvedPlayer: AudioPlayer | null | undefined = undefined
 
 function resolveAudioPlayer(): AudioPlayer | null {
@@ -365,9 +374,30 @@ function resolveAudioPlayer(): AudioPlayer | null {
     process.platform === "darwin"
       ? [{ cmd: "afplay", buildArgs: (file, volume) => ["-v", volume.toString(), file] }]
       : [
-          { cmd: "ffplay", buildArgs: (file) => ["-nodisp", "-autoexit", "-loglevel", "quiet", file] },
+          {
+            cmd: "ffplay",
+            // ffplay -h: "-volume volume  set startup volume 0=min 100=max"
+            buildArgs: (file, volume) => [
+              "-nodisp",
+              "-autoexit",
+              "-loglevel",
+              "quiet",
+              "-volume",
+              String(scaleVolume(volume, 100)),
+              file,
+            ],
+          },
+          // mpg123 scales with -f, but its range was not verified here; left as-is
+          // rather than guessing a factor.
           { cmd: "mpg123", buildArgs: (file) => ["-q", file] },
-          { cmd: "paplay", buildArgs: (file) => [file] },
+          {
+            cmd: "paplay",
+            // paplay --help: "--volume=VOLUME  Specify the initial (linear) volume
+            // in range 0...65536"
+            buildArgs: (file, volume) => [`--volume=${scaleVolume(volume, 65536)}`, file],
+          },
+          // aplay has no volume-set option (only --disable-softvol), so volume
+          // cannot be honoured on this fallback.
           { cmd: "aplay", buildArgs: (file) => ["-q", file] },
         ]
 


### PR DESCRIPTION
`playAudio()` accepts a `volume` multiplier and threads it all the way through to the player:

```ts
const proc = spawn(player.path, player.buildArgs(tempFile, volume))
```

The macOS branch honours it:

```ts
{ cmd: "afplay", buildArgs: (file, volume) => ["-v", volume.toString(), file] }
```

Every Linux candidate declares `buildArgs: (file) => ...` and silently discards the argument:

```ts
{ cmd: "ffplay", buildArgs: (file) => ["-nodisp", "-autoexit", "-loglevel", "quiet", file] },
{ cmd: "mpg123", buildArgs: (file) => ["-q", file] },
{ cmd: "paplay", buildArgs: (file) => [file] },
{ cmd: "aplay",  buildArgs: (file) => ["-q", file] },
```

So per-voice `volume` in the config, and the `volume` field on the notification API, do nothing on Linux — playback is always at system level. There is no error; the value is simply dropped. `FALLBACK_VOLUME = 1.0` and per-voice `entry.volume ?? 1.0` confirm the intended scale is a multiplier where 1.0 is normal, matching afplay's `-v`.

### Fix

Map that multiplier onto each player's own integer scale, taken from the tools' own help output:

```
$ ffplay -h | grep volume
-volume volume      set startup volume 0=min 100=max

$ paplay --help | grep volume
      --volume=VOLUME    Specify the initial (linear) volume in range 0...65536
```

A shared helper clamps and rounds:

```ts
function scaleVolume(volume: number, max: number): number {
  if (!Number.isFinite(volume) || volume < 0) return max
  return Math.min(max, Math.round(volume * max))
}
```

A non-finite or negative value falls back to the player's normal level rather than silencing playback, which seemed the safer failure direction for a notification system.

### Deliberately not changed

- **`aplay`** has no volume-set option — only `--disable-softvol`. Volume cannot be honoured on this fallback.
- **`mpg123`** scales with `-f`, but I could not verify its range on the machine I tested on, and guessing a factor risks making playback quieter for everyone else. Left as-is, with a comment marking it.

Both are noted inline so the gap is visible rather than silent.

### Verification

Flags confirmed present rather than assumed — a deliberately misspelled variant is rejected while the real one is accepted:

```
$ ffplay -nodisp -autoexit -loglevel error -volume 50 tone.mp3     # accepted
$ ffplay -nodisp -autoexit -loglevel error -vollume 50 tone.mp3
Failed to set value '50' for option 'vollume': Option not found

$ paplay --volume=32768 tone.mp3                                    # exit 0
$ paplay --vollume=32768 tone.mp3
paplay: unrecognized option '--vollume=32768'
```

`scaleVolume` covered by unit checks: `1.0 → max`, `0.5 → half`, `0 → 0`, `2.0 → clamped (no amplification)`, `NaN → normal`, `-1 → normal`.

`bun build VoiceServer/voice.ts --target=bun` compiles clean in place.

No change to macOS behaviour — the `darwin` branch is untouched.
