### PR TITLE
docs(cli): drop hardcoded '6.0.0' version banner (install is 7.1.1)

### DIFF
--- a/LifeOS/install/LIFEOS/DOCUMENTATION/Tools/Cli.md
+++ b/LifeOS/install/LIFEOS/DOCUMENTATION/Tools/Cli.md
@@ -2,7 +2,7 @@
 version: 1.1.10
 ---
 
-> **LifeOS 6.0.0** — This system is under active development. APIs, configuration formats, and features may change without notice.
+> **LifeOS** — This system is under active development. APIs, configuration formats, and features may change without notice. (Version lives in `LIFEOS/VERSION`.)
 
 # LifeOS Command-Line Tools
 


### PR DESCRIPTION
## Problem

`Tools/Cli.md` opens with a hardcoded banner reading **LifeOS 6.0.0**, but this install is on 7.1.1 (`LIFEOS/VERSION`), and the master doc + `ARCHITECTURE_SUMMARY` both say 7.1.1. The hardcoded number drifts on every release.

## Fix

Drop the hardcoded version from the banner and point to `LIFEOS/VERSION` as the source of truth.

## File
- `LifeOS/install/LIFEOS/DOCUMENTATION/Tools/Cli.md`
