### PR TITLE
docs: discoverable doc headers for every flat tool in LIFEOS/TOOLS

### DIFF
--- a/LifeOS/install/LIFEOS/TOOLS/AddBg.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/AddBg.ts
@@ -1,16 +1,16 @@
 #!/usr/bin/env bun
 
 /**
- * add-bg - Add Background Color CLI
+ * AddBg.ts — add a solid background color to a transparent PNG image
  *
  * Add a solid background color to transparent PNG images.
- * Part of the Images skill for LifeOS system.
+ * Companion to RemoveBg.ts in the Art toolchain.
  *
  * Usage:
  *   add-bg input.png "#EAE9DF" output.png
  *   add-bg input.png --ul-brand output.png
  *
- * @see ~/.claude/skills/Images/SKILL.md
+ * @see ~/.claude/skills/Art/SKILL.md
  */
 
 import { existsSync } from "node:fs";

--- a/LifeOS/install/LIFEOS/TOOLS/Banner.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/Banner.ts
@@ -1,10 +1,16 @@
 #!/usr/bin/env bun
 
 /**
- * LifeOS Banner - Responsive Neofetch-style launch banner (Navy theme)
+ * Banner.ts — responsive neofetch-style LifeOS launch banner (Navy theme)
+ *
  * Routes by terminal width: full (85+) → medium (70+) → compact (55+) →
- * minimal (45+) → ultra-compact (<45). Force a variant with --design=<name>,
- * render all variants with --test.
+ * minimal (45+) → ultra-compact (<45). This is the banner the CLI launcher
+ * renders at startup.
+ *
+ * Usage:
+ *   bun Banner.ts                  # render for the current terminal width
+ *   bun Banner.ts --design=<name>  # force a specific width variant
+ *   bun Banner.ts --test           # render every variant
  */
 
 import { existsSync, readFileSync } from "fs";

--- a/LifeOS/install/LIFEOS/TOOLS/BannerMatrix.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/BannerMatrix.ts
@@ -1,8 +1,10 @@
 #!/usr/bin/env bun
 
 /**
- * BannerMatrix - Matrix Digital Rain LifeOS Banner
- * Neofetch-style layout with The Matrix aesthetic
+ * BannerMatrix.ts — Matrix "digital rain" LifeOS launch banner (alternative theme)
+ *
+ * Neofetch-style layout with The Matrix aesthetic. Alternative theme prototype:
+ * the CLI launcher renders Banner.ts, not this file. Run directly to preview.
  *
  * Design:
  *   LEFT:  LifeOS logo emerging from Matrix rain (Katakana cascade)
@@ -15,6 +17,11 @@
  *   - Binary/hex scattered
  *   - Glitch effects
  *   - Hacker terminal feel
+ *
+ * Usage:
+ *   bun BannerMatrix.ts                                  # render for the current terminal width
+ *   bun BannerMatrix.ts --mode=<nano|micro|mini|normal>  # force a display mode
+ *   bun BannerMatrix.ts --test                           # render every mode
  */
 
 import { readdirSync, existsSync, readFileSync } from "fs";

--- a/LifeOS/install/LIFEOS/TOOLS/BannerNeofetch.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/BannerNeofetch.ts
@@ -1,13 +1,21 @@
 #!/usr/bin/env bun
 
 /**
- * BannerNeofetch - Modern Neofetch-Style LifeOS Banner
+ * BannerNeofetch.ts — modern neofetch-style LifeOS launch banner (alternative theme)
+ *
+ * Alternative theme prototype: the CLI launcher renders Banner.ts, not this
+ * file. Run directly to preview.
  *
  * LEFT SIDE: High-resolution 3D isometric cube using Braille + block elements
  * RIGHT SIDE: Modern stats with emoji icons, progress bars, color-coded values
  * BOTTOM SECTION: Gradient header, quote, sparkline histogram, LifeOS block art
  *
  * Aesthetic: Modern tech startup (gh, npm, vercel) with gradient colors (blue->purple->cyan)
+ *
+ * Usage:
+ *   bun BannerNeofetch.ts            # render full layout
+ *   bun BannerNeofetch.ts --compact  # compact layout (alias -c)
+ *   bun BannerNeofetch.ts --test     # render both layouts
  */
 
 import { readdirSync, existsSync, readFileSync } from "fs";

