### PR TITLE
docs: annotate private _* skill paths as absent from the public release

### DIFF
--- a/LifeOS/install/LIFEOS/DOCUMENTATION/Amber/AmberSystem.md
+++ b/LifeOS/install/LIFEOS/DOCUMENTATION/Amber/AmberSystem.md
@@ -65,6 +65,8 @@ Everything that can drop an idea into Amber. Each is real unless marked `roadmap
 | # | Input | Trigger | LifeOS component | Status |
 |---|-------|---------|------------------|--------|
 | 1 | **Summarize hotkey** | browser hotkey on any page | Arbol `arbol-a-summarize` (`LIFEOS/USER/CUSTOMIZATIONS/ARBOL/summarize/`) | live |
+> **Note:** `_`-prefixed skill paths referenced below (e.g. `skills/_LIFEOS/`, `skills/_ULWORK/`) are **private skills, absent from the public release** — those paths do not exist on a public install.
+
 | 2 | **Bookmarks → idea-issues** | bookmark sweep (`tb`) | `skills/_X/Tools/bookmark-issue.ts` → `Type:queue` work issues | live |
 | 3 | **Bookmarks → summarize (cloud)** | hourly cron | `ARBOL/Workers/_F_X_BOOKMARKS_SUMMARIZE` → summarize binding → sheet | live |
 | 4 | **Harvest → Knowledge** | `/ha` on a URL/video/text | `skills/_HARVEST` → `_F_HARVEST` → `_A_HARVEST_CLASSIFY` → `HarvestExecutor.ts` | live |

--- a/LifeOS/install/LIFEOS/DOCUMENTATION/Config/ConfigSystem.md
+++ b/LifeOS/install/LIFEOS/DOCUMENTATION/Config/ConfigSystem.md
@@ -39,6 +39,8 @@ LifeOS configuration follows the **system/user separation** contract (`LIFEOS/DO
 | `settings.json` | SYSTEM (generated) | Merged at SessionStart by `MergeSettings.ts` from `settings.system.json` + `settings.user.json`. Read-only at runtime — manual edits get overwritten next session. |
 | `settings.system.json` | SYSTEM | Defaults: hooks, permissions, env, daidentity defaults, notifications, tips. Ships in public LifeOS. |
 | `LIFEOS/USER/CONFIG/settings.user.json` | USER | Per-principal overlay: identity values, voice IDs, principal name + timezone, custom `spinnerVerbs` + `spinnerTipsOverride`, env overrides. Deep-merged into system defaults; USER always wins. |
+> **Note:** `_`-prefixed skill paths referenced below (e.g. `skills/_LIFEOS/`, `skills/_ULWORK/`) are **private skills, absent from the public release** — those paths do not exist on a public install.
+
 | `CLAUDE.md` | SYSTEM (with USER `@`-imports) | Routing table + top-level `@`-imports of USER identity files. Public release template at `skills/_LIFEOS/RELEASE_TEMPLATES/CLAUDE.public.md`. |
 | `LIFEOS/LIFEOS_SYSTEM_PROMPT.md` | SYSTEM | Constitutional rules (system prompt layer, loaded via `--append-system-prompt-file`). |
 | `LIFEOS/USER/CONFIG/OPERATIONAL_RULES.md` | USER | Per-principal operational rules: repo conventions, env paths, vendor-specific doctrine (Cloudflare token, deploy semantics). `@`-imported directly from `CLAUDE.md` — CC does not follow transitive `@`-imports. |

--- a/LifeOS/install/LIFEOS/DOCUMENTATION/LifeOs/LifeOsSchema.md
+++ b/LifeOS/install/LIFEOS/DOCUMENTATION/LifeOs/LifeOsSchema.md
@@ -10,6 +10,8 @@ version: 1.0.4
 
 **Status:** Draft v1.0 · 2026-04-16
 **Applies to:** `LIFEOS/USER/` in every LifeOS installation
+> **Note:** `_`-prefixed skill paths referenced below (e.g. `skills/_LIFEOS/`, `skills/_ULWORK/`) are **private skills, absent from the public release** — those paths do not exist on a public install.
+
 **Companion docs:** `LIFEOS/DOCUMENTATION/LifeOs/LifeOsThesis.md` (the why), `LIFEOS/DOCUMENTATION/Pulse/PulseSystem.md` (the dashboard), `skills/_LIFEOS/RELEASE_TEMPLATES/USER/` (the starter scaffold)
 
 ---

