### PR TITLE
docs(security): Write(path) deny rules are never matched — use Edit(path)

### DIFF
--- a/LifeOS/install/LIFEOS/DOCUMENTATION/Security/README.md
+++ b/LifeOS/install/LIFEOS/DOCUMENTATION/Security/README.md
@@ -71,7 +71,7 @@ In `settings.json`, scoped narrowly to **irrecoverable** ops only. Categories:
 - Pipe-to-shell: `curl|sh`, `wget|bash`, etc.
 - Force-push to main/master: `git push --force * main`
 - Permission bombs: `chmod -R 777 /`, fork bomb
-- System-root file writes: `Edit(/etc/**)`, `Write(/usr/**)`, etc.
+- System-root file writes: `Edit(/etc/**)`, `Edit(/usr/**)`, etc. (`Edit(path)` rules govern Edit, Write, and NotebookEdit alike; a bare `Write(path)` rule is accepted but never matched by file permission checks, so it must not be used)
 - Credential reads: SSH private keys, cloud credentials, GPG private keyring
 
 Intentionally **NOT** denied: `rm -rf node_modules`, `git reset --hard`, `chmod` on user files. These are recoverable; the model's judgment plus the constitutional rule are sufficient.


### PR DESCRIPTION
## Problem

`DOCUMENTATION/Security/README.md` line 74 documents the deny-list category as:

> - System-root file writes: `Edit(/etc/**)`, `Write(/usr/**)`, etc.

The `Write(path)` form does not do what the doc implies. It is accepted into the settings file and then **never matched** by file permission checks.

## Why it matters

This is a security doc describing a deny-list. A rule that silently never matches is worse than a missing rule, because it reads as coverage that isn't there. Anyone copying this pattern writes deny rules believing `/usr/**` is protected when nothing is enforcing it.

The actual contract:

| Rule form | Governs | Matched? |
|---|---|---|
| `Edit(path)` | Edit, Write, NotebookEdit | yes |
| `Write(path)` | — | **no** |

An `Edit(path)` rule already covers all file-editing tools, so `Write(path)` is never the right choice — not in `deny`, not in `allow`, not in `ask`.

**Claude Code 2.1.210** added a startup warning for each unmatched rule of this shape, which is how this surfaces in practice: one warning line per offending rule, every session.

## Fix

Corrects the example to `Edit(/usr/**)` and states the contract inline so the pattern isn't copied forward.

Documentation-only change.

## Affected versions

The matching behavior predates the warning; the **2.1.210** startup warning is what makes it visible. Any install on 2.1.210 or later will see warnings for rules written in the documented shape.
