### PR TITLE
fix(pulse): start telos module so /api/telos/health reports live state

### DIFF
--- a/LifeOS/install/LIFEOS/PULSE/pulse.ts
+++ b/LifeOS/install/LIFEOS/PULSE/pulse.ts
@@ -188,6 +188,7 @@ async function loadModules(config: PulseConfig) {
   if (config.telos?.enabled !== false) {
     try {
       telosModule = await import("./modules/telos")
+      if (telosModule.start) await telosModule.start()
     } catch (err) {
       log("warn", "Telos freshness module not available", { error: String(err) })
     }


### PR DESCRIPTION
## Problem

`GET /api/telos/health` always reports `{"status":"stopped"}`, even though the telos module works (its `/api/telos/freshness` and related endpoints return live data).

## Root cause

`modules/telos.ts` gates its health on `state.running`:

```ts
if (!state.running) return { status: "stopped" };
```

`state.running` is only set true inside the module's `start()`. Every other Pulse module gets `.start()` called right after import in `pulse.ts` (memory, conduit, menubar, books, hypotheses, …), but the telos import does not:

```ts
telosModule = await import("./modules/telos")
// <-- no start() call, unlike every sibling
```

So `state.running` is permanently false and health is stuck on "stopped". The other telos endpoints work because they compute live and don't depend on `state.running`.

## Fix

Call `start()` after import, mirroring the sibling modules:

```ts
telosModule = await import("./modules/telos")
if (telosModule.start) await telosModule.start()
```

Verified live on a running Pulse: after the change, `curl http://127.0.0.1:31337/api/telos/health` returns `{"status":"healthy", ...}` (was `"stopped"`).

## Affected file
- `LifeOS/install/LIFEOS/PULSE/pulse.ts` (telos module load block)