--- a/LifeOS/install/LIFEOS/DOCUMENTATION/LifeosSystemArchitecture.md
+++ b/LifeOS/install/LIFEOS/DOCUMENTATION/LifeosSystemArchitecture.md
@@ -217,6 +217,8 @@ The LifeOS live tree and the public release are structurally identical modulo a 
 **Three enforcement layers:**
 1. **Write-time** — `hooks/SystemFileGuard.hook.ts` (PreToolUse) blocks writes to SYSTEM files when content matches deny-list patterns. Fail-safe-open on hook errors. 19/19 tests pass. Primary defense.
 2. **PR-time** (Phase H, deferred) — GitHub Actions runs `DenyListCheck.ts` on every PR against the public repo.
+> **Note:** `_`-prefixed skill paths referenced below (e.g. `skills/_LIFEOS/`, `skills/_ULWORK/`) are **private skills, absent from the public release** — those paths do not exist on a public install.
+
 3. **Release-time** — `skills/_LIFEOS/Tools/ShadowRelease.ts` runs 14 gates (G1–G14: zone deletion, identity grep, CF ID grep, trufflehog, .env strays, private tokens, ref integrity, private-skill refs, username-path leak, staging boot, dashboard leak, template-only USER/MEMORY, hidden-file leakage, critical-artifact presence). Backstop. Should consistently return zero findings if layers 1 and 2 are healthy.
 
 **Two-repo sync** — `~/.claude/.git/hooks/pre-push` auto-commits and pushes `~/.config/LIFEOS/USER/` to the user's private USER-data repo before each push from `~/.claude/`. The two repos stay in sync structurally. A private "kai update" / "push both repos" workflow wraps this with 4 boundary gates (USER-zone leak check, DenyListCheck, both-remotes-private confirmation, post-push HEAD verification).

--- a/LifeOS/install/LIFEOS/DOCUMENTATION/Memory/MemorySystem.md
+++ b/LifeOS/install/LIFEOS/DOCUMENTATION/Memory/MemorySystem.md
@@ -510,6 +510,8 @@ An append-only JSONL file where hooks emit structured, typed events alongside th
 - `LIFEOS/TOOLS/ComputeGap.ts` → `gap-history.jsonl`
 - `LIFEOS/PULSE/Performance/cost-aggregator.ts` → `session-costs.jsonl`
 - `LIFEOS/PULSE/modules/syslog.ts` → `unifi-syslog.jsonl`
+> **Note:** `_`-prefixed skill paths referenced below (e.g. `skills/_LIFEOS/`, `skills/_ULWORK/`) are **private skills, absent from the public release** — those paths do not exist on a public install.
+
 - `skills/_HOMESECURITY/Tools/HomeSensorDetector.ts` → `home-sensor.jsonl`, `perimeter.jsonl`
 - `skills/_NETWORK/Tools/Speedtest.ts` → `speedtest.jsonl`
 

--- a/LifeOS/install/LIFEOS/DOCUMENTATION/Pulse/PulseSystem.md
+++ b/LifeOS/install/LIFEOS/DOCUMENTATION/Pulse/PulseSystem.md
@@ -112,6 +112,8 @@ sendVoiceSummary(ctx, fullText) — fire-and-forget IIFE
 
 - `modules/telegram.ts` ships **zero** principal-identifiable literals (no chat IDs, no bot tokens, no principal-specific names). `DenyListCheck` reports 0 real-leaks.
 - Voice ID is read from `settings.json` at module import, not hardcoded — so no `{{...}}` placeholder needs install-time resolution; the setup-time template substitution doesn't need to know about this module.
+> **Note:** `_`-prefixed skill paths referenced below (e.g. `skills/_LIFEOS/`, `skills/_ULWORK/`) are **private skills, absent from the public release** — those paths do not exist on a public install.
+
 - USER bootstrap templates for the four context-block sources exist at `skills/_LIFEOS/RELEASE_TEMPLATES/USER/{DIGITAL_ASSISTANT/DA_IDENTITY.md, PRINCIPAL/PRINCIPAL_IDENTITY.md, TELOS/PRINCIPAL_TELOS.md, PROJECTS.md}` — a fresh install runs functional from day one, even before `/interview` populates the principal's real content.
 
 ### Adjacent gotchas

