### PR TITLE
feat(lifeos): add 'doctor' subcommand so the advised 'lifeos doctor' works

### DIFF
--- a/LifeOS/install/LIFEOS/TOOLS/lifeos.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/lifeos.ts
@@ -623,6 +623,7 @@ USAGE:
 
 COMMANDS:
   k update                 Update Claude Code to latest version
+  k doctor                 Run the LifeOS capability check (Doctor.ts)
   k version, -v            Show version information
   k profiles               List available MCP profiles
   k mcp list               List all available MCPs
@@ -659,6 +660,18 @@ EXAMPLES:
 // Main
 // ============================================================================
 
+async function cmdDoctor(extraArgs: string[]): Promise<void> {
+  // Delegate to the standalone Doctor.ts capability checker. This makes the
+  // `lifeos doctor` invocation the statusline/Doctor.ts advise actually work.
+  const doctorPath = `${import.meta.dir}/Doctor.ts`;
+  const result = spawnSync(["bun", doctorPath, ...extraArgs], {
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  process.exit(result.exitCode ?? 0);
+}
+
 async function main() {
   const args = process.argv.slice(2);
 
@@ -679,6 +692,7 @@ async function main() {
   let subArg: string | undefined;
   let promptText: string | undefined;
   let wallpaperArgs: string[] = [];
+  let doctorArgs: string[] = [];
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -728,6 +742,11 @@ async function main() {
       case "profiles":
         command = "profiles";
         break;
+      case "doctor":
+        command = "doctor";
+        doctorArgs = args.slice(i + 1);
+        i = args.length; // forward remaining args to Doctor.ts
+        break;
       case "mcp":
         command = "mcp";
         subCommand = args[++i];
@@ -766,6 +785,9 @@ async function main() {
       break;
     case "profiles":
       cmdProfiles();
+      break;
+    case "doctor":
+      await cmdDoctor(doctorArgs);
       break;
     case "mcp":
       if (subCommand === "list") {


### PR DESCRIPTION
## Problem

`Doctor.ts` and the statusline advise running `lifeos doctor` on a capability regression (`Doctor.ts:270,338` write "capability regression — lifeos doctor" into the statusline). But `lifeos.ts` has no `doctor` subcommand, so `bun LIFEOS/TOOLS/lifeos.ts doctor` errors with `Unknown command: doctor`. The working invocation is the more obscure `bun LIFEOS/TOOLS/Doctor.ts`.

## Fix

Add a `doctor` subcommand to `lifeos.ts` that execs `Doctor.ts` (forwarding any extra args like `decline <name>`), plus a help line. Verified live: `bun lifeos.ts doctor` now runs the capability check (exit 0) instead of erroring.

## File
- `LifeOS/install/LIFEOS/TOOLS/lifeos.ts`
