### PR TITLE
fix(pulse): validate cron schedules at config load (crash loop + hang)

### DIFF
--- a/LifeOS/install/LIFEOS/PULSE/lib.ts
+++ b/LifeOS/install/LIFEOS/PULSE/lib.ts
@@ -35,6 +35,13 @@ export interface Job {
    * - "user":   from LIFEOS/USER/CONFIG/PULSE.user.toml (private, stripped at release)
    */
   _source?: JobSource
+  /**
+   * Why this job's schedule was rejected, if it was. Set by loadConfig() when
+   * validateCron() refuses the expression. A job carrying this is force-
+   * disabled and never evaluated by the scheduler — it stays in the list so
+   * the dashboard can show the operator what needs fixing.
+   */
+  scheduleError?: string
 }
 
 export interface DaemonConfig {
@@ -130,56 +137,148 @@ export async function loadConfig(daemonDir: string): Promise<DaemonConfig> {
     if (!userOverrideNames.has(usr.name)) merged.push(usr)
   }
 
-  return { jobs: merged }
+  return { jobs: merged.map(checkSchedule) }
+}
+
+// Schedules are validated once, here, as the config is read — not on every
+// scheduler tick. One bad expression disables exactly one job; the rest of
+// the config keeps running. Silently dropping the job would be worse than the
+// crash it replaces, so the reason, the job name and the expression are all
+// logged, and the reason rides along on the job for the dashboard.
+function checkSchedule(job: Job): Job {
+  const problem = validateCron(job.schedule)
+  if (!problem) return job
+
+  log("error", `Disabling cron job ${job.name}: invalid schedule "${job.schedule}" — ${problem}`, {
+    job: job.name,
+    schedule: job.schedule,
+    reason: problem,
+    source: job._source,
+    subsystem: "cron",
+  })
+  return { ...job, enabled: false, scheduleError: problem }
 }
 
 // ── Cron Matching (from Monitor/cron/scheduler.ts) ──
+//
+// The parser is total: every expression either produces fields or an Error
+// naming what is wrong with it. It never spins. Two user typos used to take
+// the whole daemon down instead of skipping one job:
+//
+//   "0 9 * *"     — four fields. The throw escaped the scheduler loop into
+//                   main().catch → process.exit(1), and the supervisors
+//                   restart on a 30s throttle, so a typo became a crash cycle.
+//   "*/0 * * * *" — zero step. `for (i = start; i <= end; i += 0)` never
+//                   advanced while the values array grew without bound: event
+//                   loop blocked, process OOM'd.
+//
+// Callers should prefer validateCron() at config-read time; matchesCron()
+// still throws so a schedule that slipped through is loud rather than silent.
 
 interface CronField {
   type: "any" | "values"
   values: number[]
 }
 
