### PR TITLE
fix(pulse): stop setup.ts clobbering an existing PULSE.toml

### DIFF
--- a/LifeOS/install/LIFEOS/PULSE/setup.ts
+++ b/LifeOS/install/LIFEOS/PULSE/setup.ts
@@ -6,12 +6,16 @@
  * Reads DA_IDENTITY.md for worker identity.
  * Generates PULSE.toml, .env, and installs launchd service.
  *
- * Usage: bun run setup.ts
+ * Usage: bun run setup.ts [--force]
  * Goal: under 30 minutes from bare machine to working worker.
+ *
+ * Config writes are create-only. Re-running against a configured install
+ * leaves PULSE.toml and the launch agent alone; --force replaces them, but
+ * announces it first and copies the old file aside with a timestamp.
  */
 
 import { join, resolve } from "path"
-import { existsSync, mkdirSync } from "fs"
+import { copyFileSync, existsSync, mkdirSync } from "fs"
 
 const HOME = process.env.HOME ?? "~"
 const LIFEOS_DIR = join(HOME, ".claude", "LIFEOS")
@@ -43,6 +47,52 @@ function ok(text: string): void {
 
 function warn(text: string): void {
   console.log(`  [!!] ${text}`)
+}
+
+// ── Config write guard ──
+//
+// Provisioning must never destroy an existing install. PULSE.toml is the
+// daemon's config of record — modules, ports, notification routing, the DA
+// block, every cron job — and most installs are not git repos, so a clobber
+// is unrecoverable. Every config write goes through writeConfigPreserving:
+// create when absent, leave alone when present, replace only under an
+// explicit --force, announced up front and after a timestamped copy-aside.
+// This is the same check the .env branch has always done.
+
+export type ConfigWriteOutcome = "created" | "preserved" | "overwritten"
+
+export interface ConfigWriteResult {
+  outcome: ConfigWriteOutcome
+  /** Set only when an existing file was replaced under --force. */
+  backupPath?: string
+}
+
+/** `<file>.backup-<iso>` — the copy-aside naming the other install tools use. */
+export function backupPathFor(path: string, now: Date = new Date()): string {
+  return `${path}.backup-${now.toISOString().replace(/[:.]/g, "-")}`
+}
+
+export async function writeConfigPreserving(
+  path: string,
+  contents: string,
+  opts: {
+    force?: boolean
+    /** Called before anything on disk changes, so the user sees it coming. */
+    onOverwrite?: (info: { path: string; backupPath: string }) => void
+  } = {},
+): Promise<ConfigWriteResult> {
+  if (!existsSync(path)) {
+    await Bun.write(path, contents)
+    return { outcome: "created" }
+  }
+
+  if (!opts.force) return { outcome: "preserved" }
+
+  const backupPath = backupPathFor(path)
+  opts.onOverwrite?.({ path, backupPath })
+  copyFileSync(path, backupPath)
+  await Bun.write(path, contents)
+  return { outcome: "overwritten", backupPath }
 }
 
 // ── Step 1: Read Identity ──
@@ -154,7 +204,7 @@ async function setupTelegram(workerName: string): Promise<{ botToken: string; ch
 
 // ── Step 4: Generate Config Files ──
 
-async function generateConfigs(opts: {
+export async function generateConfigs(opts: {
   name: string
   description: string
   appId: string
@@ -164,6 +214,7 @@ async function generateConfigs(opts: {
   botToken: string
   chatId: string
   specialization: string[]
+  force?: boolean
 }): Promise<void> {
   heading("Step 4: Generating Config Files")
 
@@ -213,8 +264,22 @@ output = "telegram"
 enabled = true
 `
 
-  await Bun.write(join(PULSE_DIR, "PULSE.toml"), pulseToml)
-  ok("PULSE.toml written")
+  const pulseTomlPath = join(PULSE_DIR, "PULSE.toml")
+  const written = await writeConfigPreserving(pulseTomlPath, pulseToml, {
+    force: opts.force,
+    onOverwrite: ({ backupPath }) =>
+      warn(`--force: replacing PULSE.toml — copying the current one to ${backupPath}`),
+  })
+
+  if (written.outcome === "created") {
+    ok("PULSE.toml written")
+  } else if (written.outcome === "overwritten") {
+    ok(`PULSE.toml replaced (backup: ${written.backupPath})`)
+  } else {
+    warn("PULSE.toml already exists — left untouched. Your daemon config is the record.")
+    warn("Merge the worker block below by hand, or re-run with --force to replace it (backed up first).")
+    console.log(`\n${"─".repeat(50)}\n${pulseToml}${"─".repeat(50)}`)
+  }
 
   // .env
   const envLines = [
@@ -339,7 +404,7 @@ async function setupLocalHTTPS(): Promise<void> {
 
 // ── Step 6: Install launchd Service ──
 
-async function installService(): Promise<void> {
+async function installService(force = false): Promise<void> {
   heading("Step 6: Installing launchd Service")
 
   // Create directories
@@ -361,13 +426,24 @@ async function installService(): Promise<void> {
   // file is deny-list clean; the installed copy is per-user materialized.
   const template = await Bun.file(plistSrc).text()
   const materialized = template.replaceAll("__HOME__", HOME)
-  await Bun.write(plistDst, materialized)
+  const written = await writeConfigPreserving(plistDst, materialized, {
+    force,
+    onOverwrite: ({ backupPath }) =>
+      warn(`--force: replacing the launch agent — copying the current one to ${backupPath}`),
+  })
   const proc = Bun.spawn(["launchctl", "load", plistDst], {
     stdout: "pipe",
     stderr: "pipe",
   })
   await proc.exited
-  ok("launchd service installed")
+
+  if (written.outcome === "created") {
+    ok("launchd service installed")
+  } else if (written.outcome === "overwritten") {
+    ok(`launchd service reinstalled (backup: ${written.backupPath})`)
+  } else {
+    ok("launch agent already installed — left untouched (any local edits kept)")
+  }
 }
 
 // ── Step 7: Health Check ──
@@ -414,6 +490,11 @@ ${"═".repeat(50)}
 ${"═".repeat(50)}`)
 
   const startTime = Date.now()
+  const force = process.argv.includes("--force")
+  if (force) {
+    warn("--force: an existing PULSE.toml and launch agent will be REPLACED.")
+    warn("Each one is copied to <file>.backup-<timestamp> before it is touched.")
+  }
 
   const identity = await readIdentity()
 
@@ -428,10 +509,11 @@ ${"═".repeat(50)}`)
     ...github,
     ...telegram,
     specialization,
+    force,
   })
 
   await setupLocalHTTPS()
-  await installService()
+  await installService(force)
   await healthCheck()
 
   const elapsed = Math.round((Date.now() - startTime) / 1000)
@@ -452,7 +534,10 @@ ${"═".repeat(50)}
 `)
 }
 
-main().catch((err) => {
-  console.error(`Setup failed: ${err}`)
-  process.exit(1)
-})
+// Guarded so tests can import the config-write helpers without provisioning.
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error(`Setup failed: ${err}`)
+    process.exit(1)
+  })
+}

--- a/LifeOS/install/test/pulse/setup.test.ts
+++ b/LifeOS/install/test/pulse/setup.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Pulse provisioning must never destroy an existing install's config.
+ *
+ * Doctrine: LIFEOS/DOCUMENTATION/Testing/TestingDoctrine.md — parallel test/
+ * tree mirroring the source path, zero external deps, no time waits.
+ *
+ * setup.ts resolves its install paths from HOME at module load, so HOME is
+ * pointed at a temp dir before the dynamic import below. Nothing here spawns a
+ * subprocess, so paiTestEnv is not in play.
+ */
+
+import { afterAll, beforeEach, describe, expect, test } from "bun:test"
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "fs"
+import { tmpdir } from "os"
+import { join } from "path"
+
+const REAL_HOME = process.env.HOME
+const FAKE_HOME = mkdtempSync(join(tmpdir(), "lifeos-pulse-setup-"))
+process.env.HOME = FAKE_HOME
+
+const CLAUDE_DIR = join(FAKE_HOME, ".claude")
+const PULSE_DIR = join(CLAUDE_DIR, "LIFEOS", "PULSE")
+const PULSE_TOML = join(PULSE_DIR, "PULSE.toml")
+const ENV_FILE = join(CLAUDE_DIR, ".env")
+
+const { backupPathFor, generateConfigs, writeConfigPreserving } = await import(
+  "../../LIFEOS/PULSE/setup.ts"
+)
+
+/** A live daemon config, of the shape Pulse actually runs on. */
+const LIVE_CONFIG = `# LifeOS Pulse — Unified Daemon Configuration
+
+[voice]
+enabled = true
+
+[telegram]
+enabled = true
+
+[observability.server]
+port = 31337
+enabled = true
+
+[da]
+heartbeat = "*/15 * * * *"
+cost_ceiling_usd = 12.5
+
+[[job]]
+name = "evening-diary"
+schedule = "0 21 * * *"
+type = "claude"
+enabled = true
+`
+
+function setupOpts(overrides: Record<string, unknown> = {}) {
+  return {
+    name: "echo",
+    description: "research specialist",
+    appId: "111111",
+    installationId: "222222",
+    privateKeyPath: join(FAKE_HOME, "key.pem"),
+    repos: ["your-org/your-repo"],
+    botToken: "",
+    chatId: "",
+    specialization: ["research"],
+    ...overrides,
+  }
+}
+
+function backupsOf(path: string): string[] {
+  const dir = join(path, "..")
+  const base = path.split("/").pop()!
+  return readdirSync(dir).filter((f) => f.startsWith(`${base}.backup-`))
+}
+
+beforeEach(() => {
+  rmSync(CLAUDE_DIR, { recursive: true, force: true })
+  mkdirSync(PULSE_DIR, { recursive: true })
+})
+
+afterAll(() => {
+  rmSync(FAKE_HOME, { recursive: true, force: true })
+  if (REAL_HOME === undefined) delete process.env.HOME
+  else process.env.HOME = REAL_HOME
+})
+
+describe("writeConfigPreserving", () => {
+  test("creates the file when it is absent", async () => {
+    const path = join(PULSE_DIR, "absent.toml")
+
+    const result = await writeConfigPreserving(path, "new = true\n")
+
+    expect(result.outcome).toBe("created")
+    expect(result.backupPath).toBeUndefined()
+    expect(readFileSync(path, "utf8")).toBe("new = true\n")
+  })
+
+  test("leaves an existing file untouched and takes no backup", async () => {
+    const path = join(PULSE_DIR, "present.toml")
+    writeFileSync(path, LIVE_CONFIG)
+
+    const result = await writeConfigPreserving(path, "clobbered = true\n")
+
+    expect(result.outcome).toBe("preserved")
+    expect(readFileSync(path, "utf8")).toBe(LIVE_CONFIG)
+    expect(backupsOf(path)).toEqual([])
+  })
+
+  test("force announces and backs up before anything on disk changes", async () => {
+    const path = join(PULSE_DIR, "present.toml")
+    writeFileSync(path, LIVE_CONFIG)
+    const seen: Array<{ contentAtAnnounce: string; backupExistedYet: boolean }> = []
+
+    const result = await writeConfigPreserving(path, "replaced = true\n", {
+      force: true,
+      onOverwrite: ({ backupPath }) => {
+        seen.push({
+          contentAtAnnounce: readFileSync(path, "utf8"),
+          backupExistedYet: existsSync(backupPath),
+        })
+      },
+    })
+
+    expect(seen).toEqual([{ contentAtAnnounce: LIVE_CONFIG, backupExistedYet: false }])
+    expect(result.outcome).toBe("overwritten")
+    expect(readFileSync(path, "utf8")).toBe("replaced = true\n")
+    expect(readFileSync(result.backupPath!, "utf8")).toBe(LIVE_CONFIG)
+  })
+
+  test("backup path is the target plus a sortable timestamp", () => {
+    const path = join(PULSE_DIR, "PULSE.toml")
+
+    const backup = backupPathFor(path, new Date("2026-01-02T03:04:05.678Z"))
+
+    expect(backup).toBe(`${path}.backup-2026-01-02T03-04-05-678Z`)
+  })
+})
+
+describe("generateConfigs", () => {
+  test("writes a starter config on a fresh install", async () => {
+    await generateConfigs(setupOpts())
+
+    const written = readFileSync(PULSE_TOML, "utf8")
+    expect(written).toContain(`name = "echo"`)
+    expect(written).toContain(`[[job]]`)
+    expect(backupsOf(PULSE_TOML)).toEqual([])
+  })
+
+  test("preserves an existing config with every value intact", async () => {
+    writeFileSync(PULSE_TOML, LIVE_CONFIG)
+
+    await generateConfigs(setupOpts())
+
+    expect(readFileSync(PULSE_TOML, "utf8")).toBe(LIVE_CONFIG)
+    expect(backupsOf(PULSE_TOML)).toEqual([])
+  })
+
+  test("Anti: provisioning does not replace a live config with the worker template", async () => {
+    writeFileSync(PULSE_TOML, LIVE_CONFIG)
+
+    await generateConfigs(setupOpts())
+
+    const onDisk = readFileSync(PULSE_TOML, "utf8")
+    expect(onDisk).toContain("port = 31337")
+    expect(onDisk).toContain("cost_ceiling_usd = 12.5")
+    expect(onDisk).toContain("evening-diary")
+    expect(onDisk).not.toContain("[worker]")
+    expect(onDisk).not.toContain("github-work")
+  })
+
+  test("force replaces the config, but only after backing it up", async () => {
+    writeFileSync(PULSE_TOML, LIVE_CONFIG)
+
+    await generateConfigs(setupOpts({ force: true }))
+
+    expect(readFileSync(PULSE_TOML, "utf8")).toContain("[worker]")
+    const backups = backupsOf(PULSE_TOML)
+    expect(backups).toHaveLength(1)
+    expect(readFileSync(join(PULSE_DIR, backups[0]!), "utf8")).toBe(LIVE_CONFIG)
+  })
+
+  test("appends to an existing .env rather than replacing it", async () => {
+    writeFileSync(ENV_FILE, "ELEVENLABS_API_KEY=keep-me\n")
+
+    await generateConfigs(setupOpts())
+
+    const env = readFileSync(ENV_FILE, "utf8")
+    expect(env).toContain("ELEVENLABS_API_KEY=keep-me")
+    expect(env).toContain("GITHUB_APP_ID=111111")
+  })
+})


### PR DESCRIPTION
## The problem

`PULSE/setup.ts` unconditionally overwrites `PULSE.toml` with a three-job template. There is no existence check and no backup, so running the documented `bun run setup.ts` on an already-configured install destroys the daemon's config of record in a single call.

What goes: `[voice]`, `[telegram]`, `[imessage]`, `[observability]` including the server port, every `[notifications.*]` routing rule and threshold, `[hooks] blocked_skills`, `[work]`, `[bunker]`, `[syslog]`, `[local_intelligence]`, `[telos]`, the whole `[da]` block (heartbeat, diary and growth schedules, cost ceiling), and every `[[job]]` cron entry — replaced by `[worker]` plus three samples.

Most personal installs are not git repositories, so this is unrecoverable.

The fix is suggested by the surrounding code: the `.env` write about twenty lines below already checks for existence and appends rather than clobbering. The two branches of the same function disagreed with each other.

## The fix

Every config write now goes through one `writeConfigPreserving` helper:

- **absent** → created, so first-run onboarding is unchanged
- **present** → preserved untouched, and the run says so
- **`--force`** → replaced, but only after announcing it and copying the existing file aside as `<file>.backup-<timestamp>`

Create-only is the right default here rather than a merge: a partial merge of a TOML the operator has hand-tuned produces a config that is neither theirs nor the template's, and silently reintroducing sample jobs into a live scheduler is its own failure. Preserve-and-tell leaves the operator in control, and `--force` plus a backup covers the genuine reset case.

The launch agent write is guarded the same way, for the same reason.

## Tests

`test/pulse/setup.test.ts`, 9 cases: a fresh path is created, an existing config survives byte-identical, `--force` replaces it, the backup holds the original contents, and the announcement fires before anything on disk changes.

```
9 pass
0 fail
26 expect() calls
```

Separately verified against the exported helper with an independent case set, including one the unit tests do not cover: repeated `--force` runs keep distinct backups rather than overwriting the previous one.

```
✓ absent → created
✓ present → preserved
✓ preserved: real job survived
✓ preserved: template not leaked in
✓ force → overwritten
✓ force announced before the write
✓ force: backup holds the ORIGINAL
✓ repeat force keeps distinct backups — 2 backup(s)
```

## Notes

No behaviour change for a fresh install. The only way to lose config now is to pass `--force`, which prints the backup path first.
