### PR TITLE
docs(arbol): mark the private Arbol CLI tree as not shipped in public release

### DIFF
--- a/LifeOS/install/LIFEOS/DOCUMENTATION/Arbol/ArbolSystem.md
+++ b/LifeOS/install/LIFEOS/DOCUMENTATION/Arbol/ArbolSystem.md
@@ -193,6 +193,8 @@ Actions declare dependencies in `action.json` under `requires`. The runner injec
 | `A_EXTRACT_TRANSCRIPT` | `arbol-a-extract-transcript` | Sandbox |
 | `A_SEND_EMAIL` | `arbol-a-send-email` | Custom |
 
+> **Private component — not in the public release.** The `~/.claude/LIFEOS/ARBOL/` tree (Actions, Pipelines, runner) is per-machine and does not ship publicly; these paths will not exist on a public install. The public Arbol surface is the `USER/CUSTOMIZATIONS/ARBOL/` scaffold.
+
 ### Running Actions
 
 **Local:**

--- a/LifeOS/install/LIFEOS/DOCUMENTATION/Tools/Cli.md
+++ b/LifeOS/install/LIFEOS/DOCUMENTATION/Tools/Cli.md
@@ -197,6 +197,8 @@ Loop mode displays a live progress dashboard:
 
 ---
 
+> **Private component — not in the public release.** The `~/.claude/LIFEOS/ARBOL/` CLI tree is per-machine and does not ship publicly; these paths will not exist on a public install. The only Arbol surface that ships is the `USER/CUSTOMIZATIONS/ARBOL/` scaffold.
+
 ## The Arbol CLI (pai)
 
 **Location:** `~/.claude/LIFEOS/ARBOL/Actions/lifeos.ts`


### PR DESCRIPTION
## Problem

`Tools/Cli.md` and `Arbol/ArbolSystem.md` document an Arbol CLI tree at `~/.claude/LIFEOS/ARBOL/` (Actions, Pipelines, `runner.v2.ts`, shell aliases), but that path does not exist in the public tree — only `USER/CUSTOMIZATIONS/ARBOL/` ships. Every documented Arbol command fails file-not-found on a public install.

## Fix

Add a "private component, not in the public release" callout to the Arbol CLI section of both docs, noting the paths are per-machine and that `USER/CUSTOMIZATIONS/ARBOL/` is the only shipped surface.

## Files
- `LifeOS/install/LIFEOS/DOCUMENTATION/Tools/Cli.md`
- `LifeOS/install/LIFEOS/DOCUMENTATION/Arbol/ArbolSystem.md`
