### PR TITLE
fix(Interceptor): preflight detects a missing pinned Extension, not just a stale one

### DIFF
--- a/LifeOS/install/skills/Interceptor/Tools/PreflightIsolation.sh
+++ b/LifeOS/install/skills/Interceptor/Tools/PreflightIsolation.sh
@@ -16,10 +16,12 @@
 #      Default/working pattern. This is the new guarantee — "connected" was the
 #      old check; "target is provably not a working profile" is the contract now.
 #
-#   4. Extension freshness (graceful): compare the pinned Extension copy's
-#      PINNED_FROM.txt against the upstream dist IF present. Mismatch → fail with
-#      re-pin remediation. Upstream absent → WARN and continue (do not hard-fail
-#      on a missing reference).
+#   4. Extension present, then fresh. Absent Extension/ → hard fail (browser
+#      control cannot work without it, and the freshness check below cannot see
+#      this case: it is guarded on PINNED_FROM.txt, which is gone too). Then,
+#      graceful: compare the pinned copy's PINNED_FROM.txt against the upstream
+#      dist IF present. Mismatch → fail with re-pin remediation. Upstream absent
+#      → WARN and continue (do not hard-fail on a missing reference).
 #
 # There is NO fallback path. A missing/stale pinned context is a hard stop with
 # remediation, never an auto-route to Default. The old "fall back to the first
@@ -32,8 +34,9 @@
 #   fi
 #
 # Exit codes: 0 cleared; 2 binary missing; 3 version-parse fail; 4 version too low;
-# 5 no contexts connected; 6 pinned context not connected (UUID rot); 7 target is a
-# Default/working profile (deny); 8 test-context unset in preferences.
+# 5 no contexts connected; 6 pinned context not connected (UUID rot) OR pinned
+# Extension stale; 7 target is a Default/working profile (deny); 8 test-context
+# unset in preferences; 9 no pinned Extension at all.
 
 set -euo pipefail
 
@@ -231,6 +234,43 @@ PINNED_FROM="$EXT_DIR/PINNED_FROM.txt"
 UPSTREAM_DIST="${INTERCEPTOR_SRC:-$HOME/Projects/interceptor}/extension/dist"
 UPSTREAM_MANIFEST="$UPSTREAM_DIST/manifest.json"
 
