### PR TITLE
docs(delegation): subagent fan-out is capped at 20 since Claude Code 2.1.217

### DIFF
--- a/LifeOS/install/LIFEOS/DOCUMENTATION/Delegation/DelegationSystem.md
+++ b/LifeOS/install/LIFEOS/DOCUMENTATION/Delegation/DelegationSystem.md
@@ -64,7 +64,9 @@ Agent({ prompt: "System design / distributed systems. Design the distributed cac
 Use the Agents skill to compose task-specific agents with unique traits, voices, and expertise:
 - Use a SINGLE message with MULTIPLE Agent tool calls
 - Each agent gets FULL CONTEXT and DETAILED INSTRUCTIONS via ComposeAgent prompt
-- Launch as many as needed (no artificial limit)
+- Launch as many as the work needs, but design around two runtime ceilings (Claude Code 2.1.217+):
+  - **Concurrency caps at 20 running subagents.** Excess spawns are denied, not queued — a fan-out wider than 20 silently loses the overflow unless `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` is raised in `settings.json`.
+  - **Subagents cannot spawn subagents by default.** Nested delegation is off; raise `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH` if a pattern genuinely needs a second tier.
 - **ALWAYS launch a spotcheck agent after parallel work completes**
 
 **Agent routing by task type:**


### PR DESCRIPTION
## Problem

`DelegationSystem.md` line 67 tells readers:

> - Launch as many as needed (no artificial limit)

That is no longer true, and the way it fails is silent.

## Why it matters

**Claude Code 2.1.217** introduced two runtime ceilings on subagents:

- A cap of **20 concurrently-running subagents**. Once reached, further spawns are **denied, not queued** — a fan-out wider than 20 loses the overflow with no error surfaced to the reader who followed this doc.
- **Nested spawning is disabled by default** — a subagent can no longer spawn subagents.

Both are overridable, but only if you know they exist. A delegation guide that promises no limit leads users to design swarm patterns that quietly execute partially. The failure mode is the dangerous kind: it looks like it worked.

## Fix

Replaces the bare claim with the two ceilings and names the override for each:

- `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS`
- `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH`

Documentation-only change; no behavior is modified.

## Affected versions

Introduced in Claude Code **2.1.217**. Any LifeOS install running 2.1.217 or later is affected.
