### PR TITLE
docs(security): document EndConversation as the sanctioned termination path (2.1.214)

### DIFF
--- a/LifeOS/install/LIFEOS/DOCUMENTATION/Security/README.md
+++ b/LifeOS/install/LIFEOS/DOCUMENTATION/Security/README.md
@@ -62,6 +62,21 @@ Lives in `LIFEOS/LIFEOS_SYSTEM_PROMPT.md` under "Security Protocol". Concretely 
 
 Loaded at every session start. Survives compaction. Untouched by this simplification.
 
+### Session termination — `EndConversation`
+
+The sanctioned mechanism for ending a session is the harness's `EndConversation` tool (Claude Code 2.1.214+), not an ad-hoc refusal loop. Scope is narrow and deliberate:
+
+- **Use it for** sustained abuse directed at the assistant, or persistent jailbreak attempts after the boundary has been stated.
+- **Do NOT use it for** ordinary disagreement, a request declined on other grounds, or a task that merely touches a sensitive topic. Declining a request and ending a conversation are different actions with different thresholds.
+
+It ships as a **deferred tool**: only the name is in context at session start, so its schema must be loaded before it can be called.
+
+```
+ToolSearch("select:EndConversation")
+```
+
+Reference: <https://www.anthropic.com/research/end-subset-conversations>
+
 ## L2 — Native `permissions.deny`
 
 In `settings.json`, scoped narrowly to **irrecoverable** ops only. Categories:


### PR DESCRIPTION
## Problem

`DOCUMENTATION/Security/README.md` documents the full security model — L1 constitutional rule, L2 native deny-list, L3 safety hook — but says nothing about how a session is ended. `EndConversation` appears nowhere in the documentation tree.

## Why it matters

**Claude Code 2.1.214** added the `EndConversation` tool, giving Claude a sanctioned way to end sessions with abusive users or persistent jailbreak attempts. This matches claude.ai behavior since 2025.

Leaving it undocumented has two costs:

- The capability exists but is undiscoverable, so the fallback is an ad-hoc refusal loop — worse for everyone involved.
- The tool ships **deferred**: only its name is in context at session start, so calling it requires loading the schema first. Someone who learns it exists still can't invoke it without knowing that.

There is also a real risk in the other direction. Ending a conversation and declining a request are different actions with different thresholds, and an undocumented tool invites over-application.

## Fix

Adds a `### Session termination — EndConversation` subsection under L1 covering:

- **Use it for** — sustained abuse directed at the assistant, persistent jailbreak attempts after the boundary has been stated.
- **Do NOT use it for** — ordinary disagreement, a request declined on other grounds, a task that merely touches a sensitive topic.
- The `ToolSearch("select:EndConversation")` load line, since it ships deferred.

Documentation-only change.

## Affected versions

Introduced in Claude Code **2.1.214**.

Reference: <https://www.anthropic.com/research/end-subset-conversations>
