### PR TITLE
fix(knowledge): specify created/updated as archive-entry dates

### DIFF
--- a/LifeOS/install/skills/Knowledge/SKILL.md
+++ b/LifeOS/install/skills/Knowledge/SKILL.md
@@ -102,7 +102,7 @@ Create a new note manually in the specified entity type.
 2. Ask for a title (or use remaining args after type)
 3. Generate kebab-case filename from title
 4. **MANDATORY: Find 2-3 related notes first.** Before writing the new note, grep existing Knowledge for related entities by topic/tags/name. This becomes the `related:` frontmatter array. No Knowledge note ships without typed links. See Canonical Linking Requirement below.
-5. Create the note with proper frontmatter from `_schema.md` — schemas require: `title`, `type`, `tags` (min 1), `created`, `updated`, `quality` (0-10), plus type-specific body sections.
+5. Create the note with proper frontmatter from `_schema.md` — schemas require: `title`, `type`, `tags` (min 1), `created`, `updated`, `quality` (0-10), plus type-specific body sections. Set `created:` and `updated:` to today's date from `date +%Y-%m-%d` — archive-entry dates, never a source's publication date.
 6. Write the file to `KNOWLEDGE/<Type>/<kebab-case-title>.md` — slug max 60 chars
 7. Verify every slug in `related:` exists in the archive before saving
 8. Regenerate the type's MOC:
@@ -197,7 +197,7 @@ rg "^status: seedling" ~/.claude/LIFEOS/MEMORY/KNOWLEDGE/ --type md -l
 **Step 4 — If approved:**
 - Write the updated note
 - Promote status from `seedling` to `budding` (or `evergreen` if comprehensive)
-- Update the `updated` date
+- Update `updated:` to today's date from `date +%Y-%m-%d`; leave `created:` untouched
 - Regenerate affected MOCs
 
 If no seedlings exist, report archive is clean.
@@ -224,6 +224,7 @@ Determine entity type (People, Companies, Ideas, or Research) using the classifi
 Create the primary note using the schema for that type:
 - Generate kebab-case slug from title (max 60 chars)
 - Write to `KNOWLEDGE/<Type>/<slug>.md` with proper frontmatter
+- Set `created:` and `updated:` to today's date from `date +%Y-%m-%d` — both record when the note entered the archive, **not** when the source was published. If the source states its own publication date, that belongs in `source_date:`; never let it reach `created:`, and never guess a date the source does not state.
 - Include `source_url:` or `source_path:` in frontmatter
 - **MANDATORY: Include `related:` array with 2-4 typed links** — the ripple pass (Step 3) identifies these, and they must be baked into the frontmatter of the primary note at creation time, not added after
 
@@ -265,7 +266,7 @@ After the user approves (or you determine updates are low-risk cross-references)
 - **Primary note**: ensure `related:` frontmatter array has 2-4 typed entries — this is mandatory, not optional
 - **Related notes**: add reverse-direction `related:` entries to their frontmatter with appropriate types
 - **Body wikilinks**: add `[[wikilinks]]` in existing prose where natural (not forced)
-- Update `updated:` date on modified notes
+- Update `updated:` to today's date from `date +%Y-%m-%d` on modified notes; leave their `created:` untouched
 - For contradictions: add a `> ⚠️ **Contradiction:** [note] claims X — see [[new-note]] for counter-evidence` callout, AND add `type: contradicts` in related: arrays
 
 ### Step 5 — Log and index


### PR DESCRIPTION
## What

The Knowledge skill lists `created` and `updated` as required frontmatter but never states what value they should hold.

- `add` step 5 names both as required, with no value guidance.
- `ingest` Step 2 says only "write ... with proper frontmatter".
- `develop` and `ingest` Step 4 say "update the `updated` date" without saying to what.

With nothing specified, the model fills them from whatever the source suggests — an article's dateline, a repo's first-commit year — or a plausible-looking constant when the source states no date at all.

The rest of the codebase has already decided this question. `KnowledgeSchema.ts` documents `source_date` as *"everything published in a given year (vs created = archived)"*, and `KnowledgeHarvester` stamps `created: ${today}` on the notes it mints. Only the SKILL.md workflows leave it unstated, so the one path a model drives by hand is the one path with no contract.

Two things downstream care:

- `mintId()` derives each note's stable id from `sha256(slug|created)`. A guessed `created` produces an id that isn't reproducible from the note's real provenance.
- MOC "recent" sections sort on `updated`, so a publication date in that field reorders the dashboard by article age rather than by archive activity.

## Change

One file, four lines. State the contract where each workflow writes frontmatter:

- `ingest` Step 2 and `add` step 5 — both fields from `date +%Y-%m-%d`; a stated publication date goes to `source_date`; never guess one the source does not state.
- `develop` Step 4 and `ingest` Step 4 — move `updated` to today, leave `created` untouched.

No schema change, no new field — `source_date` already exists and is already documented for exactly this. No code touched.

## Why it's safe

Prose-only, and it constrains a value that was previously unconstrained. Benign in both directions: if a model already wrote today's date, behavior is unchanged; if it was guessing, it stops. No existing note is rewritten — this affects only notes written after the change.

## Verification

Scanned a 6,508-note archive built with these workflows. 1,160 of those notes have a `_log.md` entry recording the true ingest date, so `created` can be checked against ground truth:

| Check | Result |
|---|---|
| `created` == logged ingest date | 717 / 1,160 (61.8%) |
| `created` != logged ingest date | **443 / 1,160 (38.2%)** |
| No `created` field at all | 137 / 6,508 |

One date value alone accounts for 202 notes whose logged ingest dates are spread across five different months — so that cluster cannot be a bulk-import artifact.

Honest caveat on the 38.2%: it is an upper bound on "wrong". A note hand-created before a later ingest counts as a mismatch legitimately. The scan compares against the *earliest* log entry per slug to keep that class small. The two largest `created` clusters in the archive do look like genuine bulk-harvest days and are not counted as evidence here.

Tested on macOS, Bun 1.3.14.

## Scope

Only `skills/Knowledge/SKILL.md`. Does not touch `KnowledgeSchema.ts`, `KnowledgeLint.ts`, `KnowledgeHarvester.ts`, or any existing note.

One related gap found while measuring, left out to keep this to one concern — happy to follow up: the workflows give no guidance on quoting a title containing a colon, which makes the frontmatter unparseable and is unavoidable for sources whose real title has a subtitle.
