### PR TITLE
Restore hook registrations dropped in the 2026-07-11 consolidation (LoopDetector / DriftReminder / AlgorithmNudge)

### DIFF
--- a/LifeOS/install/hooks/hooks.json
+++ b/LifeOS/install/hooks/hooks.json
@@ -136,6 +136,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "$HOME/.claude/hooks/PostToolObserver.hook.ts",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "$HOME/.claude/hooks/EventLogger.hook.ts",
             "timeout": 5,
             "async": true
@@ -208,8 +213,28 @@
         "hooks": [
           {
             "type": "command",
+            "command": "$HOME/.claude/hooks/DriftReminder.hook.ts",
+            "timeout": 5,
+            "async": true
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
             "command": "$HOME/.claude/hooks/MemoryTurnStart.hook.ts",
             "timeout": 8
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/AlgorithmNudge.hook.ts",
+            "timeout": 5,
+            "async": true
           }
         ]
       }


### PR DESCRIPTION
The 2026-07-11 "hooks-BPE consolidation" (per `LIFEOS/DOCUMENTATION/Hooks/HookSystem.md`) built per-event dispatcher hooks but never registered three of them in the shipped install payload (`LifeOS/install/hooks/hooks.json`, the sole source `Tools/InstallHooks.ts` merges into a user's `settings.json`), even though `HookSystem.md` documents all three as registered and live. This PR brings the shipped config back in line with the docs.

### 1. `PostToolObserver.hook.ts` — missing from `PostToolUse`
`HookSystem.md:322` documents it in the `PostToolUse` catch-all group (sync, `timeout: 5`, ahead of `EventLogger.hook.ts`). `HookSystem.md:343-345` describes it as the dispatcher that bundles `LoopDetector.run()` (exact-repeat / oscillation / hammering detection) and the PostToolUse branch of `AlgorithmNudge.run()`.

**User-visible effect of the gap:** unregistered, `LoopDetector` never runs — no detection of repeat/oscillation/hammering tool-call patterns.

**Fix:** added to the existing `matcher:""` catch-all group in `PostToolUse` (not a new group — a second empty-matcher group would cause a merge dupe on `InstallHooks.ts`'s idempotent-merge), ahead of `EventLogger.hook.ts`, matching the documented order exactly.

### 2. `DriftReminder.hook.ts` — missing from `UserPromptSubmit`
`HookSystem.md:142` documents it registered on `UserPromptSubmit` (`timeout: 5`, `async: true`). `HookSystem.md:168-170` describes it as the deterministic voice/format drift nudge (banned-vocab regex, banner-presence check, em-dash count against the Stop-hook last-response cache; no LLM calls).

**User-visible effect of the gap:** the voice/format drift check other live hooks and the system prompt assume is running never fires.

**Fix:** added to `UserPromptSubmit`, positioned per the documented fire order.

### 3. `AlgorithmNudge.hook.ts` — missing its `UserPromptSubmit` registration
`HookSystem.md:144` documents it registered on `UserPromptSubmit` (`timeout: 5`, `async: true`) *in addition to* its existing `PostToolUseFailure` registration (unchanged by this PR — still present, not duplicated). `HookSystem.md:1562` states explicitly: "the UserPromptSubmit chain is 6 hooks (`PromptProcessing`, `SatisfactionCapture`, `ReminderRouter`, `DriftReminder`, `MemoryTurnStart`, `AlgorithmNudge`)" — the shipped payload only had 4.

**User-visible effect of the gap:** per `HookSystem.md:178-183`, the `UserPromptSubmit` branch is what fires the always-on skill-routing nudge ("prompt matches a skill's USE WHEN → invoke, don't handroll") and, in a live Algorithm run, the principal-message nudge — both dead without this registration. It is also documented as the sole writer of `state.primaryTranscript` on this path, which other `AlgorithmNudge` branches use to gate subagent-noise suppression — missing it leaves that gate failing open.

**Fix:** added to `UserPromptSubmit` at the position `HookSystem.md:1562` documents (last in the chain), leaving the `PostToolUseFailure` registration untouched.

---

**Scope note:** only `LifeOS/install/hooks/hooks.json` needed changes — it is the single authoritative hook-registration payload (`InstallHooks.ts` merges only this file into `settings.json`; `settings.system.json` / `settings.enhancements.json` carry no `hooks` key, and there is no second copy of `hooks.json` elsewhere in the tree, so no parallel mirror needed updating).

Diff is additive-only: three new hook entries, no existing entries removed, reordered, or duplicated.