--- a/LifeOS/install/LIFEOS/DOCUMENTATION/Security/NpmRapidResponse.md
+++ b/LifeOS/install/LIFEOS/DOCUMENTATION/Security/NpmRapidResponse.md
@@ -77,6 +77,8 @@ bun install --frozen-lockfile
 - npm token (if any) — `npm token list`, revoke, regenerate
 - GitHub PAT (any token used in CI on the host) — `gh auth refresh`
 - AWS / GCP / Azure on dev hosts where install ran during worm window
+> **Note:** `_`-prefixed skill paths referenced below (e.g. `skills/_LIFEOS/`, `skills/_ULWORK/`) are **private skills, absent from the public release** — those paths do not exist on a public install.
+
 - See `~/.claude/skills/_INCIDENT_RESPONSE/SKILL.md` for the full rotation protocol
 
 ## Hardening levers (one per attack surface)

--- a/LifeOS/install/LIFEOS/DOCUMENTATION/Security/README.md
+++ b/LifeOS/install/LIFEOS/DOCUMENTATION/Security/README.md
@@ -93,6 +93,8 @@ That's the entire defense delta beyond L1 and L2 on the ingress side.
 
 ## Release Deny-List (canonical sensitive-pattern source)
 
+> **Note:** `_`-prefixed skill paths referenced below (e.g. `skills/_LIFEOS/`, `skills/_ULWORK/`) are **private skills, absent from the public release** — those paths do not exist on a public install.
+
 The release pipeline has its own constitutional surface: the **deny-list** at `~/.claude/skills/_LIFEOS/DENY_LIST.txt`. Plain text, one ripgrep-compatible regex per line, four sections (`Identity`, `Hostnames`, `Cloudflare IDs`, `Private Tokens`).
 
 | Consumer | What it does |

--- a/LifeOS/install/LIFEOS/DOCUMENTATION/SystemUserBoundary.md
+++ b/LifeOS/install/LIFEOS/DOCUMENTATION/SystemUserBoundary.md
@@ -104,6 +104,8 @@ Anything else — direct `Read('LIFEOS/USER/...')`, hardcoded voice IDs in modul
 
 ## Two-repo sync (post-Phase-G.1, 2026-05-22)
 
+> **Note:** `_`-prefixed skill paths referenced below (e.g. `skills/_LIFEOS/`, `skills/_ULWORK/`) are **private skills, absent from the public release** — those paths do not exist on a public install.
+
 The USER tree is its own private git repo: `~/.config/LIFEOS/USER/` → the user's `<your-username>/<your-user-data-repo>` (PRIVATE GitHub). The SYSTEM tree is `~/.claude/` → the user's `<your-username>/.claude` (PRIVATE GitHub). A pre-push hook at `~/.claude/.git/hooks/pre-push` (1836 bytes) auto-commits and pushes the USER repo before every `git push` from `~/.claude/`, so the two repos stay in sync structurally. A workflow ("update the kai repo" / "push both repos") wraps this with four boundary gates: (G1) USER-zone leak check on pending `~/.claude` changes, (G2) `DenyListCheck.ts` must return 0 real-leaks, (G3) both remotes confirmed private via `gh api`, (G4) post-push HEAD verification on both repos. **Pre-flight refuses to proceed if the public LifeOS repo appears in either remote** — this workflow is explicit private-only. Public LifeOS release goes through the shadow-release pipeline (`skills/_LIFEOS/Tools/ShadowRelease.ts`) with the separate 14-gate sanitization; the shipped distribution unit is the single `LifeOS/` skill emitted from that staging tree, not the `.claude/` clone.
 
 ## Enforcement layers

