### PR TITLE
docs(work): note USER/WORK config files are created by work-system setup, not shipped

### DIFF
--- a/LifeOS/install/LIFEOS/DOCUMENTATION/Work/WorkSystem.md
+++ b/LifeOS/install/LIFEOS/DOCUMENTATION/Work/WorkSystem.md
@@ -176,7 +176,7 @@ A `<da-name>-can-take` label serves as the queue marker for "the DA should pick 
 |-------|----------|----------|-------------------|
 | **System code (public)** | `~/.claude/LIFEOS/PULSE/`, `~/.claude/LIFEOS/TOOLS/`, generic capture hooks under `~/.claude/hooks/` | Modules, CLIs, generic hooks | YES — scrubbed, public-clean |
 | **Private components** | `~/.claude/skills/_ULWORK/`, `~/.claude/hooks/ULWorkSync.hook.ts` | Underscore-private skill + principal-specific SessionEnd capture hook (target the private UL work repo) | NO — rsync-excluded from the public release payload, same as any underscore-prefixed private skill |
-| **User config** | `~/.claude/LIFEOS/USER/WORK/` | `labels.yml`, `config.yaml`, `work_repo.json`, `README.md` | NO — USER zone, excluded by containment |
+| **User config** | `~/.claude/LIFEOS/USER/WORK/` | `labels.yml`, `config.yaml`, `work_repo.json` (these three are created by the work-system setup — `SetWorkRepo.ts --bootstrap`, see below; only `README.md` ships by default), `README.md` | NO — USER zone, excluded by containment |
 | **Templates for new users** | `~/.claude/skills/_LIFEOS/RELEASE_TEMPLATES/WORK_REPO/` | README template, TASKLIST starter, .github/labels.yml, ISSUE_TEMPLATE, workflows | YES — placeholder substitution at user-setup time (planned, not yet built) |
 | **Live repo** | The configured private GitHub repo | Issues, TASKLIST.md, README, SOPs, CHANGELOG | NO — user's private property |
 


### PR DESCRIPTION
## Problem

`Work/WorkSystem.md` (and CLAUDE.md) list `USER/WORK/config.yaml`, `labels.yml`, and `work_repo.json` as user-config files, but on a fresh install `USER/WORK/` contains only `README.md` and sample dirs — those three files don't exist yet. The doc presents them as if always present.

## Fix

Note in the config-file row that `labels.yml` / `config.yaml` / `work_repo.json` are created by the work-system setup (`SetWorkRepo.ts --bootstrap`, already documented lower in the same file), and only `README.md` ships by default.

## File
- `LifeOS/install/LIFEOS/DOCUMENTATION/Work/WorkSystem.md`
