### PR TITLE
feat(pulse): agents Actions list — newest-first default, date on non-today events, sort toggle

### DIFF
--- a/LifeOS/install/LIFEOS/PULSE/Observability/src/components/activity/EventRow.tsx
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/src/components/activity/EventRow.tsx
@@ -138,12 +138,31 @@ const EVENT_TYPE_LABELS: Record<string, string> = {
 
 function formatTime(timestamp?: number): string {
   if (!timestamp) return "";
-  return new Date(timestamp).toLocaleTimeString("en-GB", {
+  const d = new Date(timestamp);
+  const time = d.toLocaleTimeString("en-GB", {
     hour: "2-digit",
     minute: "2-digit",
     second: "2-digit",
     hour12: false,
   });
+  // Prepend the date when the event is not from today, so cross-day events
+  // stay unambiguous in the Time column.
+  const now = new Date();
+  const isToday =
+    d.getFullYear() === now.getFullYear() &&
+    d.getMonth() === now.getMonth() &&
+    d.getDate() === now.getDate();
+  if (isToday) return time;
+  // Non-today: zero-padded day + 3-letter month (e.g. "03 Jul"). Across a year
+  // boundary, also show the year (e.g. "31 Dec 2025 07:31:22").
+  const sameYear = d.getFullYear() === now.getFullYear();
+  const date = d.toLocaleDateString(
+    "en-GB",
+    sameYear
+      ? { day: "2-digit", month: "short" }
+      : { day: "2-digit", month: "short", year: "numeric" },
+  );
+  return `${date} ${time}`;
 }
 
 function getToolInfo(event: HookEvent): { tool: string; detail?: string } | null {

--- a/LifeOS/install/LIFEOS/PULSE/Observability/src/components/activity/EventTimeline.tsx
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/src/components/activity/EventTimeline.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useRef, useEffect, useMemo } from "react";
+import { useRef, useEffect, useMemo, useState } from "react";
 import type { HookEvent } from "@/hooks/useAgentEvents";
 import type { TimeRange } from "@/hooks/useChartData";
 import EventRow from "./EventRow";
 import IntensityBar from "./IntensityBar";
-import { Box } from "lucide-react";
+import { Box, ArrowDownWideNarrow, ArrowUpWideNarrow } from "lucide-react";
 
 interface EventTimelineProps {
   events: HookEvent[];
@@ -25,17 +25,20 @@ export default function EventTimeline({
   onSetTimeRange,
 }: EventTimelineProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
+  // "desc" = most recent first (the default when Actions opens); "asc" = oldest first.
+  const [sortOrder, setSortOrder] = useState<"desc" | "asc">("desc");
 
   const sortedEvents = useMemo(() => {
-    return events.slice().reverse();
-  }, [events]);
+    const arr = events.slice().sort((a, b) => (a.timestamp ?? 0) - (b.timestamp ?? 0));
+    return sortOrder === "desc" ? arr.reverse() : arr;
+  }, [events, sortOrder]);
 
-  // Auto-scroll to top on new events
+  // Auto-scroll to top on new events — only meaningful when newest is at the top.
   useEffect(() => {
-    if (scrollRef.current) {
+    if (sortOrder === "desc" && scrollRef.current) {
       scrollRef.current.scrollTop = 0;
     }
-  }, [events.length]);
+  }, [events.length, sortOrder]);
 
   return (
     <div className="flex-1 overflow-hidden flex flex-col">
@@ -60,7 +63,26 @@ export default function EventTimeline({
           <span className="w-20">Tool</span>
           <span className="flex-1">Details</span>
         </div>
-        <span className="w-16 text-right">Time</span>
+        <div className="w-24 flex items-center justify-end gap-1">
+          <span>Time</span>
+          <button
+            type="button"
+            onClick={() => setSortOrder((o) => (o === "desc" ? "asc" : "desc"))}
+            title={
+              sortOrder === "desc"
+                ? "Most recent first — click for oldest first"
+                : "Oldest first — click for most recent first"
+            }
+            aria-label="Toggle sort order"
+            className="p-0.5 rounded hover:bg-white/[0.06] text-[var(--ink-3)] hover:text-[var(--ink-1)] transition-colors"
+          >
+            {sortOrder === "desc" ? (
+              <ArrowDownWideNarrow size={13} />
+            ) : (
+              <ArrowUpWideNarrow size={13} />
+            )}
+          </button>
+        </div>
       </div>
 
       {/* Scrollable Event List */}


### PR DESCRIPTION
## What this improves

Three behaviors on the **Agents → Actions** event list (`ObservabilityDashboard` → `EventTimeline` / `EventRow`):

1. **Most-recent-first by default** when Actions opens. Sorting is now explicit on `timestamp` rather than a blind `reverse()`, so order is deterministic regardless of the incoming array order.
2. **Date on non-today events.** The Time column shows time only for today's events; for older events it prepends a zero-padded day + 3-letter month (`03 Jul`), and across a year boundary it also shows the year (`31 Dec 2025 07:31:22`).
3. **Sort toggle** next to the Time column header — an arrow button flips between most-recent-first and oldest-first. Auto-scroll-to-top only fires in most-recent-first mode (otherwise it would scroll away from new events).

## Files
- `LifeOS/install/LIFEOS/PULSE/Observability/src/components/activity/EventTimeline.tsx` — `sortOrder` state, explicit sort, header toggle button, scroll gate
- `LifeOS/install/LIFEOS/PULSE/Observability/src/components/activity/EventRow.tsx` — `formatTime()` date-aware rendering

Frontend-only; no backend change. `out/` build artifacts excluded (regenerated by `bun run build`).

## Verification
- `bun run build` in `Observability/` → compiled successfully, `/agents` route emitted; `curl /agents` → 200.
- Visual interaction (toggle, date rendering) not browser-verified — this headless host has no Chrome for Interceptor. Logic compiles clean; rendered behavior is deferred-verify.
