### PR TITLE
docs(skills): document context/background; opt Knowledge out of 2.1.218 background default

### DIFF
--- a/LifeOS/install/LIFEOS/DOCUMENTATION/Skills/SkillSystem.md
+++ b/LifeOS/install/LIFEOS/DOCUMENTATION/Skills/SkillSystem.md
@@ -225,6 +225,22 @@ science_cycle_time: meso         # Optional: micro | meso | macro
 - **Max 500 characters recommended, 650 hard ceiling.** Claude Code has a total character budget for all skill descriptions combined. In practice, descriptions over ~650 chars cause skills to be silently dropped from the session listing — the skill becomes invisible and unroutable. Keep descriptions tight: brief prose summary + USE WHEN trigger keywords. Move detailed explanations to the SKILL.md body, not the YAML description.
 - **NO separate `triggers:` or `workflows:` arrays in YAML**
 
+**Execution-shape fields — `context` and `background`.**
+
+| Field | Values | Meaning |
+|-------|--------|---------|
+| `context` | `inline` \| `fork` | Where the skill runs. `inline` expands into the current conversation; `fork` spawns a subagent. Omit for `inline`. |
+| `background` | `true` \| `false` | Whether a forked skill runs detached. Only meaningful alongside `context: fork`. |
+
+**Gotcha (Claude Code 2.1.218):** `context: fork` skills now run in the **background by default** — previously they blocked the main thread. A forked skill returns via task notification rather than inline output, so any skill whose result the *same turn* depends on must opt out explicitly:
+
+```yaml
+context: fork
+background: false
+```
+
+The test: would the user ask this skill a question and expect the answer in that turn? If yes, set `background: false`. Long-running deliberation skills (research, debate, evaluation) should keep the background default — detaching them is the point.
+
 ### Science Protocol Compliance (Optional)
 
 Skills that involve systematic investigation, iteration, or evidence-based improvement can declare Science Protocol compliance:

--- a/LifeOS/install/skills/Knowledge/SKILL.md
+++ b/LifeOS/install/skills/Knowledge/SKILL.md
@@ -5,6 +5,7 @@ description: "Manage the LifeOS Knowledge Archive — a curated, typed graph of 
 argument-hint: [search|add|harvest|develop|ingest|contradictions|graph|retrieve|mine|<query>]
 effort: low
 context: fork
+background: false
 ---
 
 # Knowledge Skill


### PR DESCRIPTION
## Problem

Two related gaps:

1. `SkillSystem.md` documents the skill frontmatter contract but never mentions `context:` or `background:` — despite seven shipped skills declaring `context: fork`.
2. `skills/Knowledge/SKILL.md` declares `context: fork` with no `background` value, so it inherits a default that changed underneath it.

## Why it matters

**Claude Code 2.1.218** changed skills declaring `context: fork` to run as **background subagents by default**. Previously they blocked the main thread.

A backgrounded skill returns via task notification rather than inline output. For long-running deliberation skills that is an improvement — detaching them is the point. But `Knowledge` is an interactive lookup skill (`effort: low`, argument-hint `[search|...|retrieve|<query>]`). A user asking *"what do we know about X"* expects the answer in that turn. Backgrounded, it doesn't arrive there.

Because neither field was documented, there was no way to discover the opt-out short of reading the changelog.

## Fix

- Documents `context` and `background` in `SkillSystem.md` with a field table and the 2.1.218 gotcha, plus the test for which way to set it.
- Adds `background: false` to `Knowledge` only.

The other six fork skills — Council, Evals, Ideate, Research, RootCauseAnalysis, SystemsThinking — are all `effort: high` deliberation and are deliberately left on the new background default.

## Affected versions

Introduced in Claude Code **2.1.218**. `background` is a real parsed frontmatter field in that build, verified against the shipped binary.
