### PR TITLE
Add Grill discovery-interview workflow to the ISA skill

### DIFF
--- a/LifeOS/install/commands/grill-me.md
+++ b/LifeOS/install/commands/grill-me.md
@@ -1,0 +1,17 @@
+---
+name: grill-me
+description: Relentless checkpointed discovery interview that interrogates a half-formed idea until its shape is clear, then hands off to ISA Scaffold. Routes to the ISA skill's Grill workflow. USE WHEN /grill-me, grill me, discovery interview, figure out the shape, brainstorm before scaffolding an ISA. NOT FOR filling an existing ISA's thin sections (use ISA Interview).
+argument-hint: <topic> [slug]
+---
+
+# grill-me — ISA Grill workflow
+
+Invoke the ISA skill's **Grill** workflow on `$ARGUMENTS`:
+
+```
+Skill("ISA", "grill me on $ARGUMENTS")
+```
+
+If `$ARGUMENTS` is empty, ask what idea/plan/decision to grill, then proceed.
+
+Grill walks the design tree one question at a time (recommending an answer each turn, exploring the codebase instead of asking when it can), checkpoints every turn to `MEMORY/WORK/{slug}/grill.md`, runs a pre-mortem→ISC pass, and hands off to `ISA Scaffold`. Full procedure: `~/.claude/skills/ISA/Workflows/Grill.md`.

--- a/LifeOS/install/skills/ISA/SKILL.md
+++ b/LifeOS/install/skills/ISA/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ISA
 version: 1.0.13
-description: "Owns the Ideal State Artifact — the primitive holding a project or task's articulated ideal state; scaffolds, interviews, scores completeness, reconciles feature excerpts to master, seeds from a repo, and appends decisions/changelog/verification across a locked fourteen-section order. USE WHEN ISA, ISC, ideal state, ideal state criteria, project specification, hill-climb, articulating done. NOT FOR creating new skills (use CreateSkill)."
+description: "Owns the Ideal State Artifact — the primitive holding a project or task's articulated ideal state; scaffolds, interviews, grills a half-formed idea into shape via checkpointed discovery, scores completeness, reconciles feature excerpts to master, seeds from a repo, and appends decisions/changelog/verification across a locked fourteen-section order. USE WHEN ISA, ISC, ideal state, ideal state criteria, project specification, hill-climb, articulating done, grill me, discovery interview. NOT FOR creating new skills (use CreateSkill)."
 effort: medium
 ---
 
@@ -106,6 +106,7 @@ Match the verb in the request to a workflow. When ambiguous, default to Scaffold
 |---------------|----------|------|
 | "scaffold", "create", "generate", "new ISA from this prompt", "extract feature as ephemeral" | **Scaffold** | `Workflows/Scaffold.md` |
 | "interview me", "fill in the ISA", "deepen", "ask me questions" | **Interview** | `Workflows/Interview.md` |
+| "grill me", "grill", "discovery interview", "figure out the shape" | **Grill** | `Workflows/Grill.md` |
 | "check", "audit", "score this ISA", "is it complete?" | **CheckCompleteness** | `Workflows/CheckCompleteness.md` |
 | "reconcile", "merge feature file back", "ephemeral → master" | **Reconcile** | `Workflows/Reconcile.md` |
 | "seed", "bootstrap from this repo", "draft an ISA from existing code" | **Seed** | `Workflows/Seed.md` |