--- a/LifeOS/install/LIFEOS/TOOLS/BannerPrototypes.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/BannerPrototypes.ts
@@ -1,7 +1,13 @@
 #!/usr/bin/env bun
 
 /**
- * Banner Prototypes - Testing different cyberpunk designs
+ * BannerPrototypes.ts — gallery of six experimental cyberpunk banner designs
+ *
+ * Design-exploration prototype, not wired to the CLI launcher (which renders
+ * Banner.ts). Running it prints all six designs in sequence; takes no arguments.
+ *
+ * Usage:
+ *   bun BannerPrototypes.ts   # print every prototype design
  */
 
 const RESET = "\x1b[0m";

--- a/LifeOS/install/LIFEOS/TOOLS/BannerRetro.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/BannerRetro.ts
@@ -1,7 +1,10 @@
 #!/usr/bin/env bun
 
 /**
- * BannerRetro - Retro BBS/DOS Terminal Banner for LifeOS
+ * BannerRetro.ts — retro BBS/DOS-terminal LifeOS launch banner (alternative theme)
+ *
+ * Alternative theme prototype: the CLI launcher renders Banner.ts, not this
+ * file. Run directly to preview.
  *
  * Neofetch-style layout with classic ASCII art aesthetic:
  * - LEFT: Isometric LifeOS cube using classic ASCII characters
@@ -13,6 +16,11 @@
  * - BBS door games and ANSI art
  * - DOS-era interface aesthetics
  * - Amber/green phosphor CRT terminals
+ *
+ * Usage:
+ *   bun BannerRetro.ts                               # render (default retro mode)
+ *   bun BannerRetro.ts --mode=<retro|ascii|compact>  # force a mode
+ *   bun BannerRetro.ts --test                        # render every mode
  */
 
 import { readdirSync, existsSync, readFileSync } from "fs";

--- a/LifeOS/install/LIFEOS/TOOLS/BannerTokyo.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/BannerTokyo.ts
@@ -1,8 +1,14 @@
 #!/usr/bin/env bun
 
 /**
- * Banner - Tokyo Night Theme
- * Deep blue-black with soft neon accents
+ * BannerTokyo.ts — gallery of six Tokyo Night banner designs
+ *
+ * Deep blue-black with soft neon accents. Design-exploration prototype, not
+ * wired to the CLI launcher (which renders Banner.ts). Running it prints all
+ * six designs in sequence; takes no arguments.
+ *
+ * Usage:
+ *   bun BannerTokyo.ts   # print every Tokyo Night design
  */
 
 const RESET = "\x1b[0m";

--- a/LifeOS/install/LIFEOS/TOOLS/DAGrowth.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/DAGrowth.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 /**
- * DA Growth Viewer — CLI tool
+ * DAGrowth.ts — view the primary DA's diary, opinions, growth events, and summary
  *
  * View diary entries, opinions, growth events, and summary for the primary DA.
  *
@@ -10,6 +10,8 @@
  *   bun LIFEOS/TOOLS/DAGrowth.ts opinions        # Current opinions
  *   bun LIFEOS/TOOLS/DAGrowth.ts growth          # Growth event log
  *   bun LIFEOS/TOOLS/DAGrowth.ts summary         # Overview
+ *
+ * @see ~/.claude/LIFEOS/DOCUMENTATION/Pulse/DaSubsystem.md
  */
 
 import { join } from "path"

