### PR TITLE
fix(doctor): detect browsers installed via Nix, Home Manager, or PATH

### DIFF
--- a/LifeOS/install/LIFEOS/TOOLS/Doctor.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/Doctor.ts
@@ -119,13 +119,24 @@ function envKey(name: string): string | null {
   return null;
 }
 
+function whichPath(bin: string): string | null {
+  const hit = (process.env.PATH || '').split(':').find(p => p && existsSync(join(p, bin)));
+  return hit ? join(hit, bin) : null;
+}
+
 function chromeBinary(): string | null {
   const candidates = [
     '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    '/Applications/Nix Apps/Google Chrome.app/Contents/MacOS/Google Chrome',
     '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
+    '/Applications/Nix Apps/Brave Browser.app/Contents/MacOS/Brave Browser',
     '/usr/bin/google-chrome', '/usr/bin/chromium', '/usr/bin/chromium-browser',
   ];
-  return candidates.find(existsSync) || null;
+  // Nix/Home Manager installs expose the browser on PATH rather than in /Applications
+  return candidates.find(existsSync)
+    || whichPath('google-chrome') || whichPath('chromium')
+    || whichPath('brave') || whichPath('brave-browser')
+    || null;
 }
 
 // ── capability registry ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`Doctor.ts`'s `chromeBinary()` only probes legacy install locations:

- `/Applications/Google Chrome.app` / `/Applications/Brave Browser.app`
- `/usr/bin/google-chrome`, `/usr/bin/chromium`, `/usr/bin/chromium-browser`

On machines where the browser is installed declaratively — nix-darwin / Home Manager put GUI apps under `/Applications/Nix Apps/` and expose the binary on PATH (e.g. `/run/current-system/sw/bin/google-chrome`) — none of these candidates exist, so Doctor reports:

```
✗ Browser verification (Interceptor) — broken
  no Chrome/Brave/Chromium binary found
```

…even though Chrome is installed and fully working. The cached "broken" verdict (7-day TTL in `capabilities.json`) then steers sessions into declaring Interceptor unusable and suggesting a redundant Chrome install.

## Fix

Two additions to `chromeBinary()`, no behavior change on machines where the current paths already match:

1. Add the `/Applications/Nix Apps/` locations for Chrome and Brave to the candidate list.
2. Fall back to a PATH lookup via a small `whichPath()` helper (like the existing `which()`, but returning the resolved path — the probe's detail string does `browser.split('/')`, so the fallback must yield a string, not a boolean). Covers `google-chrome`, `chromium`, `brave`, and `brave-browser` — the last also fixes the Linux-Brave false negative reported in #1496 (item 3), which was closed without the fix landing: `/usr/bin` is on PATH, so the lookup finds `/usr/bin/brave-browser` without more hardcoded candidates.

## Testing

On a nix-darwin machine with Chrome installed via Home Manager (`/Applications/Nix Apps/Google Chrome.app`, binary on PATH):

- Before: `✗ Browser verification (Interceptor) — broken — no Chrome/Brave/Chromium binary found`
- After: `✅ Browser verification (Interceptor) — live — skill present, browser found (Google Chrome)`

Unchanged on a machine with a standard `/Applications/Google Chrome.app` install (first candidate still wins).
