### PR TITLE
Clean up stray legacy PAI/Kai branding remnants (cosmetic only)

### DIFF
--- a/LifeOS/install/skills/Art/Tools/Generate.ts
+++ b/LifeOS/install/skills/Art/Tools/Generate.ts
@@ -724,7 +724,7 @@ async function addBackgroundColor(inputPath: string, outputPath: string, hexColo
  * thumbnail is derived, so the signature lands on BOTH versions.
  * Pointsize scales with image width so it reads at any resolution.
  */
-async function stampKaiSignature(imagePath: string): Promise<void> {
+async function stampDaSignature(imagePath: string): Promise<void> {
   // Derive pointsize from the image width (≈3% of width; 1024px → ~31pt —
   // 2026-07-09: reduced from 4.5% so it reads as a painter's mark, not a label).
   let pointsize = 31;
@@ -1194,7 +1194,7 @@ async function main(): Promise<void> {
     const signatureDefault = args.workflow === "Essay" || args.thumbnail === true;
     const stampSignature = args.signature ?? signatureDefault;
     if (stampSignature) {
-      await stampKaiSignature(actualOutput);
+      await stampDaSignature(actualOutput);
     }
 
     // Generate thumbnail with background color if requested (blog header mode)

--- a/LifeOS/install/skills/CreateCLI/SKILL.md
+++ b/LifeOS/install/skills/CreateCLI/SKILL.md
@@ -228,7 +228,7 @@ Every generated CLI follows:
 **Usage:**
 ```bash
 ghcli repos --user exampleuser
-ghcli issues create --repo pai --title "Bug fix"
+ghcli issues create --repo myrepo --title "Bug fix"
 ghcli search "typescript CLI"
 ghcli --help
 ```

--- a/LifeOS/install/skills/LifeOS/install/settings.enhancements.json
+++ b/LifeOS/install/skills/LifeOS/install/settings.enhancements.json
@@ -665,7 +665,7 @@
       "settings.json is the single source of truth for all LifeOS configuration.",
       "daidentity in settings.json controls {{DA_NAME}}'s name, color, voice, and personality.",
       "principal in settings.json stores your name, timezone, and voice clone.",
-      "The statusline command runs from PAI/LIFEOS_StatusLine.sh.",
+      "The statusline command runs from LIFEOS/LIFEOS_StatusLine.sh.",
       "Personality traits (0-100) shape how emotions are expressed vocally.",
       "Never hardcode paths. Use ${LIFEOS_DIR}, ${PROJECTS_DIR}, {PRINCIPAL.NAME}.",
       "Interceptor-first: if you haven't SEEN it with the Interceptor skill, you can't claim it works.",

--- a/LifeOS/install/skills/Remotion/Tools/Theme.ts
+++ b/LifeOS/install/skills/Remotion/Tools/Theme.ts
@@ -102,10 +102,10 @@ export const LIFEOS_THEME = {
 } as const
 
 // Type exports
-export type PAITheme = typeof LIFEOS_THEME
-export type PAIColors = typeof LIFEOS_THEME.colors
-export type PAITypography = typeof LIFEOS_THEME.typography
-export type PAIAnimation = typeof LIFEOS_THEME.animation
+export type LifeosTheme = typeof LIFEOS_THEME
+export type LifeosColors = typeof LIFEOS_THEME.colors
+export type LifeosTypography = typeof LIFEOS_THEME.typography
+export type LifeosAnimation = typeof LIFEOS_THEME.animation
 
 // Utility: Get interpolate input/output for fade
 export const fadeInterpolation = (startFrame = 0) => ({


### PR DESCRIPTION
## Summary

Cleans up a small number of stray legacy "PAI"/"Kai" branding remnants in the skills — verified individually against this repo's own content, not a find-and-replace.

Each candidate string was classified as either a **cosmetic remnant** (safe to modernize — prose/identifier with no functional effect) or a **functional identifier** (a real path, trigger phrase, or flow name that code/users actually depend on). Only the cosmetic ones are changed here.

## Changes

| File | Change | Why it's safe |
|---|---|---|
| `LifeOS/install/skills/Art/Tools/Generate.ts` | `stampKaiSignature` → `stampDaSignature` | Private, non-exported function, only one call site, both in this same file. The text it actually stamps is already the generic `{{DA_NAME}}` template — only the internal function *name* still said "Kai". |
| `LifeOS/install/skills/Remotion/Tools/Theme.ts` | `PAITheme`/`PAIColors`/`PAITypography`/`PAIAnimation` → `LifeosTheme`/`LifeosColors`/`LifeosTypography`/`LifeosAnimation` | Repo-wide search shows these exported type aliases are referenced nowhere else in the repo — dead branding left behind by the codebase's earlier `Pai*` → `Lifeos*` identifier sweep, which appears to have missed this file. |
| `LifeOS/install/skills/CreateCLI/SKILL.md` | Example `--repo pai` → `--repo myrepo` | Purely an illustrative value in a usage example, not a real repo/flag/identifier. |
| `LifeOS/install/skills/LifeOS/install/settings.enhancements.json` | Fact string `"...runs from PAI/LIFEOS_StatusLine.sh."` → `"...runs from LIFEOS/LIFEOS_StatusLine.sh."` | Stale doc string — the repo's own install layout and deploy code (`LifeOS/Tools/DeployComponents.ts`) use `LIFEOS/` throughout with zero `PAI` references, so the fact told to the DA no longer matched reality. This file is JSON, not `.md`, so it fell outside the repo's earlier "prose branding" doc sweep. |

## Found but intentionally NOT changed — why

These all matched "PAI"/"Kai" but are load-bearing, not cosmetic:

- **`Knowledge/SKILL.md`** — references `pai-knowledge-linking-architecture.md`. This file also appears to be missing/dangling already; renaming the reference wouldn't fix that, and could make the drift harder to spot. Left for a maintainer to resolve directly.
- **`Interceptor/SKILL.md`** — `/tmp/pai-screenshots/`. Verified functional: `install/hooks/ContextReduction.hook.sh` literally does `mkdir -p /tmp/pai-screenshots && cd`'s there before rewriting Interceptor `--save` calls. Renaming the doc without touching the hook would break the documented behavior.
- **`Upgrade/SKILL.md`** — `"pai upgrade"` in the `USE WHEN` trigger list. A real, user-typed trigger phrase; removing it silently drops a working trigger.
- **`CreateSkill/Workflows/CreateSkill.md` and `UpdateSkill.md`** — `` `UpdateKaiRepo` `` ship-flow name, invoked by the (templated-out) private release skill at version-bump time. A real flow name, not prose.
- **`Daemon/Tools/SecurityFilter.ts`** — `(?:LIFEOS|PAI)/USER/`, `(?:LIFEOS|PAI)/MEMORY/`, `PAI/Algorithm/v[\d.]+\.md` regexes. Deliberate dual-branding patterns in the public-daemon-profile security scrubber — removing `PAI` narrows what gets redacted. Security-relevant, not cosmetic.
- **`Daemon/Tools/DaemonAggregator.ts`** — `thesis.match(/PAI\/|hooks\/|.../)` gates which knowledge ideas get treated as "internal architecture" and skipped. Changing the pattern changes filtering behavior; out of scope for a branding-only PR (possibly worth its own look — it doesn't also match `LIFEOS/`).
- **`LifeOS/Tools/InstallEngine.ts`** — comments describing detection of "a prior LifeOS/PAI install". These correctly document real backward-compatibility logic for legacy installs; not a remnant.

No filesystem paths, usernames, or credentials from any local environment are referenced anywhere in this diff.