+# Relativize a $HOME-rooted path to ~ for display. Same helper (and same reason)
+# as Tools/Pin.sh: do NOT use ${x/#$HOME/~} — bash 5.2+ tilde-expands the
+# replacement back to an absolute /Users/<name> path, so the substitution prints
+# the very thing it is meant to hide. Verified: bash 3.2 -> "~/...", bash 5.3 ->
+# "/Users/<name>/...", and `#!/usr/bin/env bash` picks up 5.x when one is on PATH.
+rel_home() { case "$1" in "$HOME"/*) printf '~%s' "${1#"$HOME"}";; *) printf '%s' "$1";; esac; }
+EXT_DIR_DISP="$(rel_home "$EXT_DIR")"
+UPSTREAM_DIST_DISP="$(rel_home "$UPSTREAM_DIST")"
+PIN_SH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/Pin.sh"
+
+# 4a. Extension present at all? The freshness comparison below is guarded on
+# PINNED_FROM.txt existing, so a WHOLLY MISSING Extension/ takes the
+# warn-and-continue branch and preflight exits 0 — it detects a STALE pin but
+# never an ABSENT one. Chrome keeps an already-loaded unpacked extension alive
+# from memory after its directory disappears, so the gap stays invisible until
+# the next Chrome restart, then presents as unrelated runner/injection errors.
+if [ ! -f "$EXT_DIR/manifest.json" ]; then
+    cat >&2 <<EOF
+[PreflightIsolation] FAIL: no pinned Extension at $EXT_DIR_DISP
+
+WHY THIS MATTERS:
+  Browser control needs the unpacked extension loaded from this directory. It is
+  a local pin of the built extension and is deliberately NOT shipped with the
+  skill, so anything that replaces the skill directory removes it with no
+  replacement. Chrome may still be running a copy from memory right now; that
+  copy does not survive a restart.
+
+REMEDIATION:
+  1. Re-pin:  bash "$(rel_home "$PIN_SH")"
+     (needs the built extension at $UPSTREAM_DIST_DISP; override with INTERCEPTOR_SRC)
+  2. In the test profile: chrome://extensions/ -> Load Unpacked
+       from $EXT_DIR_DISP
+  3. Re-run this preflight.
+EOF
+    exit 9
+fi
+
 if [ -f "$PINNED_FROM" ] && [ -f "$UPSTREAM_MANIFEST" ]; then
     pinned_version="$(grep -i '^Manifest version:' "$PINNED_FROM" | sed -E 's/.*: *//' | tr -d ' ')"
     upstream_version="$(grep '"version"' "$UPSTREAM_MANIFEST" | head -1 | sed -E 's/.*"version" *: *"([^"]+)".*/\1/')"
@@ -256,7 +296,7 @@ else
     # Warn, do not hard-fail on a missing reference.
     printf '[PreflightIsolation] WARN: cannot verify extension freshness ' >&2
     printf '(upstream dist %s absent or PINNED_FROM.txt missing). Proceeding.\n' \
-        "${UPSTREAM_DIST/#$HOME/~}" >&2
+        "$UPSTREAM_DIST_DISP" >&2
 fi
 
 # --- All checks passed ---


### PR DESCRIPTION
## What

`PreflightIsolation.sh` check 4 compares the pinned `Extension/PINNED_FROM.txt` against the upstream build to catch a stale extension. The comparison is guarded on that file existing:

```bash
if [ -f "$PINNED_FROM" ] && [ -f "$UPSTREAM_MANIFEST" ]; then
    # ...compare versions, exit 6 on mismatch
else
    # WARN: cannot verify extension freshness. Proceeding.
fi
```

When `Extension/` is missing entirely, `PINNED_FROM.txt` is gone with it, so the guard is false and the check takes the warn-and-continue branch. Preflight exits 0. It detects a STALE pin but never an ABSENT one.

That gap is easy to hit, because `Extension/` is a local pin (`Tools/Pin.sh`) that is deliberately not shipped with the skill — so anything replacing the skill directory removes it with no replacement. It is also slow to notice: Chrome keeps an already-loaded unpacked extension running from memory after its directory disappears, so browser control keeps working until the next Chrome restart, then fails as `screenshot-runner.js could not load` — which the skill's own gotchas attribute to a *stale* extension, sending you down the wrong path.

## Change

One file, two edits to check 4.

1. An existence check before the freshness comparison. Missing `Extension/manifest.json` → hard fail with re-pin remediation, `exit 9` (next free code; header updated).

2. The section's home-path rendering moves to a `rel_home()` helper — the same one, for the same reason, that `Tools/Pin.sh` already carries. `${x/#$HOME/~}` tilde-expands the replacement back to an absolute `/Users/<name>` path on bash 5.2+, so it prints the path it is meant to hide. Drive-by, in the same block; happy to split it out if you would rather keep this to one concern.

Sentinel is `manifest.json`, not `PINNED_FROM.txt` — the question is "is there a loadable extension here", and a hand-copied directory can lack the provenance file while being perfectly loadable.

## Why it's safe

The new branch only fires in a state that previously reported success while browser control was unrecoverable. Its failure mode is a hard stop with instructions, not silence, and it cannot corrupt anything — the check is a single `[ -f ]` test with no writes.

Stock behavior is unchanged in all three previously-detected cases (table below).

## Verification

Check 4 exercised in isolation, driven from the real file bytes (extracted by `awk` range, not retyped), against `origin/main` and the patched version:

| Case | `origin/main` | patched |
|---|---|---|
| A. pinned + upstream present, versions match | 0 | 0 |
| B. pinned stale vs upstream | 6 | 6 |
| C. pinned present, upstream dist absent | 0 (WARN) | 0 (WARN) |
| D. **`Extension/` missing** | **0 (WARN)** | **9 (FAIL)** |

Home-path rendering, `Extension/` under `$HOME`, run on bash 5.3:

- `origin/main` → `/Users/<name>/.pfprobe/src/extension/dist`
- patched → `~/.pfprobe/Extension`

Confirmed the underlying quirk directly: `EXT_DIR="$HOME/x"; echo "${EXT_DIR/#$HOME/~}"` gives `~/x` on bash 3.2 and `/Users/<name>/x` on bash 5.3. `#!/usr/bin/env bash` picks up 5.x whenever one is on PATH.

`bash -n` clean. Tested on macOS 15 (Darwin 25.5), bash 3.2.57 and 5.3.15, interceptor 0.22.2.

## Scope

Check 4 only. Checks 1–3, the target-deny logic, and every existing exit code are untouched.

Found but deliberately not changed:

- `SKILL.md:121` says the upstream dist is "absent (currently true)". That is environment-specific narration in a skill body and reads as stale, but it is not this fix's business.
- The stale-extension path keeps `exit 6`, which it shares with "pinned context not connected". Splitting those is a separate call; I only documented the overlap in the header rather than renumbering an existing code.
- `Pin.sh` itself needs no change — it already handles path rendering correctly, which is where the helper came from.