--- a/LifeOS/install/LIFEOS/TOOLS/ExtractTranscript.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/ExtractTranscript.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env bun
 
 /**
- * ExtractTranscript.ts
+ * ExtractTranscript.ts — transcribe audio/video files via the OpenAI Whisper API
  *
  * CLI tool for extracting transcripts from audio/video files using OpenAI Whisper API
- * Part of LifeOS's extracttranscript skill
+ * Companion to SplitAndTranscribe.ts in the transcription toolchain
  *
  * Usage:
  *   bun ExtractTranscript.ts <file-or-folder> [options]

--- a/LifeOS/install/LIFEOS/TOOLS/FeatureRegistry.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/FeatureRegistry.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 /**
- * Feature Registry CLI
+ * FeatureRegistry.ts — JSON feature-tracking registry for complex multi-feature tasks
  *
  * JSON-based feature tracking for complex multi-feature tasks.
  * Based on Anthropic's agent harness patterns - JSON is more robust

--- a/LifeOS/install/LIFEOS/TOOLS/ForgeProgress.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/ForgeProgress.ts
@@ -1,4 +1,22 @@
 #!/usr/bin/env bun
+/**
+ * ForgeProgress.ts — run a Forge (codex exec) agent with live progress streamed to Pulse
+ *
+ * Spawns the `codex` CLI as a child process, tails its JSONL stdout into a
+ * per-slug events file (keeping a small ring buffer of the latest entries),
+ * polls that buffer to a Pulse notify endpoint for live progress, enforces a
+ * timeout with signal-based teardown, and prints a single final verdict line
+ * (success | error | timeout) as JSON on stdout. Exits non-zero on anything
+ * but success. Also exported as `default async main(argv)` for programmatic use.
+ *
+ * Usage:
+ *   bun ForgeProgress.ts --slug <slug> --prompt "<task>" [flags]
+ *   echo "<task>" | bun ForgeProgress.ts --slug <slug>        # prompt via stdin
+ *
+ * Flags (defaults): --model gpt-5.6-sol · --reasoning-effort high ·
+ *   --sandbox workspace-write · --timeout-ms 300000 ·
+ *   --pulse-url http://localhost:31337/notify
+ */
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { createInterface } from "node:readline";
 import { accessSync, constants, createWriteStream, existsSync, type WriteStream } from "node:fs";

--- a/LifeOS/install/LIFEOS/TOOLS/GenerateKnowledgeSchemaDoc.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/GenerateKnowledgeSchemaDoc.ts
@@ -11,6 +11,8 @@
  * CLI:
  *   bun GenerateKnowledgeSchemaDoc.ts            # write the doc
  *   bun GenerateKnowledgeSchemaDoc.ts --stdout   # print, don't write
+ *
+ * @see ~/.claude/LIFEOS/DOCUMENTATION/Memory/MemorySystem.md
  */
 
 import { writeFileSync } from "node:fs";

