### PR TITLE
fix(pulse): memory-consolidation must be a script job, not type:claude

### DIFF
--- a/LifeOS/install/LIFEOS/PULSE/PULSE.toml
+++ b/LifeOS/install/LIFEOS/PULSE/PULSE.toml
@@ -138,9 +138,12 @@ enabled = true
 [[job]]
 name = "memory-consolidation"
 schedule = "0 3 * * *"
-type = "claude"
-prompt = "Run learning consolidation: execute `bun run ~/.claude/LIFEOS/TOOLS/SessionHarvester.ts --recent 20` then `bun run ~/.claude/LIFEOS/TOOLS/LearningPatternSynthesis.ts --week`. Summarize what was learned and any patterns found."
-model = "sonnet"
+# Deterministic tools, no LLM needed. Must be a script job: `type = "claude"`
+# spawns the CLI with `--tools ""` (see PULSE/lib.ts), so an agent asked to
+# *execute* these commands can't — it narrates and exits, logging "completed"
+# in a few seconds while running nothing.
+type = "script"
+command = "bun run ~/.claude/LIFEOS/TOOLS/SessionHarvester.ts --recent 20 && bun run ~/.claude/LIFEOS/TOOLS/LearningPatternSynthesis.ts --week"
 output = "log"
 enabled = true
 


### PR DESCRIPTION
The memory-consolidation job runs two deterministic CLIs (SessionHarvester, LearningPatternSynthesis) but was typed as "claude". spawnClaude() launches the CLI with --tools "" (PULSE/lib.ts), so an agent told to *execute* those commands has no tool to do it — it emits a few seconds of narration and exits, which the runner logs as "completed". The job has therefore never run.

Convert it to type:"script"; spawnScript() runs the command via bash -c, so the && chain executes both tools directly. Drops the (never-reached) LLM "summarize" step and the now-unused model key.