### PR TITLE
fix(installer): bun install nested runtime packages so Pulse can start

### DIFF
--- a/LifeOS/Tools/DeployCore.ts
+++ b/LifeOS/Tools/DeployCore.ts
@@ -43,7 +43,7 @@ function arg(a: string[], flag: string): string | undefined {
 }
 
 interface DeployResult {
-  what: "skills" | "runtime" | "memory" | "dependencies";
+  what: "skills" | "runtime" | "memory" | "dependencies" | "nested-dependencies";
   src: string;
   dst: string;
   present: boolean;
@@ -164,6 +164,81 @@ function deployDependencies(payloadInstall: string, configRoot: string, apply: b
   return r;
 }
 
+/**
+ * (e) nested runtime deps: several directories INSIDE the deployed runtime tree
+ * ship their OWN package.json (LIFEOS/PULSE, LIFEOS/PULSE/Observability,
+ * LIFEOS/TOOLS, ...) — declaring a dependency there does not make bun/node
+ * resolve it. Module resolution stops walking up at the first ancestor
+ * directory that owns a package.json, so the shared configRoot/node_modules
+ * deployDependencies() just installed never satisfies these. This is exactly
+ * why a fresh install dies with `Cannot find package 'smol-toml'` on `bun run
+ * pulse.ts`: LIFEOS/PULSE/package.json lists smol-toml correctly, but nothing
+ * ever ran `bun install` inside LIFEOS/PULSE/. Walk the deployed runtime tree
+ * for every package.json (skipping node_modules/.git) and `bun install --cwd`
+ * each one it finds. The Observability dashboard additionally needs a build —
+ * it ships as a Next.js static export (Observability/out/index.html) that
+ * pulse.ts itself already detects as missing and reports as a copy-paste fix
+ * command; building it here just does that automatically instead of leaving
+ * every fresh Pulse install to 503 until the human runs it by hand.
+ */
+function findNestedDependencyDirs(runtimeDst: string): string[] {
+  const found: string[] = [];
+  const walk = (dir: string): void => {
+    if (!existsSync(dir)) return;
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === "node_modules" || entry.name === ".git") continue;
+      const p = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(p);
+      } else if (entry.isFile() && entry.name === "package.json") {
+        found.push(dir);
+      }
+    }
+  };
+  walk(runtimeDst);
+  return found.sort();
+}
+
+function deployNestedDependencies(configRoot: string, apply: boolean): DeployResult {
+  const runtimeDst = join(configRoot, "LIFEOS");
+  const r: DeployResult = {
+    what: "nested-dependencies", src: runtimeDst, dst: runtimeDst,
+    present: existsSync(runtimeDst), copied: 0, actions: [], blockers: [], failures: [],
+  };
+  if (!r.present) return r; // runtime not deployed yet — deployRuntime() already reports that blocker
+
+  const dirs = findNestedDependencyDirs(runtimeDst);
+  for (const dir of dirs) {
+    const isObservability = dir === join(runtimeDst, "PULSE", "Observability");
+    const needsBuild = isObservability && !existsSync(join(dir, "out", "index.html"));
+
+    if (!apply) {
+      r.actions.push(`bun install --cwd ${dir}`);
+      if (needsBuild) r.actions.push(`bun run build --cwd ${dir}`);
+      continue;
+    }
+
+    const proc = Bun.spawnSync(["bun", "install"], { cwd: dir, stdout: "pipe", stderr: "pipe" });
+    if (proc.exitCode !== 0) {
+      r.failures.push(`bun install --cwd ${dir} exited ${proc.exitCode}: ${proc.stderr.toString().trim()}`);
+      continue;
+    }
+    r.copied++;
+    r.actions.push(`bun install --cwd ${dir}`);
+
+    // Build the Observability dashboard once its deps resolve — see comment above.
+    if (needsBuild) {
+      const build = Bun.spawnSync(["bun", "run", "build"], { cwd: dir, stdout: "pipe", stderr: "pipe" });
+      if (build.exitCode !== 0) {
+        r.failures.push(`bun run build --cwd ${dir} exited ${build.exitCode}: ${build.stderr.toString().trim()}`);
+      } else {
+        r.actions.push(`bun run build --cwd ${dir}`);
+      }
+    }
+  }
+  return r;
+}
+
 function main(): void {
   const a = process.argv.slice(2);
   const home = process.env.HOME || homedir();
@@ -187,6 +262,7 @@ function main(): void {
     deployRuntime(payloadInstall, configRoot, apply),
     scaffoldMemory(configRoot, apply),
     deployDependencies(payloadInstall, configRoot, apply),
+    deployNestedDependencies(configRoot, apply),
   ];
 
   // A missing required payload source (blocker) or a copy failure is a hard

--- a/LifeOS/install/skills/LifeOS/Tools/DeployCore.ts
+++ b/LifeOS/install/skills/LifeOS/Tools/DeployCore.ts
@@ -43,7 +43,7 @@ function arg(a: string[], flag: string): string | undefined {
 }
 
 interface DeployResult {
-  what: "skills" | "runtime" | "memory" | "dependencies";
+  what: "skills" | "runtime" | "memory" | "dependencies" | "nested-dependencies";
   src: string;
   dst: string;
   present: boolean;
@@ -164,6 +164,81 @@ function deployDependencies(payloadInstall: string, configRoot: string, apply: b
   return r;
 }
 
+/**
+ * (e) nested runtime deps: several directories INSIDE the deployed runtime tree
+ * ship their OWN package.json (LIFEOS/PULSE, LIFEOS/PULSE/Observability,
+ * LIFEOS/TOOLS, ...) — declaring a dependency there does not make bun/node
+ * resolve it. Module resolution stops walking up at the first ancestor
+ * directory that owns a package.json, so the shared configRoot/node_modules
+ * deployDependencies() just installed never satisfies these. This is exactly
+ * why a fresh install dies with `Cannot find package 'smol-toml'` on `bun run
+ * pulse.ts`: LIFEOS/PULSE/package.json lists smol-toml correctly, but nothing
+ * ever ran `bun install` inside LIFEOS/PULSE/. Walk the deployed runtime tree
+ * for every package.json (skipping node_modules/.git) and `bun install --cwd`
+ * each one it finds. The Observability dashboard additionally needs a build —
+ * it ships as a Next.js static export (Observability/out/index.html) that
+ * pulse.ts itself already detects as missing and reports as a copy-paste fix
+ * command; building it here just does that automatically instead of leaving
+ * every fresh Pulse install to 503 until the human runs it by hand.
+ */
+function findNestedDependencyDirs(runtimeDst: string): string[] {
+  const found: string[] = [];
+  const walk = (dir: string): void => {
+    if (!existsSync(dir)) return;
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === "node_modules" || entry.name === ".git") continue;
+      const p = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(p);
+      } else if (entry.isFile() && entry.name === "package.json") {
+        found.push(dir);
+      }
+    }
+  };
+  walk(runtimeDst);
+  return found.sort();
+}
+
+function deployNestedDependencies(configRoot: string, apply: boolean): DeployResult {
+  const runtimeDst = join(configRoot, "LIFEOS");
+  const r: DeployResult = {
+    what: "nested-dependencies", src: runtimeDst, dst: runtimeDst,
+    present: existsSync(runtimeDst), copied: 0, actions: [], blockers: [], failures: [],
+  };
+  if (!r.present) return r; // runtime not deployed yet — deployRuntime() already reports that blocker
+
+  const dirs = findNestedDependencyDirs(runtimeDst);
+  for (const dir of dirs) {
+    const isObservability = dir === join(runtimeDst, "PULSE", "Observability");
+    const needsBuild = isObservability && !existsSync(join(dir, "out", "index.html"));
+
+    if (!apply) {
+      r.actions.push(`bun install --cwd ${dir}`);
+      if (needsBuild) r.actions.push(`bun run build --cwd ${dir}`);
+      continue;
+    }
+
+    const proc = Bun.spawnSync(["bun", "install"], { cwd: dir, stdout: "pipe", stderr: "pipe" });
+    if (proc.exitCode !== 0) {
+      r.failures.push(`bun install --cwd ${dir} exited ${proc.exitCode}: ${proc.stderr.toString().trim()}`);
+      continue;
+    }
+    r.copied++;
+    r.actions.push(`bun install --cwd ${dir}`);
+
+    // Build the Observability dashboard once its deps resolve — see comment above.
+    if (needsBuild) {
+      const build = Bun.spawnSync(["bun", "run", "build"], { cwd: dir, stdout: "pipe", stderr: "pipe" });
+      if (build.exitCode !== 0) {
+        r.failures.push(`bun run build --cwd ${dir} exited ${build.exitCode}: ${build.stderr.toString().trim()}`);
+      } else {
+        r.actions.push(`bun run build --cwd ${dir}`);
+      }
+    }
+  }
+  return r;
+}
+
 function main(): void {
   const a = process.argv.slice(2);
   const home = process.env.HOME || homedir();
@@ -187,6 +262,7 @@ function main(): void {
     deployRuntime(payloadInstall, configRoot, apply),
     scaffoldMemory(configRoot, apply),
     deployDependencies(payloadInstall, configRoot, apply),
+    deployNestedDependencies(configRoot, apply),
   ];
 
   // A missing required payload source (blocker) or a copy failure is a hard


### PR DESCRIPTION
## Problem

On a fresh install, **Pulse dies on startup**:
```
error: Cannot find package 'smol-toml' from '.../LIFEOS/PULSE/pulse.ts'
```
`smol-toml` *is* correctly declared in `LIFEOS/PULSE/package.json`. The bug is not a missing manifest entry — it is that the installer never runs `bun install` **inside the nested package**.

Several directories in the deployed runtime ship their own `package.json` (`LIFEOS/PULSE/`, `LIFEOS/PULSE/Observability/`, `LIFEOS/TOOLS/`, …). Node/Bun module resolution stops walking up at the first ancestor that owns a `package.json`, so the shared `node_modules` the installer creates at the config root never satisfies these nested packages. Each needs its own `bun install`.

The Observability dashboard has a second layer of the same problem: it ships as a Next.js static export (`Observability/out/index.html`) that must be **built**. Until it is, `pulse.ts` reports `status: degraded` and the dashboard route returns HTTP 503.

## Reproduction

1. Fresh install.
2. `bun run pulse.ts` → dies on `Cannot find package 'smol-toml'`.
3. After manually `bun install`-ing `LIFEOS/PULSE/`, Pulse starts but `GET /` 503s until `Observability/` is installed and built.

## Fix

Adds a `nested-dependencies` deploy step to `DeployCore.ts` that, after the existing dependency step:
- walks the deployed runtime tree for every `package.json` (skipping `node_modules`/`.git`) and runs `bun install --cwd <dir>` on each;
- additionally runs `bun run build` for the Observability dashboard when its static export is missing.

Respects the existing `--apply` / dry-run contract (dry-run lists the exact `bun install` / `bun run build` commands it would run) and records per-package failures without aborting the whole deploy.

## Files
- `LifeOS/Tools/DeployCore.ts`
- `LifeOS/install/skills/LifeOS/Tools/DeployCore.ts` (install-payload mirror)