--- a/LifeOS/install/LIFEOS/TOOLS/GenerateTelosSummary.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/GenerateTelosSummary.ts
@@ -13,6 +13,8 @@
  * - Structural compression preserving causal links (M→G→P→S chains)
  * - ~60 lines targeting signal density over completeness (Nyx's constraint)
  * - Staleness detection via timestamp (Vex's TTL requirement)
+ *
+ * @see ~/.claude/LIFEOS/DOCUMENTATION/Freshness/FreshnessSystem.md
  */
 
 import { readFileSync, writeFileSync, existsSync } from 'fs';

--- a/LifeOS/install/LIFEOS/TOOLS/GetTranscript.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/GetTranscript.ts
@@ -4,12 +4,12 @@
  * GetTranscript.ts - Extract transcript from YouTube video
  *
  * Usage:
- *   bun ~/.claude/skills/Videotranscript/Tools/GetTranscript.ts <youtube-url>
- *   bun ~/.claude/skills/Videotranscript/Tools/GetTranscript.ts <youtube-url> --save <output-file>
+ *   bun ~/.claude/LIFEOS/TOOLS/GetTranscript.ts <youtube-url>
+ *   bun ~/.claude/LIFEOS/TOOLS/GetTranscript.ts <youtube-url> --save <output-file>
  *
  * Examples:
- *   bun ~/.claude/skills/Videotranscript/Tools/GetTranscript.ts "https://www.youtube.com/watch?v=abc123"
- *   bun ~/.claude/skills/Videotranscript/Tools/GetTranscript.ts "https://youtu.be/abc123" --save transcript.txt
+ *   bun ~/.claude/LIFEOS/TOOLS/GetTranscript.ts "https://www.youtube.com/watch?v=abc123"
+ *   bun ~/.claude/LIFEOS/TOOLS/GetTranscript.ts "https://youtu.be/abc123" --save transcript.txt
  *
  * @author LifeOS System
  * @version 1.0.0

--- a/LifeOS/install/LIFEOS/TOOLS/HarvestExecutor.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/HarvestExecutor.ts
@@ -1,11 +1,17 @@
 #!/usr/bin/env bun
 /**
- * HarvestExecutor
+ * HarvestExecutor.ts — execute Arbol-routed harvest actions into the local memory stores.
  *
  * Executes routed harvest actions from the Arbol harvest API against the local
  * LifeOS knowledge and learning stores. The tool is intentionally conservative:
  * it backfills from existing notes when possible, never fabricates related
  * links, and records per-item execution state in a sidecar file.
+ *
+ * Usage:
+ *   bun HarvestExecutor.ts [--dry-run] [--item <id>] [--limit <n>] [--force]
+ *   bun HarvestExecutor.ts --help
+ *
+ * @see ~/.claude/skills/Harvest/SKILL.md
  */
 
 import { parseArgs } from "node:util";

--- a/LifeOS/install/LIFEOS/TOOLS/HealthSnapshot.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/HealthSnapshot.ts
@@ -1,4 +1,17 @@
 #!/usr/bin/env bun
+/**
+ * HealthSnapshot.ts — ingest health JSON drops from the iCloud inbox into dated Markdown snapshots.
+ *
+ * Reads JSON files from the iCloud health inbox, renders each into a
+ * TELOS/HEALTH/snapshots/YYYY-MM-DD.md metric table, and moves the source into
+ * the processed folder. Snapshot paths resolve through LifeosConfig so a
+ * relocated user dir keeps working.
+ *
+ * Usage:
+ *   bun HealthSnapshot.ts ingest   # process every .json in the inbox into snapshots
+ *   bun HealthSnapshot.ts sample   # drop a sample snapshot into the inbox to test
+ *   bun HealthSnapshot.ts status   # show inbox count, latest snapshot, paths
+ */
 import { readdir, readFile, writeFile, rename, mkdir } from "node:fs/promises"
 import { existsSync } from "node:fs"
 import { homedir } from "node:os"

--- a/LifeOS/install/LIFEOS/TOOLS/LifeosConfig.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/LifeosConfig.ts
@@ -15,6 +15,11 @@
  *   - PULSE.user.toml already in user-config dir as precedent.
  *
  * See: LIFEOS/DOCUMENTATION/SystemUserBoundary.md § "The four allowed access patterns".
+ *
+ * Usage: bun LifeosConfig.ts   # print the resolved, validated config as JSON
+ * Consumed by: Banner tools, PULSE (pulse.ts, telegram), hooks/lib/identity,
+ *   HealthSnapshot.ts, GenerateTelosSummary.ts, and other system modules that
+ *   compose paths or read identity/voice/integration values.
  */
 
 import { existsSync, statSync } from "node:fs";

--- a/LifeOS/install/LIFEOS/TOOLS/LifeosLogo.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/LifeosLogo.ts
@@ -1,13 +1,13 @@
 #!/usr/bin/env bun
 
 /**
- * LifeOS Logo - Figlet-style A + I
+ * LifeosLogo.ts — print the LifeOS wordmark as ANSI-colored ASCII art.
  *
- * Classic ASCII art style like figlet/toilet
- * - A blocky "A" where the P is hidden through color
- * - P portion (left leg + top + crossbar) = purple
- * - Right leg of A (below crossbar) = blue
- * - I next to it in cyan
+ * Figlet-style blocky "AI" wordmark: a blocky "A" with the "P" hidden through
+ * color (purple left leg/top/crossbar, blue right leg) beside a cyan "I".
+ * Also exports printLogo()/getLogo() for reuse by other tools.
+ *
+ * Usage: bun LifeosLogo.ts   # print the logo to stdout
  */
 
 const rgb = (r: number, g: number, b: number) => `\x1b[38;2;${r};${g};${b}m`;

--- a/LifeOS/install/LIFEOS/TOOLS/MemoryGraph.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/MemoryGraph.ts
@@ -7,7 +7,7 @@ for (const __k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
 }
 
 /**
- * MemoryGraph — a first-class graph layer over the WHOLE LifeOS memory system.
+ * MemoryGraph.ts — a first-class graph layer over the WHOLE LifeOS memory system.
  *
  * Supersedes KnowledgeGraph.ts (KNOWLEDGE-only, console-text, no clustering).
  * Ingests every memory silo as nodes, builds DECLARED edges (related / wikilink /
@@ -21,6 +21,8 @@ for (const __k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
  * so the trustworthy baseline ships first. Inference is a later, validated layer.
  *
  * Privacy: 100% local. Zero network calls.
+ *
+ * Usage: bun MemoryGraph.ts <command>
  *
  * Commands:
  *   build      Rebuild the graph cache (graph.json) + PATTERNS.md

--- a/LifeOS/install/LIFEOS/TOOLS/MergeSettings.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/MergeSettings.ts
@@ -1,12 +1,23 @@
 #!/usr/bin/env bun
 
 /**
+ * MergeSettings.ts — deep-merge system settings JSON with a user overlay.
+ *
  * Deep-merges a system settings JSON value with a user overlay.
  * Objects merge recursively while preserving system key order.
  * New user-only object keys are appended after system keys at each level.
  * Scalars and arrays replace by default, with user values winning conflicts.
  * Arrays can opt into append via { "__merge": "append", "values": [...] }.
  * Merge annotations are consumed and never emitted in the output.
+ *
+ * Usage:
+ *   bun MergeSettings.ts --system SYSTEM --user USER --output OUTPUT
+ *   bun MergeSettings.ts --system SYSTEM --user USER --check EXISTING
+ *
+ * Consumed by: SettingsBackport.ts (imports mergeSettings, deepEqual,
+ *   parseJsonFileOrThrow, MERGE_SNAPSHOT_PATH).
+ *
+ * @see ~/.claude/LIFEOS/DOCUMENTATION/Config/ConfigSystem.md
  */
 
 import { readFile, writeFile } from "node:fs/promises";

--- a/LifeOS/install/LIFEOS/TOOLS/NeofetchBanner.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/NeofetchBanner.ts
@@ -1,7 +1,10 @@
 #!/usr/bin/env bun
 
 /**
- * NeofetchBanner - LifeOS System Banner in Neofetch Style
+ * NeofetchBanner.ts — neofetch-style LifeOS system banner, Tokyo Night palette (alternative theme)
+ *
+ * Alternative theme prototype: the CLI launcher renders Banner.ts, not this
+ * file. Run directly to preview.
  *
  * Layout:
  *   LEFT:   Isometric LifeOS cube logo (ASCII/Braille art)
@@ -13,6 +16,11 @@
  *   - Binary streams
  *   - Targeting reticle elements
  *   - Neon glow feel
+ *
+ * Usage:
+ *   bun NeofetchBanner.ts            # render (auto full/compact by terminal width)
+ *   bun NeofetchBanner.ts --compact  # force compact layout
+ *   bun NeofetchBanner.ts --test     # render compact and normal
  */
 
 import { readdirSync, existsSync, readFileSync } from "fs";

--- a/LifeOS/install/LIFEOS/TOOLS/PangramScore.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/PangramScore.ts
@@ -9,7 +9,7 @@ for (const __k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
 /**
  * PangramScore.ts — score text for AI-detectability via the Pangram API.
  *
- * Use it as a voice-eval probe: feed in my (or anyone's) writing and get back
+ * Use it as a voice-eval probe: feed in anyone's writing and get back
  * how much of it reads as AI-generated. Lower fraction_ai = sounds more human.
  *
  * Two-step async flow (from the official docs, June 2026):
@@ -22,6 +22,12 @@ for (const __k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
  *
  * Key: PANGRAM_API_KEY in ~/.claude/.env (not present yet — add it before running).
  * Override the endpoint with PANGRAM_API_URL if Pangram moves it.
+ *
+ * Usage:
+ *   bun PangramScore.ts "text to score"
+ *   bun PangramScore.ts --file path/to/sample.md
+ *   echo "text" | bun PangramScore.ts
+ *   ... add --json for the raw response
  */
 
 import { readFileSync, appendFileSync, mkdirSync } from "node:fs";

--- a/LifeOS/install/LIFEOS/TOOLS/PiSync.sh
+++ b/LifeOS/install/LIFEOS/TOOLS/PiSync.sh
@@ -3,6 +3,8 @@
 #
 # v2 — matches existing Pi skills by frontmatter `name:` field rather than
 # regex on dir name. Avoids the ALLCAPS/ArXiv duplicate problem in v1.
+#
+# Usage: ./PiSync.sh   (or: bash PiSync.sh)   # takes no arguments
 
 set -euo pipefail
 

--- a/LifeOS/install/LIFEOS/TOOLS/PipelineOrchestrator.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/PipelineOrchestrator.ts
@@ -1,16 +1,15 @@
 #!/usr/bin/env bun
 /**
- * ============================================================================
- * LifeOS Pipeline Orchestrator - Run Pipelines with Monitoring
- * ============================================================================
+ * PipelineOrchestrator.ts — run LifeOS pipelines and report progress to the monitor.
  *
- * Runs pipelines and reports progress to the PipelineMonitor.
+ * Loads a pipeline definition from ../PIPELINES, executes each step (actions
+ * resolved from ../ACTIONS), and POSTs start/update/finish events to the
+ * PipelineMonitor at $MONITOR_URL (default http://localhost:8765). Runs
+ * silently when the monitor is unreachable.
  *
- * USAGE:
+ * Usage:
  *   bun PipelineOrchestrator.ts run <pipeline> [--input '<json>'] [--agent <name>]
- *   bun PipelineOrchestrator.ts demo   # Run demo with multiple pipelines
- *
- * ============================================================================
+ *   bun PipelineOrchestrator.ts demo   # run demo with multiple pipelines
  */
 
 import { readFile } from "fs/promises";

--- a/LifeOS/install/LIFEOS/TOOLS/PreviewMarkdown.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/PreviewMarkdown.ts
@@ -1,6 +1,11 @@
 #!/usr/bin/env bun
 /**
- * Preview a markdown file in the browser
+ * PreviewMarkdown.ts — render a Markdown file to HTML and open it in the browser.
+ *
+ * Reads the given Markdown file, renders it to a self-contained HTML page
+ * (marked + DOMPurify sanitize), writes it to a temp dir, and opens it in the
+ * system browser. Prints the resulting file:// URL as JSON.
+ *
  * Usage: bun PreviewMarkdown.ts <path-to-markdown>
  */
 

--- a/LifeOS/install/LIFEOS/TOOLS/RemoveBg.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/RemoveBg.ts
@@ -1,15 +1,19 @@
 #!/usr/bin/env bun
 
 /**
- * remove-bg - Background Removal CLI
+ * RemoveBg.ts — remove image backgrounds with local rembg (no API).
  *
- * Remove backgrounds from images using local rembg.
- * Part of the Images skill for LifeOS system.
+ * Cuts the background from PNG/JPG/JPEG/WebP images using a local rembg binary
+ * (resolved from $REMBG_BIN or ~/.local/bin/rembg). Always writes PNG (alpha
+ * channel required); routes every cut through a temp file so it never truncates
+ * its own source. Overwrites in place, writes to a named output, or batches.
  *
  * Usage:
- *   remove-bg input.png                    # Overwrites original
- *   remove-bg input.png output.png         # Saves to new file
- *   remove-bg file1.png file2.png file3.png # Batch process
+ *   bun RemoveBg.ts input.png                     # overwrite original
+ *   bun RemoveBg.ts input.jpg output.png          # write to a new file
+ *   bun RemoveBg.ts file1.png file2.png file3.png # batch process
+ *
+ * @see ~/.claude/skills/Art/SKILL.md
  */
 
 import { resolve, extname } from "node:path";

--- a/LifeOS/install/LIFEOS/TOOLS/RetagSweepTypes.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/RetagSweepTypes.ts
@@ -11,6 +11,10 @@
  * Type:queue) are left untouched.
  *
  * Dry-run by default. `--apply` mutates via `gh issue edit`.
+ *
+ * Usage:
+ *   bun RetagSweepTypes.ts           # dry-run: print the planned label changes
+ *   bun RetagSweepTypes.ts --apply   # apply the changes via `gh issue edit`
  */
 import { classifyType } from "./WorkSweep";
 import { loadWorkConfig } from "../../hooks/lib/work-config";

--- a/LifeOS/install/LIFEOS/TOOLS/SessionProgress.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/SessionProgress.ts
@@ -1,12 +1,21 @@
 #!/usr/bin/env bun
 /**
- * Session Progress CLI
+ * SessionProgress.ts — manage session-continuity files for multi-session work.
  *
- * Manages session continuity files for multi-session work.
- * Based on Anthropic's claude-progress.txt pattern.
+ * Creates and updates per-project progress files (objectives, decisions,
+ * completed work, blockers, handoff notes, next steps) so a later session can
+ * resume with full context. Based on the claude-progress.txt pattern.
  *
  * Usage:
- *   bun run ~/.claude/LIFEOS/TOOLS/SessionProgress.ts <command> [options]
+ *   bun SessionProgress.ts create <project> [objectives...]
+ *   bun SessionProgress.ts decision <project> <decision> <rationale>
+ *   bun SessionProgress.ts work <project> <description> [artifacts...]
+ *   bun SessionProgress.ts blocker <project> <blocker> [resolution]
+ *   bun SessionProgress.ts next <project> <step1> <step2>...
+ *   bun SessionProgress.ts handoff <project> <notes>
+ *   bun SessionProgress.ts resume <project>
+ *   bun SessionProgress.ts list
+ *   bun SessionProgress.ts complete <project>
  */
 
 import { existsSync, readFileSync, writeFileSync, readdirSync } from 'fs';

--- a/LifeOS/install/LIFEOS/TOOLS/SplitAndTranscribe.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/SplitAndTranscribe.ts
@@ -1,9 +1,14 @@
 #!/usr/bin/env bun
 
 /**
- * split-and-transcribe.ts
+ * SplitAndTranscribe.ts — split a large audio file into chunks and transcribe with Whisper.
  *
- * Helper to split large audio files and transcribe them
+ * Splits an audio file into ~20MB segments with ffmpeg (to stay under the
+ * OpenAI 25MB limit), transcribes each chunk via the Whisper API, merges the
+ * results, and cleans up the temp chunks. Requires OPENAI_API_KEY.
+ * Also exports splitAndTranscribe() for programmatic use.
+ *
+ * Usage: bun SplitAndTranscribe.ts <file> [format]   # format: txt (default) | json | srt | vtt
  */
 
 import { spawn } from "child_process";

--- a/LifeOS/install/LIFEOS/TOOLS/current-work-dir.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/current-work-dir.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 /**
- * current-work-dir.ts
+ * current-work-dir.ts — print the absolute work directory of the active LifeOS session
  *
  * Prints the work directory (absolute path) of the principal's current active
  * LifeOS session, resolved against the canonical session registry at

--- a/LifeOS/install/LIFEOS/TOOLS/gmail.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/gmail.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env bun
+// gmail.ts — direct Gmail API client (count/ids/archive/fetch/send) over an OAuth refresh token
+//
 // Direct Gmail API client using OAuth refresh token.
 // Usage:
 //   gmail.ts count "<q>"                           # inbox-size estimate for query


### PR DESCRIPTION
## Summary

Every flat (single-file) tool in `LIFEOS/TOOLS/` now carries a doc header that says what it is, how to run it, and where its governing doc lives. Comment-only — zero code changes.

Agents and humans alike decide what a tool does by reading its head. Most tools here already follow a strong de-facto convention (see `Inference.ts`, `WorkSweep.ts`, `ISARender.ts`); this PR brings the stragglers up to the same bar: on a census of the shipped root, ~25 tools were missing an identity line and/or usage, and several were completely headerless (`ForgeProgress.ts`, `HealthSnapshot.ts`, `SplitAndTranscribe.ts`).

## The header contract (codified from the corpus, not invented)

A flat tool's leading comment block carries:

1. **Identity line** — `<Name>.ts — <one-line purpose>`
2. **Purpose prose** — 1–6 lines: what it does, why it exists, its cardinal boundary if it has one
3. **Usage** — runnable invocation(s) for invocable tools; pure library modules instead state "Library, not a CLI" plus a `Consumed by:` line; dual modules carry both
4. **`@see` pointer** — only where a governing doc actually exists (skill, system doc, subsystem README)

That's the whole contract, stated here in full — this PR intentionally cites no standard file, since none ships in the repo today. A short standard doc codifying the contract may follow as a separate contribution.

## What's in the diff

- Header additions/gap-fixes across the flat root (including `PiSync.sh`), each derived from the file's actual code — argv handling read before writing usage lines.
- Banner theme variants (`BannerMatrix`, `BannerNeofetch`, `BannerPrototypes`, `BannerRetro`, `BannerTokyo`, `NeofetchBanner`) are honestly labeled as alternative prototypes not wired to the launcher (only `Banner.ts` is invoked).
- One substance fix: `GetTranscript.ts`'s usage examples pointed at a `skills/Videotranscript/` location that does not exist in the repo; corrected to the tool's real path.

## Verification

- Diffs are comment-only (checked mechanically: no non-comment line added or removed).
- A deterministic header audit (regex over the element contract) passes for every tool in the root after this PR.

---