--- a/LifeOS/install/skills/ISA/Workflows/Grill.md
+++ b/LifeOS/install/skills/ISA/Workflows/Grill.md
@@ -1,0 +1,91 @@
+# Grill Workflow
+
+Relentless, checkpointed discovery interview that interrogates a half-formed idea until its shape is clear, then hands off to Scaffold to build the ISA. Where Interview FILLS a known ISA structure, Grill DISCOVERS a structure that doesn't exist yet. Human-invoked and exploratory; never Algorithm-automatic.
+
+## When to invoke
+
+- User directly: `Skill("ISA", "grill me on <topic>")` or `/grill-me <topic>`
+- Before Scaffold when the idea is too unformed to scaffold a strong ISA.
+- To refresh a spec: "grill me again on <slug>, here's new findings."
+
+NOT for filling an existing ISA's thin sections — that's Interview.
+
+## Inputs
+
+| Input | Required | Description |
+|-------|----------|--------------|
+| topic | yes | The idea/plan/decision to interrogate |
+| slug | no | WORK dir to use; derived from topic if absent |
+| max_questions | no | Default 12 |
+
+## Procedure
+
+### Step 1 — Voice notification
+
+```bash
+curl -s -X POST http://localhost:31337/notify \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Running the Grill workflow in the ISA skill"}' \
+  > /dev/null 2>&1 &
+```
+
+### Step 2 — Establish the WORK dir
+
+Resolve the canonical LifeOS work dir — **`~/.claude/LIFEOS/MEMORY/WORK/{slug}/`** (absolute; the same dir Scaffold writes the ISA to, so the handoff stays co-located). Use this path even when `/grill-me` is invoked from another repo's cwd — it is NOT project-relative, and it is NOT a bare `~/.claude/MEMORY/WORK/` outside the `LIFEOS/` tree. Create `grill.md` there with three sections: **Shape & Key Decisions**, **Q&A Log**, **Open Flags**. This file is the checkpoint target — never a project-root `brainstorms/` folder.
+
+### Step 3 — Shape check (only if the category is ambiguous)
+
+If it's unclear what *kind* of thing this is (skill vs hook vs CLI vs doc, etc.), propose 2-3 candidate shapes up front and ask discriminating questions to prune to one before walking the tree. Skip when the shape is already obvious.
+
+### Step 4 — Walk the design tree
+
+Resolve dependencies in order — never a leaf before its parent. Per decision:
+
+- Ask one question at a time via **AskUserQuestion** — one question per call, never batch. Present your recommended answer as the first option (mark it "(Recommended)") alongside the real alternatives, so the user confirms or overrides in one step; they can always pick "Other" to redirect. Fall back to a free-text question only when the answer space is genuinely open-ended and won't bound into options.
+- Never a bare open ask — always lead with where you'd land and why.
+- Explore the codebase instead of asking when the answer is discoverable (Grep/Read first; ask only if code can't answer it).
+- On a low-confidence or high-stakes call, add a one-line strongest-objection to your own recommendation before the user answers.
+
+### Step 5 — Checkpoint after every turn
+
+Immediately write to `grill.md`: append the Q&A pair to Q&A Log, promote settled decisions into Shape & Key Decisions, record "needs external input" items under Open Flags. Survives context-window degradation on long sessions.
+
+### Step 6 — Pre-mortem → draft ISCs
+
+Before closing, run one failure-mode pass: "imagine this shipped and failed — what went wrong?" Convert each failure mode into a draft binary criterion (ISC) under Shape & Key Decisions. This is what makes the resulting ISA hard-to-vary.
+
+### Step 7 — Stop conditions
+
+End when the shape is clear enough to scaffold, max_questions is hit, or two consecutive answers are low-signal ("I don't know" / "skip").
+
+### Step 8 — Handoff
+
+Offer, in order: (1) hand the shape to Scaffold — `Skill("ISA", "scaffold from prompt: <Shape & Key Decisions + draft ISCs from grill.md>")`, targeting the same WORK dir; (2) `TaskCreate` for each Open Flag; (3) sync related skills/guides this session touched, via CreateSkill — Grill's job, not Interview's.
+
+## Output format (grill.md)
+
+```
+# Grill: <topic>
+## Shape & Key Decisions
+- <settled decision> — <rationale>
+- ISC: <binary criterion from pre-mortem>
+## Q&A Log
+### Q1: <question>
+**Recommended:** <rec>  **Answer:** <user answer>
+## Open Flags
+- [ ] <unknown> — needs <who/what>
+```
+
+## Failure modes
+
+- **User abandons mid-grill:** partial grill.md is still valuable; leave an Open Flag noting where it paused.
+- **Answers stay aspirational:** push for the concrete ("what would prove that?"); if they can't, log an Open Flag, not a settled decision.
+- **Topic is already well-formed:** say so and route straight to Scaffold — don't manufacture questions to hit max_questions.
+
+## Interaction with Scaffold
+
+Scaffold has no dedicated grill mode — the handoff is the grill.md content passed as Scaffold's prompt. Feed the **Shape & Key Decisions** (and the pre-mortem draft ISCs) into `Skill("ISA", "scaffold from prompt: …")`: Scaffold's goal-detection preserves the stated goal from that prompt and derives Vision / Out of Scope / Constraints / Principles, and the draft ISCs carry into `## Criteria`. Grill's value is front-loading the discovery so Scaffold's prompt is already hard-to-vary.
+
+---
+
+_Adapted from Matt Pocock's `grilling` / `grill-me` skills — [github.com/mattpocock/skills](https://github.com/mattpocock/skills) (MIT, © 2026 Matt Pocock). Independent implementation: it checkpoints each turn to `MEMORY/WORK/{slug}/grill.md` (rather than a project-root `brainstorms/` folder) and adds a pre-mortem→ISC pass before the Scaffold handoff._


### PR DESCRIPTION
## The gap

ISA already covers known-structure work — Scaffold, Interview, CheckCompleteness, Reconcile, Seed, Append. What's missing is the front end for when you don't know the shape yet. If an idea's still half-formed, you can't scaffold it honestly — you just bake in assumptions nobody checked. That's the most common way agentic work goes off the rails: the agent runs with the wrong mental model before you get a chance to correct it.

## The change

A Grill workflow that interrogates a half-formed idea until its shape is clear, then hands it to Scaffold. Three pieces:

- **`skills/ISA/Workflows/Grill.md`** — walks the design tree one question at a time, recommends an answer each turn, explores the codebase instead of asking when it can, and checkpoints every turn to `MEMORY/WORK/{slug}/grill.md` so a long session doesn't lose earlier answers to context drift. Runs a pre-mortem→draft-ISC pass, then hands off to Scaffold.
- **`skills/ISA/SKILL.md`** — one new routing row (`"grill me" / "discovery interview" / "figure out the shape"` → `Workflows/Grill.md`) and a Grill clause in the description.
- **`commands/grill-me.md`** — a thin `/grill-me <topic>` command that routes into `Skill("ISA", "grill me …")`. Model-invocation is off, so it only fires when you ask.

Same split as the skill it's based on: a reusable interview loop plus a thin command to trigger it.

## Why it's safe

- Additive. One new workflow, one new command, one routing row, one description tweak. Nothing existing changes.
- Fails safe. If Grill mis-routes it falls back to normal ISA behavior, and it never writes outside `MEMORY/WORK/{slug}/grill.md` — scratch output that sits next to where the ISA lands.
- Human-gated. The command is `disable-model-invocation`; Grill runs only when you call it.

## Verification

- Running live in a real install: `commands/grill-me.md` → `Skill("ISA", "grill me …")` → the SKILL.md Grill row → `Workflows/Grill.md`, all resolve. The ISA skill validates — every routing row points at a real file, and the description is under the frontmatter cap.
- The Grill → Scaffold handoff works end to end: the `grill.md` checkpoint feeds `Skill("ISA","scaffold from <slug>/grill.md")`.

## Scope

Additive. `Workflows/Grill.md` and `commands/grill-me.md` are new, plus two small edits to `ISA/SKILL.md`. No other skill, tool, or hook touched.

## Credit

This adapts Matt Pocock's **`grilling` / `grill-me` skills** ([github.com/mattpocock/skills](https://github.com/mattpocock/skills) — MIT, © 2026 Matt Pocock). His "grill me" prompt is the core idea: *interview me relentlessly about every aspect of this plan; walk each branch of the design tree, resolving dependencies one at a time; recommend an answer per question; ask one at a time; explore the codebase instead of asking.* This is an independent implementation wired into LifeOS's ISA discovery→scaffold pipeline — it checkpoints each turn to `MEMORY/WORK/{slug}/grill.md` instead of a project-root `brainstorms/` folder, and adds a pre-mortem→draft-ISC pass before the Scaffold handoff.