-function parseField(field: string, min: number, max: number): CronField {
+interface CronFieldSpec {
+  name: string
+  min: number
+  max: number
+}
+
+const CRON_FIELD_SPECS: CronFieldSpec[] = [
+  { name: "minute", min: 0, max: 59 },
+  { name: "hour", min: 0, max: 23 },
+  { name: "day-of-month", min: 1, max: 31 },
+  { name: "month", min: 1, max: 12 },
+  { name: "day-of-week", min: 0, max: 6 },
+]
+
+// An expression that enumerates every legal value of every field is ~356
+// chars. The cap rejects pathological input (long comma-separated lists of
+// ranges expand roughly 12x) and leaves anything a person would write alone.
+const MAX_CRON_LENGTH = 512
+
+// One comma-separated term: "*", "N", or "N-M", each optionally "/STEP".
+// Anything else — names like MON, negative numbers, empty terms, stray
+// characters — fails here rather than becoming a silent NaN that can never match.
+const CRON_TERM = /^(\*|\d+(?:-\d+)?)(?:\/(\d+))?$/
+
+function parseField(field: string, spec: CronFieldSpec): CronField {
   if (field === "*") return { type: "any", values: [] }
 
-  if (field.includes("/")) {
-    const [range, stepStr] = field.split("/")
-    const step = parseInt(stepStr, 10)
-    const values: number[] = []
-    let start = min, end = max
-    if (range !== "*") {
-      const [s, e] = range.split("-").map(Number)
-      start = s
-      if (e !== undefined) end = e
+  const values: number[] = []
+
+  for (const term of field.split(",")) {
+    const matched = CRON_TERM.exec(term)
+    if (!matched) throw new Error(`${spec.name} field: cannot parse "${term}"`)
+
+    const [, base, stepStr] = matched
+    const step = stepStr === undefined ? 1 : Number(stepStr)
+    if (step < 1) throw new Error(`${spec.name} field: step must be 1 or more in "${term}"`)
+
+    let start = spec.min
+    let end = spec.max
+    if (base !== "*") {
+      const [from, to] = base.split("-").map(Number)
+      start = from
+      // A bare number with a step has always meant "from N to the end of the
+      // field" here ("5/10" → 5, 15, 25, …); a bare number alone is just itself.
+      if (to !== undefined) end = to
+      else if (stepStr === undefined) end = from
     }
+
+    if (start < spec.min || start > spec.max || end < spec.min || end > spec.max) {
+      throw new Error(`${spec.name} field: "${term}" is outside ${spec.min}-${spec.max}`)
+    }
+    if (start > end) throw new Error(`${spec.name} field: range "${term}" starts after it ends`)
+
     for (let i = start; i <= end; i += step) values.push(i)
-    return { type: "values", values }
   }
 
-  if (field.includes(",")) return { type: "values", values: field.split(",").map(Number) }
+  return { type: "values", values }
+}
 
-  if (field.includes("-")) {
-    const [start, end] = field.split("-").map(Number)
-    const values: number[] = []
-    for (let i = start; i <= end; i++) values.push(i)
-    return { type: "values", values }
+function parseCron(expression: string): CronField[] {
+  if (typeof expression !== "string" || expression.trim() === "") {
+    throw new Error("schedule is empty")
+  }
+  if (expression.length > MAX_CRON_LENGTH) {
+    throw new Error(`too long (${expression.length} chars, limit ${MAX_CRON_LENGTH})`)
   }
 
-  return { type: "values", values: [parseInt(field, 10)] }
+  const parts = expression.trim().split(/\s+/)
+  if (parts.length !== CRON_FIELD_SPECS.length) {
+    throw new Error(
+      `need 5 fields (minute hour day-of-month month day-of-week), got ${parts.length}`,
+    )
+  }
+
+  return CRON_FIELD_SPECS.map((spec, i) => parseField(parts[i], spec))
+}
+
+/**
+ * Check an expression without evaluating it. Returns null when it is usable,
+ * or a human-readable reason when it is not. Never throws, never loops — this
+ * is the function config loading and any future job-editing API should use.
+ */
+export function validateCron(expression: string): string | null {
+  try {
+    parseCron(expression)
+    return null
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err)
+  }
 }
 
 export function matchesCron(expression: string, date: Date): boolean {
-  const parts = expression.trim().split(/\s+/)
-  if (parts.length !== 5) throw new Error(`Invalid cron (need 5 fields): "${expression}"`)
+  let fields: CronField[]
+  try {
+    fields = parseCron(expression)
+  } catch (err) {
+    throw new Error(`Invalid cron "${expression}": ${err instanceof Error ? err.message : String(err)}`)
+  }
 
-  const fields = [
-    parseField(parts[0], 0, 59),
-    parseField(parts[1], 0, 23),
-    parseField(parts[2], 1, 31),
-    parseField(parts[3], 1, 12),
-    parseField(parts[4], 0, 6),
-  ]
   const actuals = [date.getMinutes(), date.getHours(), date.getDate(), date.getMonth() + 1, date.getDay()]
 
   return fields.every((f, i) => f.type === "any" || f.values.includes(actuals[i]))

--- a/LifeOS/install/LIFEOS/PULSE/pulse.ts
+++ b/LifeOS/install/LIFEOS/PULSE/pulse.ts
@@ -384,7 +384,12 @@ function msUntilNextDue(jobs: PulseConfig["jobs"], state: DaemonState): number {
     const future = new Date(now.getTime() + offset * 60_000)
     for (const job of jobs) {
       if (!job.enabled) continue
-      if (matchesCron(job.schedule, future)) return offset * 60_000
+      try {
+        if (matchesCron(job.schedule, future)) return offset * 60_000
+      } catch {
+        // An unusable schedule is never due. Already reported by name at load
+        // time; sleeping is not the place to report it again every tick.
+      }
     }
   }
   return MAX_SLEEP_MS
@@ -888,6 +893,12 @@ async function main() {
     }
   }
 
+  // Backstop for the same class of failure in the schedule itself. loadConfig()
+  // already disables jobs whose cron expression doesn't validate; if one still
+  // reaches the loop, it is skipped with one message instead of throwing out of
+  // the loop into main().catch → exit(1) → supervised restart every 30s.
+  const badScheduleJobs = new Set<string>()
+
   while (!shuttingDown) {
     const tickStart = Date.now()
     const now = new Date()
@@ -895,11 +906,24 @@ async function main() {
     for (const job of config.jobs) {
       if (!job.enabled) continue
       if (missingScriptJobs.has(job.name)) continue
+      if (badScheduleJobs.has(job.name)) continue
       if (shuttingDown) break
 
       const jobState = state.jobs[job.name]
 
-      if (!isDue(job.schedule, now, jobState?.lastRun)) continue
+      let due: boolean
+      try {
+        due = isDue(job.schedule, now, jobState?.lastRun)
+      } catch (err) {
+        badScheduleJobs.add(job.name)
+        log("error", `Disabling cron job ${job.name}: unusable schedule`, {
+          schedule: job.schedule,
+          error: String(err),
+          subsystem: "cron",
+        })
+        continue
+      }
+      if (!due) continue
 
       if ((jobState?.consecutiveFailures ?? 0) >= MAX_FAILURES) {
         log("warn", `Skipping ${job.name}: ${jobState!.consecutiveFailures} consecutive failures`, {

--- a/LifeOS/install/test/pulse/lib.test.ts
+++ b/LifeOS/install/test/pulse/lib.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Cron scheduling — LIFEOS/PULSE/lib.ts
+ *
+ * Covers the two availability failures a typo in PULSE.toml used to cause:
+ *   1. crash loop — a malformed expression threw out of the scheduler loop
+ *      into main().catch → process.exit(1), and the supervisors restart on a
+ *      30s throttle.
+ *   2. hang — a zero step spun forever inside parseField, blocking the event
+ *      loop until the process OOM'd.
+ *
+ * The hang case is exercised in a subprocess with a hard kill well inside the
+ * default 5s test budget, so a regression fails the run instead of wedging it.
+ */
+import { test, expect, describe, afterAll } from "bun:test"
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "fs"
+import { tmpdir } from "os"
+import { join } from "path"
+
+// HOME is read at module load to resolve the user cron file, which loadConfig()
+// stats. Point it at a throwaway directory before importing so no test can read
+// a real operator's config.
+const FAKE_HOME = mkdtempSync(join(tmpdir(), "pulse-cron-test-"))
+process.env.HOME = FAKE_HOME
+
+const LIB_PATH = join(import.meta.dir, "../../LIFEOS/PULSE/lib.ts")
+const { validateCron, matchesCron, isDue, loadConfig } = await import(LIB_PATH)
+
+afterAll(() => rmSync(FAKE_HOME, { recursive: true, force: true }))
+
+describe("validateCron rejects", () => {
+  const bad: Array<[string, string]> = [
+    ["0 9 * *", "four fields — the typo that crash-looped the daemon"],
+    ["* * * * * *", "six fields"],
+    ["", "empty"],
+    ["   ", "whitespace only"],
+    ["*/0 * * * *", "zero step — the expression that hung the daemon"],
+    ["0-59/0 * * * *", "zero step on an explicit range"],
+    ["* */0 * * *", "zero step in another field"],
+    ["*/-1 * * * *", "negative step"],
+    ["99 * * * *", "minute out of range"],
+    ["* 24 * * *", "hour out of range"],
+    ["* * 0 * *", "day-of-month below range"],
+    ["* * * 13 *", "month out of range"],
+    ["* * * * 7", "day-of-week out of range"],
+    ["30-10 * * * *", "inverted range"],
+    ["* * 20-5 * *", "inverted range on day-of-month"],
+    ["abc * * * *", "not a number"],
+    ["* * * JAN *", "month names are not supported"],
+    ["1,,2 * * * *", "empty list term"],
+    ["1- * * * *", "truncated range"],
+    ["*/ * * * *", "missing step"],
+    ["1-2-3 * * * *", "malformed range"],
+    [`${"0-59,".repeat(200)}0 * * * *`, "absurdly long expression"],
+  ]
+
+  for (const [expression, why] of bad) {
+    test(`${JSON.stringify(expression).slice(0, 40)} — ${why}`, () => {
+      const problem = validateCron(expression)
+      expect(problem).toBeString()
+      expect(problem!.length).toBeGreaterThan(0)
+    })
+  }
+
+  test("the reason names the field that is wrong", () => {
+    expect(validateCron("* 24 * * *")).toContain("hour")
+    expect(validateCron("* * * * 7")).toContain("day-of-week")
+    expect(validateCron("0 9 * *")).toContain("5 fields")
+  })
+
+  test("matchesCron throws a message carrying the expression", () => {
+    expect(() => matchesCron("0 9 * *", new Date())).toThrow(/0 9 \* \*/)
+    expect(() => matchesCron("*/0 * * * *", new Date())).toThrow(/step must be 1 or more/)
+  })
+})
+
+describe("validateCron accepts", () => {
+  const good = [
+    "* * * * *",
+    "*/5 * * * *",
+    "*/15 * * * *",
+    "*/30 * * * *",
+    "0 3 * * *",
+    "0 23 * * *",
+    "0 4 * * 0",
+    "0 7 * * *",
+    "1,15,30 * * * *",
+    "0 9-17 * * 1-5",
+    "0 0-23/2 * * *",
+    "5/10 * * * *",
+    "0 0 1 1 *",
+    "59 23 31 12 6",
+    "  0   3  *  *  *  ",
+  ]
+
+  for (const expression of good) {
+    test(JSON.stringify(expression), () => {
+      expect(validateCron(expression)).toBeNull()
+    })
+  }
+
+  test("every schedule in the shipped PULSE.toml validates", () => {
+    const toml = readFileSync(join(import.meta.dir, "../../LIFEOS/PULSE/PULSE.toml"), "utf-8")
+    const schedules = [...toml.matchAll(/^\s*\w*schedule\s*=\s*"([^"]+)"/gm)].map((m) => m[1])
+    expect(schedules.length).toBeGreaterThan(0)
+    for (const schedule of schedules) {
+      expect([schedule, validateCron(schedule)]).toEqual([schedule, null])
+    }
+  })
+})
+
+describe("matchesCron still evaluates valid expressions", () => {
+  // 2026-01-05 is a Monday. Local time — matchesCron reads local date parts.
+  const monday0930 = new Date(2026, 0, 5, 9, 30, 0)
+
+  test("wildcard matches anything", () => {
+    expect(matchesCron("* * * * *", monday0930)).toBe(true)
+  })
+
+  test("step form matches on the step and misses off it", () => {
+    expect(matchesCron("*/15 * * * *", monday0930)).toBe(true)
+    expect(matchesCron("*/15 * * * *", new Date(2026, 0, 5, 9, 31, 0))).toBe(false)
+    expect(matchesCron("*/30 * * * *", monday0930)).toBe(true)
+  })
+
+  test("exact minute and hour", () => {
+    expect(matchesCron("30 9 * * *", monday0930)).toBe(true)
+    expect(matchesCron("30 10 * * *", monday0930)).toBe(false)
+  })
+
+  test("list form", () => {
+    expect(matchesCron("0,30,45 * * * *", monday0930)).toBe(true)
+    expect(matchesCron("0,15,45 * * * *", monday0930)).toBe(false)
+  })
+
+  test("range form on hour and day-of-week", () => {
+    expect(matchesCron("30 9-17 * * 1-5", monday0930)).toBe(true)
+    expect(matchesCron("30 9-17 * * 6", monday0930)).toBe(false)
+    expect(matchesCron("30 10-17 * * 1-5", monday0930)).toBe(false)
+  })
+
+  test("weekly and monthly forms", () => {
+    expect(matchesCron("0 4 * * 0", new Date(2026, 0, 4, 4, 0, 0))).toBe(true)
+    expect(matchesCron("0 4 * * 0", monday0930)).toBe(false)
+    expect(matchesCron("0 0 1 1 *", new Date(2026, 0, 1, 0, 0, 0))).toBe(true)
+  })
+
+  test("bare number with a step counts up from that number", () => {
+    expect(matchesCron("5/10 * * * *", new Date(2026, 0, 5, 9, 25, 0))).toBe(true)
+    expect(matchesCron("5/10 * * * *", new Date(2026, 0, 5, 9, 26, 0))).toBe(false)
+  })
+})
+
+describe("isDue", () => {
+  const monday0930 = new Date(2026, 0, 5, 9, 30, 0)
+
+  test("due when the schedule matches and it has never run", () => {
+    expect(isDue("*/15 * * * *", monday0930)).toBe(true)
+  })
+
+  test("not due twice in the same minute", () => {
+    expect(isDue("*/15 * * * *", monday0930, monday0930.getTime())).toBe(false)
+  })
+
+  test("due again in a later matching minute", () => {
+    expect(isDue("*/15 * * * *", monday0930, monday0930.getTime() - 15 * 60_000)).toBe(true)
+  })
+})
+
+describe("loadConfig", () => {
+  function daemonDirWith(toml: string): string {
+    const dir = mkdtempSync(join(tmpdir(), "pulse-cron-cfg-"))
+    writeFileSync(join(dir, "PULSE.toml"), toml)
+    return dir
+  }
+
+  const CONFIG = `
+[[job]]
+name = "typo-schedule"
+schedule = "0 9 * *"
+type = "script"
+command = "echo hi"
+output = "log"
+enabled = true
+
+[[job]]
+name = "zero-step"
+schedule = "*/0 * * * *"
+type = "script"
+command = "echo hi"
+output = "log"
+enabled = true
+
+[[job]]
+name = "healthy"
+schedule = "*/5 * * * *"
+type = "script"
+command = "echo hi"
+output = "log"
+enabled = true
+`
+
+  test("a bad schedule disables one job and leaves the rest running", async () => {
+    const dir = daemonDirWith(CONFIG)
+    try {
+      const config = await loadConfig(dir)
+      const byName = new Map(config.jobs.map((j: { name: string }) => [j.name, j]))
+
+      expect(byName.size).toBe(3)
+
+      // Kept in the list so the dashboard can show it, but never scheduled.
+      expect(byName.get("typo-schedule").enabled).toBe(false)
+      expect(byName.get("typo-schedule").scheduleError).toContain("5 fields")
+      expect(byName.get("zero-step").enabled).toBe(false)
+      expect(byName.get("zero-step").scheduleError).toContain("step")
+
+      expect(byName.get("healthy").enabled).toBe(true)
+      expect(byName.get("healthy").scheduleError).toBeUndefined()
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("Anti: loading a config with a bad schedule does not throw", async () => {
+    const dir = daemonDirWith(CONFIG)
+    try {
+      await expect(loadConfig(dir)).resolves.toBeDefined()
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+test("Anti: a pathological expression cannot hang the process", async () => {
+  // Bounded on purpose: the child is killed after 3s, inside the default 5s
+  // test budget. Before the fix these expressions never returned.
+  const script = `
+    const { validateCron, matchesCron } = await import(${JSON.stringify(LIB_PATH)})
+    const pathological = ["*/0 * * * *", "0-59/0 * * * *", "* */0 * * *", "*/0 */0 */0 */0 */0"]
+    for (const expr of pathological) {
+      if (validateCron(expr) === null) { console.log("ACCEPTED " + expr); process.exit(2) }
+      let threw = false
+      try { matchesCron(expr, new Date()) } catch { threw = true }
+      if (!threw) { console.log("NO THROW " + expr); process.exit(3) }
+    }
+    console.log("BOUNDED")
+  `
+
+  await using proc = Bun.spawn({
+    cmd: [process.execPath, "-e", script],
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const kill = setTimeout(() => proc.kill("SIGKILL"), 3_000)
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ])
+  clearTimeout(kill)
+
+  expect(stderr).toBe("")
+  expect(stdout.trim()).toBe("BOUNDED")
+  expect(exitCode).toBe(0)
+})


### PR DESCRIPTION
## The problem

Two ways a single typo in the user-editable `PULSE.toml` takes the dashboard down. Nothing validates cron strings anywhere — `jobsFromToml` only casts `j.schedule as string`.

**1. Crash loop.** `isDue()` is called at `pulse.ts:925`, outside the per-job `try` at 937 which wraps only execution. `isDue('0 9 * *')` throws `Invalid cron (need 5 fields)`, the throw escapes the scheduling loop into `main().catch`, and that calls `process.exit(1)`. Both supervisors restart it — launchd `KeepAlive` with a 30s throttle, systemd `Restart=on-failure` with `RestartSec=30` — so a four-field schedule turns the daemon into a 30-second crash cycle instead of one skipped job. `msUntilNextDue` at line 401 makes the same unguarded call.

**2. Hang.** `parseField` in `lib.ts:156` accepts a zero step. `matchesCron('*/0 * * * *', …)` never terminates: the loop counter never advances while the values array grows without bound, so the event loop is blocked and the process OOMs. Reproduced by a run that had to be killed by timeout.

Neither requires an attacker. Both are what a mistyped schedule does.

## The fix

**Validate at config load.** `validateCron()` checks field count, ranges, list and range forms, and step values. A job whose schedule fails validation is force-disabled at load with a message naming the job, the expression and the specific reason:

```
Disabling cron job typo-schedule: invalid schedule "0 9 * *" — need 5 fields (minute hour day-of-month month day-of-week), got 4
Disabling cron job zero-step: invalid schedule "*/0 * * * *" — minute field: step must be 1 or more in "*/0"
```

The daemon keeps running and keeps serving every other job.

**Reject the pathological class, not the two reported cases.** Zero and negative steps, out-of-range values, inverted ranges, wrong field counts, and empty schedules are all refused, including when they appear inside a list or attached to a range (`*/0,*/0 * * * *`, `1-5/0 * * * *`).

**Guard both evaluation call sites as a backstop.** `matchesCron`/`isDue` still throw on an invalid expression, which is deliberate: an unvalidated expression reaching them is a programming error, not user input, and silently returning `false` would hide it. Both live call sites are wrapped so that if one ever does slip through, the job is disabled once and named, rather than taking the process out. The scheduler tracks those jobs so the message appears once instead of every tick, and the sleep-calculation path treats an unusable schedule as never due without re-reporting.

## Tests

`test/pulse/lib.test.ts`, 53 cases:

```
53 pass
0 fail
107 expect() calls
```

Independently verified with a separate bounded probe — the previously-hanging expression is exercised first, so a regression would show as a timeout kill rather than a pass. It completed normally:

- 11 pathological expressions all rejected with specific reasons, including zero step, negative step, out-of-range minute and hour, inverted range, 4 and 6 field counts, empty and whitespace-only, and zero step nested in a list or range
- 7 valid forms still accepted: daily, step, monthly, weekday range, list, every-minute, every-N-hours
- Firing semantics unchanged: matches on the right minute, does not match on the wrong one, matches on a step multiple and not off-step

## Note for review

`pulse-old.ts` and `pulse-unified.ts` contain the same unguarded call sites and are deliberately left alone here — they are superseded dead code, and #1630 proposes deleting them. Worth confirming that is still the intent rather than my patching files that are on their way out.
