### PR TITLE
fix(pulse): route GET /voice/health to the voice module (was 404)

### DIFF
--- a/LifeOS/install/LIFEOS/PULSE/pulse.ts
+++ b/LifeOS/install/LIFEOS/PULSE/pulse.ts
@@ -676,7 +676,7 @@ async function main() {
       }
 
       // Voice routes: /notify, /notify/personality, /voice
-      if (voiceModule && (pathname === "/notify" || pathname === "/notify/personality" || pathname === "/voice")) {
+      if (voiceModule && (pathname === "/notify" || pathname === "/notify/personality" || pathname === "/voice" || pathname === "/voice/health")) {
         const resp = await voiceModule.handleVoiceRequest(req, pathname)
         if (resp) return resp
       }


### PR DESCRIPTION
## Problem

`GET /voice/health` returns **404**. The voice module implements the route (`VoiceServer/voice.ts:657`) and even advertises it in its own OPTIONS/CORS list, but Pulse's top-level forwarding gate never routes that path to the module.

## Root cause

`pulse.ts` only forwards three paths to `handleVoiceRequest`:

```ts
if (voiceModule && (pathname === "/notify" || pathname === "/notify/personality" || pathname === "/voice")) {
```

`/voice/health` is not in the set, so it falls through to the generic 404 and the module's handler is never invoked.

## Fix

Add `/voice/health` to the gate:

```ts
if (voiceModule && (pathname === "/notify" || pathname === "/notify/personality" || pathname === "/voice" || pathname === "/voice/health")) {
```

One-line change. Verified live on a running Pulse: after the change, `curl http://127.0.0.1:31337/voice/health` returns **200** (was 404).

## Affected file
- `LifeOS/install/LIFEOS/PULSE/pulse.ts` (the voice forwarding gate)