--- a/LifeOS/install/LIFEOS/DOCUMENTATION/Tools/Containment.md
+++ b/LifeOS/install/LIFEOS/DOCUMENTATION/Tools/Containment.md
@@ -7,6 +7,8 @@ version: 1.1.9
 > Containment zones draw the Life OS boundary at release time (`LIFEOS/DOCUMENTATION/LifeOs/LifeOsThesis.md`): the OS ships; the life never does.
 
 **Status:** Authoritative. Contributors and future DA sessions read this before adding a new file.
+> **Note:** `_`-prefixed skill paths referenced below (e.g. `skills/_LIFEOS/`, `skills/_ULWORK/`) are **private skills, absent from the public release** — those paths do not exist on a public install.
+
 **Enforcement:** `skills/_LIFEOS/Tools/ShadowRelease.ts` G1-G14 gates (release-time only). All enforcement is one-shot at release-build; there is no runtime hook. The 2026-05-06 simplification removed the prospective `ContainmentGuard.hook.ts` and consolidated enforcement to a single release-build pass.
 **Zone inventory (authoritative):** `hooks/lib/containment-zones.ts` — the source of truth ShadowRelease imports.
 **Last updated:** 2026-05-10

--- a/LifeOS/install/LIFEOS/DOCUMENTATION/Work/WorkSystem.md
+++ b/LifeOS/install/LIFEOS/DOCUMENTATION/Work/WorkSystem.md
@@ -112,6 +112,8 @@ Safety:
 
 ## Label taxonomy
 
+> **Note:** `_`-prefixed skill paths referenced below (e.g. `skills/_LIFEOS/`, `skills/_ULWORK/`) are **private skills, absent from the public release** — those paths do not exist on a public install.
+
 The canonical label list lives at `USER/WORK/labels.yml` and gets pushed to the configured repo by `bun ~/.claude/skills/_ULWORK/Tools/BootstrapLabels.ts`. Additive — never deletes existing labels.
 
 | Family | Members | Purpose |

--- a/LifeOS/install/LIFEOS/DOCUMENTATION/Writing/AIWritingPatterns.md
+++ b/LifeOS/install/LIFEOS/DOCUMENTATION/Writing/AIWritingPatterns.md
@@ -360,4 +360,6 @@ When writing about AI writing patterns (blog posts, tutorials, documentation lik
 - **Voice guide:** `LIFEOS/USER/PRINCIPAL/WRITINGSTYLE.md` — how {{PRINCIPAL_NAME}} sounds
 - **Analytical voice:**  — how {{DA_NAME}} sounds in analysis
 - **Rhetorical figures:** `LIFEOS/USER/PRINCIPAL/WRITINGSTYLE.md` — techniques for memorable lines
+> **Note:** `_`-prefixed skill paths referenced below (e.g. `skills/_LIFEOS/`, `skills/_ULWORK/`) are **private skills, absent from the public release** — those paths do not exist on a public install.
+
 - **Audit skill:** `skills/_WRITING/SKILL.md` — workflow for detect/rewrite modes


### PR DESCRIPTION
## Problem

System docs reference private, underscore-prefixed skills (`skills/_LIFEOS/…`, `skills/_ULWORK/…`, `_WRITING`, `_SURFACE`, `_NETWORK`, `_LIFELOG`, `_INCIDENT_RESPONSE`, `_HOMESECURITY`, `_HARVEST`) as if present, but `_`-prefixed skills are excluded from the public release — none of those paths exist on a public install. 53 such references span 12 docs, so a reader can't tell the absent paths are intentional.

## Fix

Add a one-line legend near the first private-skill reference in each of the 12 affected docs, noting that `_`-prefixed skill paths are private and absent from public installs. This covers every occurrence in the file without tagging each of the 53 mentions inline (keeps the docs readable). ALLCAPS tokens that merely look similar (`_API_KEY`, `_IDENTITY`, `_ALLCAPS` the convention term, etc.) are deliberately NOT touched — only real `skills/_NAME` paths.

## Files (12)
DOCUMENTATION: SystemUserBoundary.md, Memory/MemorySystem.md, Tools/Containment.md, Amber/AmberSystem.md, LifeosSystemArchitecture.md, Work/WorkSystem.md, Pulse/PulseSystem.md, Security/README.md, Writing/AIWritingPatterns.md, Config/ConfigSystem.md, LifeOs/LifeOsSchema.md, Security/NpmRapidResponse.md
