### PR TITLE
docs(testing): scope the test-location rule — subsystem packages keep their suite in-package

### DIFF
--- a/LifeOS/install/LIFEOS/DOCUMENTATION/Testing/TestingDoctrine.md
+++ b/LifeOS/install/LIFEOS/DOCUMENTATION/Testing/TestingDoctrine.md
@@ -78,6 +78,8 @@ Mirror the source path, not co-locate. Map:
 
 Snapshot files at `test/<surface>/__snapshots__/<name>.test.ts.snap`.
 
+**Subsystem-package clause.** A directory-tool with its own `package.json` (`LIFEOS/TOOLS/<tool>/`) keeps its suite in-package at `<tool>/test/` with a `package.json` `test` script — the suite travels with the deployable package. The parallel `~/.claude/test/` tree governs the repo-root surface (hooks, skills, single-file tools).
+
 ### 3. Every test file is independently runnable.
 
 `bun test test/hooks/Foo.hook.test.ts` works in isolation. No file depends on another file's globals or setup. If shared setup is needed, it goes in `test/preload.ts` and is loaded via bunfig.
@@ -311,7 +313,7 @@ Phases 2–5 are tracked separately as PROJECTS.md entries; they're not part of 
 
 ## Anti-patterns (do not do)
 
-- ❌ Co-locating test files next to source (`hooks/<Hook>.hook.test.ts` next to `hooks/<Hook>.hook.ts`). Bun does not do this and the parallel `test/` tree scales better.
+- ❌ Co-locating test files next to source (`hooks/<Hook>.hook.test.ts` next to `hooks/<Hook>.hook.ts`). Bun does not do this and the parallel `test/` tree scales better. (Repo-root surface only; subsystem packages keep in-package suites per Rule 2.)
 - ❌ Adding Jest, Vitest, Mocha, AVA, ts-node, ts-jest, sinon, jest-mock to LifeOS's `package.json`. CONSTITUTIONAL FAILURE.
 - ❌ Setting a global `coverageThreshold = 1.0`. Gamification trap; incentivizes shallow tests.
 - ❌ Adding a `--retry 3` flag to any test invocation in CI. Banned.


### PR DESCRIPTION
TestingDoctrine rule 2 maps every test into the repo-root `test/` tree, and the anti-patterns list bans co-location without qualification. That is right for the repo-root surface (hooks, skills, single-file tools) but leaves one shipped class with no home in the rule: self-contained subsystem packages — tool directories with their own `package.json`, in the current payload `LIFEOS/TOOLS/TokenXray/` and `LIFEOS/TOOLS/llcli/`. A package with its own dependencies and lifecycle is the unit that travels; routing its suite into the repo-root tree strands the tests whenever the package is developed, vendored, or deployed on its own.

Changes (docs only, no behavior change):

- Rule 2 gains a **Subsystem-package clause**: a directory-tool with its own `package.json` keeps its suite in-package at `<tool>/test/` with a `package.json` `test` script — the suite travels with the deployable package. The parallel repo-root `test/` tree continues to govern the repo-root surface.
- The co-location anti-pattern row is scoped to match (repo-root surface only; subsystem packages keep in-package suites per Rule 2). A package-local `test/` directory is the parallel-tree pattern at package scope, not co-location — co-location means a test file next to its source file.

Deliberately not touched: no test tree or harness is added (that packaging question is #1550's, whose resolution this clause is consistent with — the clause governs where tests live when they exist); no bunfig or code changes; rules 1 and 3–11 unchanged. The corpus coverage rule (every hook/skill/tool surface gets at least one test file) loses nothing — a repo-root `bun test` walk still reaches in-package suites.

We run this split on our install: two subsystem tools keep their suites in-package (a 14-file suite behind a bare `bun test` script; a second package whose script scopes unit tests apart from live-integration runners), run per-package, with the packages' deploy scripts shipping `test/` alongside the code — tests traveling with the package is exactly what the clause writes down.
