### PR TITLE
fix(memory): pin proposal target_file to the kind's canonical file

### DIFF
--- a/LifeOS/install/LIFEOS/TOOLS/MemorySystem.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/MemorySystem.ts
@@ -57,6 +57,7 @@ import {
   isKnownType,
   resolveStoragePath,
   inferProposalKind,
+  pinProposalTargetFile,
   ALL_TYPES,
   TIER_B_AUDIT_PATH,
   PRINCIPAL_MEMORY_PATH,
@@ -171,6 +172,14 @@ function enqueueProposal(item: TypedItem & { type: "proposal" }): { ok: true; id
   // the Telegram surfacer can render the [kind] badge. Falls back to the
   // path-based inference when the reviewer omits target_kind (legacy compat).
   const targetKind = item.target_kind ?? inferProposalKind(item.target_file);
+  // Pin target_file to the kind's canonical file (see pinProposalTargetFile):
+  // most kinds map to exactly one file, so trusting the reviewer's free-text
+  // path lets a hallucinated path get persisted and then silently mis-file or
+  // fail to apply. null = a multi-file (identity) path outside the allowed set.
+  const targetFile = pinProposalTargetFile(targetKind, item.target_file);
+  if (targetFile === null) {
+    return { ok: false, code: "EINVAL_ITEM", message: `target_file '${item.target_file}' is not an allowed '${targetKind}' target` };
+  }
   try {
     mkdirSync(dirname(path), { recursive: true });
     appendFileSync(
@@ -179,7 +188,7 @@ function enqueueProposal(item: TypedItem & { type: "proposal" }): { ok: true; id
         id,
         ts: new Date().toISOString(),
         status: "pending",
-        target_file: item.target_file,
+        target_file: targetFile,
         target_kind: targetKind,
         edit: item.edit,
         confidence: item.confidence,

--- a/LifeOS/install/LIFEOS/TOOLS/MemoryTypes.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/MemoryTypes.ts
@@ -214,6 +214,26 @@ export function inferProposalKind(targetFile: string): ProposalTargetKind {
   return "identity";
 }
 
+/**
+ * Pin a proposal's target_file to its kind's canonical file.
+ *
+ * Most kinds map to exactly ONE file (PROPOSAL_KIND_TO_FILES), so the target is
+ * fully determined by the kind. The reviewer emits target_file as free text, and
+ * a hallucinated path (wrong casing, a dropped path segment) would otherwise be
+ * persisted and then silently mis-file or fail to apply. For a single-file kind
+ * we therefore ignore the supplied path and return the canonical one. For a
+ * multi-file kind (identity) we can't pin, so we return the supplied path iff it
+ * is one of the allowed files, else null (the caller rejects the proposal rather
+ * than storing an out-of-set path). An unknown kind returns the supplied path
+ * unchanged (the caller validates the kind separately).
+ */
+export function pinProposalTargetFile(kind: ProposalTargetKind, suppliedTargetFile: string): string | null {
+  const allowed = PROPOSAL_KIND_TO_FILES[kind];
+  if (!allowed || allowed.length === 0) return suppliedTargetFile;
+  if (allowed.length === 1) return allowed[0];
+  return allowed.includes(suppliedTargetFile) ? suppliedTargetFile : null;
+}
+
 export function isKnownProposalKind(k: string): k is ProposalTargetKind {
   return (ALL_PROPOSAL_KINDS as readonly string[]).includes(k);
 }
@@ -463,6 +483,19 @@ function smokeTest(): number {
   check("infer: CONTACTS → contacts",             inferProposalKind(CONTACTS_PATH) === "contacts");
   check("infer: unknown path defaults to identity (legacy compat)",
     inferProposalKind("/tmp/random.md") === "identity");
+
+  // 14b. pinProposalTargetFile — single-file kinds pin (supplied path ignored),
+  //      identity validates within its set, out-of-set identity → null (reject).
+  check("pin: operational-rule ignores a hallucinated path → canonical",
+    pinProposalTargetFile("operational-rule", "/Users/anyone/LifeOS/USER/CONFIG/OPERATIONAL_RULES.md") === OPERATIONAL_RULES_PATH);
+  check("pin: style ignores any supplied path → canonical",
+    pinProposalTargetFile("style", "/tmp/whatever.md") === WRITINGSTYLE_PATH);
+  check("pin: identity keeps an in-set path (PRINCIPAL_IDENTITY)",
+    pinProposalTargetFile("identity", PRINCIPAL_IDENTITY_PATH) === PRINCIPAL_IDENTITY_PATH);
+  check("pin: identity keeps an in-set path (DA_IDENTITY)",
+    pinProposalTargetFile("identity", DA_IDENTITY_PATH) === DA_IDENTITY_PATH);
+  check("pin: identity rejects an out-of-set path → null",
+    pinProposalTargetFile("identity", "/tmp/evil.md") === null);
 
   // 15. Known-kind helper
   check("isKnownProposalKind: 'style' true", isKnownProposalKind("style"));


### PR DESCRIPTION
## Problem

Memory proposals carry `target_file` as free text emitted by the reviewer (an LLM). `PROPOSAL_KIND_TO_FILES` already maps most proposal kinds to exactly one canonical file, so the target is fully determined by the kind — yet `enqueueProposal` persists the model's path verbatim.

When the model hallucinates that path (wrong casing, a dropped path segment), the bad path is stored and then either silently mis-files the edit or fails to apply with `target file missing`, reopening the proposal on every review with no resolution.

## Fix

Pin `target_file` to the kind's canonical file at enqueue time via a new pure helper `pinProposalTargetFile(kind, suppliedPath)` in `MemoryTypes.ts`:

- **Single-file kinds** (style, definition, canonical-content, resume, operational-rule, projects, contacts): the supplied path is ignored and the canonical file is used — the model can't misdirect a deterministic target.
- **Multi-file kind** (`identity` → PRINCIPAL_IDENTITY / DA_IDENTITY): can't be pinned, so the supplied path must be one of the two allowed files; otherwise the proposal is rejected with `EINVAL_ITEM` rather than stored with an unresolvable path.
- **Unknown kind**: supplied path returned unchanged (the caller validates the kind separately) — no behavior change.

`enqueueProposal` calls the helper and rejects an out-of-set identity path.

## Testing

`bun MemoryTypes.ts test` — added 5 assertions covering the helper (single-file pin ignores a hallucinated path; identity in-set kept; identity out-of-set → null). Full smoke suite passes (57/57).

## Notes

Backward-compatible: the reverse-path inference default and the existing apply/allowlist behavior are unchanged; this only stops a hallucinated path from being persisted at the source.