### PR TITLE
docs(pulse): reconcile DA/Assistant module path and mark it private/stripped

### DIFF
--- a/LifeOS/install/LIFEOS/DOCUMENTATION/Pulse/DaSubsystem.md
+++ b/LifeOS/install/LIFEOS/DOCUMENTATION/Pulse/DaSubsystem.md
@@ -9,7 +9,7 @@ version: 1.0.10
 **The DA subsystem formalizes how LifeOS instantiates, manages, and evolves a Digital Assistant. It turns DA_IDENTITY from a flat markdown file into a living schema with interview-based creation, heartbeat-driven proactivity, natural-language scheduling, identity growth, and multi-DA awareness.**
 
 **Version:** 1.0 (Design)
-**Location:** Integrated into Pulse (`modules/da.ts`) + LIFEOS/USER/DA/
+**Location:** Shipped as a private module at `Assistant/module.ts` (stripped from the public release per #1419; `pulse.ts` existence-checks it and omits the `/assistant` routes when absent) + LIFEOS/USER/DA/. Note: an earlier design targeted `modules/da.ts`; the implemented path is `Assistant/module.ts`, matching `PulseSystem.md`.
 **Status:** Architecture complete, pending implementation
 
 ---

--- a/LifeOS/install/LIFEOS/DOCUMENTATION/Pulse/PulseSystem.md
+++ b/LifeOS/install/LIFEOS/DOCUMENTATION/Pulse/PulseSystem.md
@@ -35,7 +35,7 @@ Each subsystem runs in its own crash-isolated loop within the single Pulse proce
 | **Telegram** | grammY polling bot — per-turn LifeOS memory injection, claude-agent-sdk session, dynamic Sonnet-summarize → ElevenLabs voice-summary reply, 60-min idle-session boundary. See "Telegram Voice Pipeline" below. | `modules/telegram.ts` |
 | **iMessage** | SQLite polling bot with claude-agent-sdk sessions (absorbed from the iMessage bot, disabled by default) | `modules/imessage.ts` |
 | **Worker** | GitHub Issues work polling for LifeOS Workers (optional) | `checks/github-work.ts` |
-| **Assistant** | Digital Assistant identity, heartbeat, scheduling, growth | `Assistant/module.ts` |
+| **Assistant** | Digital Assistant identity, heartbeat, scheduling, growth. **Private module** — stripped from the public release (#1419); `pulse.ts` skips it and the `/assistant` API routes are absent on public installs (the static `/assistant` page still renders). | `Assistant/module.ts` |
 | **UserIndex** | LifeOS USER/ indexer — parses frontmatter + collections into typed JSON; fs.watch live refresh; powers `/life` dashboard + Daemon publish feed | `modules/user-index.ts` |
 | **Doctor** | Read-only System Health surface (2026-07-12, #1461). Serves `GET /api/doctor` → `{ manifest, heartbeat, reconcile }` from the advisory caches written by `LIFEOS/TOOLS/Doctor.ts`; shells `Doctor.ts --reconcile` (30s cache). Holds zero truth of its own. Rendered by `SystemHealthPanel.tsx` on the **System → Hooks** page: capability states + fix commands, doctor heartbeat age (red past 7 days — a dead checker must be loud), and hook reconciliation. Diagnostic register, no scores. | `modules/doctor.ts` |
 


### PR DESCRIPTION
## Problem

The DA/Assistant Pulse module is documented inconsistently:
- `DaSubsystem.md` says it lives at `modules/da.ts`, status "pending implementation".
- `PulseSystem.md` lists a live **Assistant** module at `Assistant/module.ts`.

Neither `modules/da.ts` nor `Assistant/module.ts` exists on a public install — it's a private module stripped from the public release (`pulse.ts` existence-checks `./Assistant/module` and omits the `/assistant` routes when absent, #1419).

## Fix

Reconcile both docs on the actually-imported path (`Assistant/module.ts`) and note it is a private module absent from the public release, so `/assistant` API routes don't exist publicly.

Note: the `assistant-*` cron jobs in `PULSE.toml` are already correctly `enabled = false` with an explanatory comment (#1392), so no PULSE.toml change is needed — the audit's claim that they ship enabled was stale.

## Files
- `LifeOS/install/LIFEOS/DOCUMENTATION/Pulse/DaSubsystem.md`
- `LifeOS/install/LIFEOS/DOCUMENTATION/Pulse/PulseSystem.md`
