### PR TITLE
docs(claude): fix wrong-case ISA/ paths to Isa/ in the routing table

### DIFF
--- a/LifeOS/install/CLAUDE.template.md
+++ b/LifeOS/install/CLAUDE.template.md
@@ -47,8 +47,8 @@ This file is the **routing table** — it tells you where everything lives. The 
 - Freshness convention (`pai-freshness-v1`) — `Freshness/FreshnessSystem.md`
 - Terminal tabs — `Pulse/TerminalTabs.md`
 - Tools reference — `Tools/Tools.md`
-- ISA — `ISA/IsaSystem.md`
-- ISA format spec — `ISA/IsaFormat.md`
+- ISA — `Isa/IsaSystem.md`
+- ISA format spec — `Isa/IsaFormat.md`
 - Testing doctrine — `Testing/TestingDoctrine.md`
 - System/user boundary — `SystemUserBoundary.md` (which files are SYSTEM, which are USER, how the boundary is enforced)
 - AI writing patterns (system-level reference) — `Writing/AIWritingPatterns.md`


### PR DESCRIPTION
## Problem

The routing table lists the ISA docs with a wrong-case `ISA/` path (`ISA/IsaSystem.md`, `ISA/IsaFormat.md`). The directory is `LIFEOS/DOCUMENTATION/Isa/` (case-sensitive on Linux), so those links fail an existence check. `ARCHITECTURE_SUMMARY` already uses the correct `Isa/` case.

## Fix

Change the two rows to `Isa/IsaSystem.md` and `Isa/IsaFormat.md`.

## File
- `LifeOS/install/CLAUDE.template.md`
