### PR TITLE
fix(algorithm): close ISC criteria only on a structured worker verdict

### DIFF
--- a/LifeOS/install/LIFEOS/TOOLS/IscResult.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/IscResult.ts
@@ -1,0 +1,129 @@
+/**
+ * ============================================================================
+ * ISC RESULT — structured verdict contract between loop workers and the parent
+ * ============================================================================
+ *
+ * PURPOSE:
+ * A parallel loop worker reports whether its criterion passed over stdout. The
+ * parent checks the criterion's box in the ISA on that report, so the signal
+ * has to be something a *failing* worker cannot emit while narrating its
+ * failure in prose. Substring matching is not that: "RESULT: ISC-3 FAIL: I
+ * could not make ISC-3 PASS" contains a pass-shaped substring and describes a
+ * failure.
+ *
+ * THE CONTRACT:
+ *   ISC_RESULT v1 id=<criterion-id> verdict=PASS
+ *   ISC_RESULT v1 id=<criterion-id> verdict=FAIL reason=<one line>
+ *   ISC_REGRESSION v1 id=<criterion-id> verdict=PASS
+ *   ISC_REGRESSION v1 id=<criterion-id> verdict=FAIL reason=<one line>
+ *
+ * A verdict line must occupy a whole line, start at column 0, and match the
+ * grammar exactly. Prose mentioning a criterion id near the word PASS never
+ * parses. The worker prompt (see buildWorkerPrompt in algorithm.ts) states the
+ * contract as `verdict=PASS|FAIL`, so no complete, valid PASS line appears
+ * anywhere in the prompt — a worker echoing its instructions cannot produce
+ * one.
+ *
+ * FAIL-CLOSED RULES — a criterion is PASS only when all of these hold:
+ *   - the worker exited 0 (a crashed, killed, or timed-out worker never passes,
+ *     whatever its stdout contains — its stdout is truncated by definition and
+ *     its verification steps may never have run),
+ *   - at least one well-formed ISC_RESULT PASS line names the criterion,
+ *   - no ISC_RESULT or ISC_REGRESSION FAIL line names the criterion,
+ *   - no line in the output opened with a sentinel and then failed to parse.
+ * Anything else — absent, malformed, or contradictory signal — is not a pass.
+ */
+
+export const ISC_RESULT_SENTINEL = "ISC_RESULT v1";
+export const ISC_REGRESSION_SENTINEL = "ISC_REGRESSION v1";
+
+const RESULT_RE = /^ISC_RESULT v1 id=(\S+) verdict=(PASS|FAIL)(?: reason=(.*))?$/;
+const REGRESSION_RE = /^ISC_REGRESSION v1 id=(\S+) verdict=(PASS|FAIL)(?: reason=(.*))?$/;
+
+/** Verdict for one criterion, from one worker's run. Only "PASS" checks a box. */
+export type IscVerdict = "PASS" | "FAIL" | "CRASHED" | "NO_SIGNAL" | "AMBIGUOUS";
+
+export interface WorkerVerdicts {
+  /** ids with a well-formed ISC_RESULT PASS line */
+  passed: Set<string>;
+  /** ids with a well-formed ISC_RESULT FAIL line */
+  failed: Set<string>;
+  /** ids a regression check reported as still passing */
+  regressionPassed: Set<string>;
+  /** ids a regression check reported as broken */
+  regressionFailed: Set<string>;
+  /** a line opened with a sentinel but did not match the grammar */
+  malformed: boolean;
+}
+
+/**
+ * Parse every verdict line out of a worker's stdout. Lines that do not begin
+ * with a sentinel are ignored; lines that begin with one and do not match the
+ * grammar set `malformed`, which fails the whole run closed.
+ */
+export function parseWorkerOutput(stdout: string): WorkerVerdicts {
+  const verdicts: WorkerVerdicts = {
+    passed: new Set(),
+    failed: new Set(),
+    regressionPassed: new Set(),
+    regressionFailed: new Set(),
+    malformed: false,
+  };
+
+  for (const rawLine of stdout.split("\n")) {
+    // Tolerate CRLF and trailing spaces only — leading whitespace means the
+    // line is quoted, indented, or inside a list, not a machine record.
+    const line = rawLine.replace(/[\r\t ]+$/, "");
+    const isResult = line.startsWith(ISC_RESULT_SENTINEL);
+    const isRegression = line.startsWith(ISC_REGRESSION_SENTINEL);
+    if (!isResult && !isRegression) continue;
+
+    const match = (isResult ? RESULT_RE : REGRESSION_RE).exec(line);
+    // A PASS carries no reason — trailing text on a PASS line is ambiguity.
+    if (!match || (match[2] === "PASS" && match[3] !== undefined)) {
+      verdicts.malformed = true;
+      continue;
+    }
+
+    const [, id, verdict] = match;
+    if (isResult) {
+      (verdict === "PASS" ? verdicts.passed : verdicts.failed).add(id);
+    } else {
+      (verdict === "PASS" ? verdicts.regressionPassed : verdicts.regressionFailed).add(id);
+    }
+  }
+
+  return verdicts;
+}
+
+/**
+ * Decide one criterion's verdict from a worker run. Exit code is a necessary
+ * condition for PASS; see the fail-closed rules in the module header.
+ */
+export function judgeCriterion(
+  criterionId: string,
+  run: { stdout: string; exitCode: number },
+): IscVerdict {
+  if (run.exitCode !== 0) return "CRASHED";
+
+  const verdicts = parseWorkerOutput(run.stdout);
+  if (verdicts.malformed) return "AMBIGUOUS";
+
+  const claimsPass = verdicts.passed.has(criterionId);
+  const claimsFail = verdicts.failed.has(criterionId) || verdicts.regressionFailed.has(criterionId);
+
+  if (claimsPass && claimsFail) return "AMBIGUOUS";
+  if (claimsFail) return "FAIL";
+  if (claimsPass) return "PASS";
+  return "NO_SIGNAL";
+}
+
+/** The verdict contract, rendered for the worker prompt. Keeps prompt and parser in sync. */
+export function iscResultContract(criterionId: string): string {
+  return `${ISC_RESULT_SENTINEL} id=${criterionId} verdict=PASS|FAIL reason=<one line, FAIL only>`;
+}
+
+/** The regression-check contract, rendered for the worker prompt. */
+export function iscRegressionContract(): string {
+  return `${ISC_REGRESSION_SENTINEL} id=<other-criterion-id> verdict=PASS|FAIL`;
+}

--- a/LifeOS/install/LIFEOS/TOOLS/algorithm.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/algorithm.ts
@@ -57,6 +57,7 @@ import { readFileSync, writeFileSync, existsSync, readdirSync, mkdirSync, append
 import { resolve, basename, join, dirname } from "path";
 import { spawnSync, spawn } from "child_process";
 import { resolveClaudeBin } from "./Inference";  // absolute claude path — ENOENT-safe under launchd/cron (PR #1460, author asdf8675309)
+import { judgeCriterion, parseWorkerOutput, iscResultContract, iscRegressionContract, type IscVerdict } from "./IscResult";
 import { randomUUID } from "crypto";
 import { generateISATemplate } from "../../../.claude/hooks/lib/isa-template";
 
@@ -829,10 +830,17 @@ YOUR WORKFLOW:
 4. Run the verification method (the Verify: part after the pipe).
 5. After your fix, also verify ALL OTHER criteria in the ISA to catch regressions from your change.
    For each criterion, run its Verify: method and report the result.
-6. Print your primary result: "RESULT: ${criterion.id} PASS" or "RESULT: ${criterion.id} FAIL: <reason>"
-   Then print regression check results: "REGRESSION_CHECK: ISC-XX PASS" or "REGRESSION_CHECK: ISC-XX FAIL"
-7. Do NOT edit the ISA file. The parent reads your stdout and updates the ISA.
-8. That's it. Exit when done.`;
+6. Print your primary result as ONE line, starting at column 0, in exactly this form —
+   no indentation, no bullet, no quotes, no backticks, no bold:
+     ${iscResultContract(criterion.id)}
+   Replace PASS|FAIL with exactly one of PASS or FAIL. Include reason= only on FAIL.
+   Print a PASS line ONLY if you ran the verification method and observed it succeed.
+   That line is the ONLY evidence the parent accepts — prose saying you passed counts
+   for nothing, and a run that prints both PASS and FAIL for your criterion is a FAIL.
+7. Then print one line per OTHER criterion you regression-checked, same rules:
+     ${iscRegressionContract()}
+8. Do NOT edit the ISA file. The parent reads your stdout and updates the ISA.
+9. That's it. Exit when done — exit non-zero only if you genuinely failed to run.`;
 }
 
 // ─── Parallel Iteration Runner ──────────────────────────────────────────────
@@ -875,15 +883,24 @@ async function runParallelIteration(
   console.log(`\x1b[90m  ⏱ Agents finished in ${elapsed}s\x1b[0m`);
   console.log("");
 
-  // Parse agent stdout for RESULT lines — agents report pass/fail via stdout only
+  // Parse agent stdout for structured ISC_RESULT verdicts. Substring matching is not
+  // enough: a failing agent's prose can contain its own id next to the word PASS.
+  // See IscResult.ts for the contract and the fail-closed rules.
+  // A regression FAIL from ANY agent vetoes that criterion for the whole iteration —
+  // one agent's fix can break the criterion another agent claims to have passed.
+  const regressionVetoes = new Set<string>();
+  for (const { stdout } of results) {
+    for (const id of parseWorkerOutput(stdout).regressionFailed) regressionVetoes.add(id);
+  }
+
+  const verdicts = new Map<number, IscVerdict | "REGRESSED">();
   const passedIds: string[] = [];
-  for (const { assignment, stdout } of results) {
+  for (const { assignment, stdout, exitCode } of results) {
     const cId = assignment.criteriaIds[0];
-    // Look for "RESULT: ISC-xxx PASS" in agent output
-    if (stdout.includes(`RESULT: ${cId} PASS`) || stdout.includes(`${cId} PASS`)) {
-      passedIds.push(cId);
-    }
-    // Also check if agent edited the ISA despite instructions (fallback detection)
+    const judged = judgeCriterion(cId, { stdout, exitCode });
+    const verdict = judged === "PASS" && regressionVetoes.has(cId) ? "REGRESSED" : judged;
+    verdicts.set(assignment.agentId, verdict);
+    if (verdict === "PASS") passedIds.push(cId);
   }
 
   // Parent updates ISA checkboxes sequentially — no concurrent writes
@@ -915,19 +932,20 @@ async function runParallelIteration(
 
   // ── Per-agent results ──
   console.log(`  \x1b[1mAgent Results:\x1b[0m`);
-  for (const { assignment, exitCode } of results) {
+  for (const { assignment } of results) {
     const cId = assignment.criteriaIds[0];
     const detail = assignment.criteriaDetails[0];
     const desc = detail.description.length > 40 ? detail.description.slice(0, 37) + "..." : detail.description;
-    const criterion = postCriteria.criteria.find(c => c.id === cId);
-    const passed = criterion?.status === "passing";
-    if (exitCode !== 0) {
-      console.log(`  \x1b[31m  Agent ${assignment.agentId} ✗ CRASHED\x1b[0m  ${cId}: ${desc}`);
-    } else if (passed) {
-      console.log(`  \x1b[32m  Agent ${assignment.agentId} ✓ PASS\x1b[0m    ${cId}: ${desc}`);
-    } else {
-      console.log(`  \x1b[33m  Agent ${assignment.agentId} ✗ FAIL\x1b[0m    ${cId}: ${desc}`);
-    }
+    const verdict = verdicts.get(assignment.agentId) ?? "NO_SIGNAL";
+    const passed = verdict === "PASS";
+    // Anything short of a clean PASS is shown as-is — NO_SIGNAL and AMBIGUOUS are
+    // distinct from a reported FAIL and the operator needs to tell them apart.
+    const color = passed ? "\x1b[32m" : verdict === "FAIL" || verdict === "NO_SIGNAL" ? "\x1b[33m" : "\x1b[31m";
+    const label = `${passed ? "✓" : "✗"} ${verdict}`.padEnd(11);
+    console.log(`  ${color}  Agent ${assignment.agentId} ${label}\x1b[0m ${cId}: ${desc}`);
+  }
+  if (regressionVetoes.size > 0) {
+    console.log(`  \x1b[31m  Regression checks failed: ${[...regressionVetoes].join(", ")}\x1b[0m`);
   }
   console.log("");
 

--- a/LifeOS/install/test/tools/IscResult.test.ts
+++ b/LifeOS/install/test/tools/IscResult.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "bun:test";
+import { judgeCriterion, parseWorkerOutput } from "../../LIFEOS/TOOLS/IscResult";
+
+// The detection rule this contract replaces: a bare substring test on the
+// worker's stdout. Reproduced verbatim so the false positives below are pinned
+// as regressions rather than described in a comment.
+const legacyDetect = (stdout: string, cId: string): boolean =>
+  stdout.includes(`RESULT: ${cId} PASS`) || stdout.includes(`${cId} PASS`);
+
+const pass = (id: string) => `ISC_RESULT v1 id=${id} verdict=PASS`;
+const fail = (id: string, reason: string) => `ISC_RESULT v1 id=${id} verdict=FAIL reason=${reason}`;
+
+describe("judgeCriterion — prose is never a pass", () => {
+  // Both strings satisfy the legacy substring test while describing a failure.
+  const falsePositives = [
+    "RESULT: ISC-3 FAIL: I could not make ISC-3 PASS despite two attempts",
+    "Verified whether ISC-3 PASSES: it does not.",
+  ];
+
+  for (const stdout of falsePositives) {
+    test(`rejects: ${stdout.slice(0, 40)}...`, () => {
+      expect(legacyDetect(stdout, "ISC-3")).toBe(true);  // the bug being fixed
+      expect(judgeCriterion("ISC-3", { stdout, exitCode: 0 })).not.toBe("PASS");
+    });
+  }
+
+  test("a full failure report with a structured FAIL line is a FAIL", () => {
+    const stdout = [
+      "I tried two approaches. Neither made ISC-3 PASS.",
+      fail("ISC-3", "verification command exits 1"),
+    ].join("\n");
+    expect(judgeCriterion("ISC-3", { stdout, exitCode: 0 })).toBe("FAIL");
+  });
+
+  test("no verdict line at all is NO_SIGNAL, not a pass", () => {
+    const stdout = "Done. Everything looks good.";
+    expect(judgeCriterion("ISC-3", { stdout, exitCode: 0 })).toBe("NO_SIGNAL");
+  });
+
+  test("an indented or quoted verdict line does not count", () => {
+    for (const stdout of [`  ${pass("ISC-3")}`, `> ${pass("ISC-3")}`, `\`${pass("ISC-3")}\``]) {
+      expect(judgeCriterion("ISC-3", { stdout, exitCode: 0 })).toBe("NO_SIGNAL");
+    }
+  });
+
+  test("the prompt's own contract template is not a passing signal", () => {
+    const stdout = "ISC_RESULT v1 id=ISC-3 verdict=PASS|FAIL reason=<one line, FAIL only>";
+    expect(judgeCriterion("ISC-3", { stdout, exitCode: 0 })).not.toBe("PASS");
+  });
+});
+
+describe("judgeCriterion — genuine verdicts", () => {
+  test("a genuine pass", () => {
+    const stdout = ["Ran the verify command, exit 0.", pass("ISC-3")].join("\n");
+    expect(judgeCriterion("ISC-3", { stdout, exitCode: 0 })).toBe("PASS");
+  });
+
+  test("a pass line for a different criterion does not pass this one", () => {
+    expect(judgeCriterion("ISC-3", { stdout: pass("ISC-4"), exitCode: 0 })).toBe("NO_SIGNAL");
+  });
+
+  test("id matching is exact, not prefix", () => {
+    expect(judgeCriterion("ISC-3", { stdout: pass("ISC-30"), exitCode: 0 })).toBe("NO_SIGNAL");
+  });
+
+  test("CRLF line endings and trailing spaces are tolerated", () => {
+    const stdout = `some log\r\n${pass("ISC-3")}  \r\n`;
+    expect(judgeCriterion("ISC-3", { stdout, exitCode: 0 })).toBe("PASS");
+  });
+});
+
+describe("judgeCriterion — a worker that did not exit cleanly never passes", () => {
+  const stdout = ["Verified the fix.", pass("ISC-3")].join("\n");
+
+  test("non-zero exit is CRASHED even with a well-formed PASS line", () => {
+    expect(judgeCriterion("ISC-3", { stdout, exitCode: 1 })).toBe("CRASHED");
+  });
+
+  test("a killed worker (SIGKILL/timeout) is CRASHED", () => {
+    expect(judgeCriterion("ISC-3", { stdout, exitCode: 137 })).toBe("CRASHED");
+  });
+});
+
+describe("judgeCriterion — ambiguity fails closed", () => {
+  test("both PASS and FAIL for the same id is AMBIGUOUS", () => {
+    const stdout = [pass("ISC-3"), fail("ISC-3", "flaky on rerun")].join("\n");
+    expect(judgeCriterion("ISC-3", { stdout, exitCode: 0 })).toBe("AMBIGUOUS");
+  });
+
+  test("a malformed verdict line poisons the run", () => {
+    const stdout = ["ISC_RESULT v1 id=ISC-3 verdict=MAYBE", pass("ISC-3")].join("\n");
+    expect(judgeCriterion("ISC-3", { stdout, exitCode: 0 })).toBe("AMBIGUOUS");
+  });
+
+  test("a PASS line carrying trailing text is malformed, not a pass", () => {
+    const stdout = "ISC_RESULT v1 id=ISC-3 verdict=PASS reason=well, mostly";
+    expect(judgeCriterion("ISC-3", { stdout, exitCode: 0 })).toBe("AMBIGUOUS");
+  });
+
+  test("a regression FAIL for the worker's own id overrides its PASS", () => {
+    const stdout = [pass("ISC-3"), "ISC_REGRESSION v1 id=ISC-3 verdict=FAIL"].join("\n");
+    expect(judgeCriterion("ISC-3", { stdout, exitCode: 0 })).toBe("AMBIGUOUS");
+  });
+});
+
+describe("parseWorkerOutput — regression lines", () => {
+  test("collects regression verdicts separately from the primary result", () => {
+    const stdout = [
+      pass("ISC-3"),
+      "ISC_REGRESSION v1 id=ISC-1 verdict=PASS",
+      "ISC_REGRESSION v1 id=ISC-2 verdict=FAIL reason=build breaks",
+    ].join("\n");
+    const verdicts = parseWorkerOutput(stdout);
+    expect([...verdicts.passed]).toEqual(["ISC-3"]);
+    expect([...verdicts.regressionPassed]).toEqual(["ISC-1"]);
+    expect([...verdicts.regressionFailed]).toEqual(["ISC-2"]);
+    expect(verdicts.malformed).toBe(false);
+  });
+
+  test("prose about a regression check is not a regression verdict", () => {
+    const stdout = "REGRESSION_CHECK: ISC-2 PASS — well, it PASSES in spirit";
+    const verdicts = parseWorkerOutput(stdout);
+    expect(verdicts.regressionPassed.size).toBe(0);
+    expect(verdicts.regressionFailed.size).toBe(0);
+  });
+
+  test("a malformed regression line is flagged", () => {
+    expect(parseWorkerOutput("ISC_REGRESSION v1 ISC-2 PASS").malformed).toBe(true);
+  });
+});


### PR DESCRIPTION
## The problem

`algorithm.ts` decided whether a parallel worker passed its criterion with a bare substring test:

```ts
if (stdout.includes(`RESULT: ${cId} PASS`) || stdout.includes(`${cId} PASS`)) {
```

The second clause subsumes the first, so the `RESULT:` anchor protected nothing. Both of these strings satisfied it while describing a **failure**:

- `RESULT: ISC-3 FAIL: I could not make ISC-3 PASS despite two attempts`
- `Verified whether ISC-3 PASSES: it does not.`

The worker's exit code was ignored for pass detection, used only for a display label. The criterion checkbox was then flipped to `[x]`, and once `postCriteria.passing >= postCriteria.total` the ISA status was set to COMPLETE with no re-verification.

So a failing worker whose prose happened to mention its own criterion id near the word PASS got that criterion checked off, and enough of those drove the artifact to COMPLETE. For a system whose entire premise is that a claim closes only on evidence, that inverts the doctrine: it reports verification it never performed.

## The fix

**A structured verdict line, not prose matching.** Workers now emit a sentinel-prefixed line:

```
ISC_RESULT v1 id=<criterion-id> verdict=PASS|FAIL reason=<one line, FAIL only>
```

The contract lives in one place (`IscResult.ts`) and is rendered into the worker prompt from the same constants the parser uses, so the two ends cannot drift.

**Fail closed on anything less than a clean verdict.** The judge returns `PASS`, `FAIL`, `CRASHED`, `AMBIGUOUS` or `NO_SIGNAL`, and only `PASS` closes a criterion. Contradictory output — a PASS and a FAIL line for the same id — is `AMBIGUOUS`, not a pass. A non-zero exit is `CRASHED` regardless of what stdout contains, so exit code is a necessary condition for passing.

**Regression checks parsed with the same rigour,** and a regression FAIL from any worker vetoes that criterion for the whole iteration, since one worker's fix can break what another claims to have passed.

**Operator-visible distinctions.** `NO_SIGNAL` and `AMBIGUOUS` are displayed as themselves rather than collapsed into a generic failure, because "the worker said it failed" and "the worker said nothing parseable" call for different responses. The dead `fallback detection` comment that had no code beneath it is gone.

## Tests

`test/tools/IscResult.test.ts`, 19 cases:

```
19 pass
0 fail
27 expect() calls
```

Separately verified with an adversarial probe written to break the parser rather than confirm it. All 19 cases behave correctly:

- Both original false-positive strings → not a pass
- Sentinel quoted inside prose, or wrapped in markdown bold → `NO_SIGNAL`
- Contradictory PASS + FAIL for one id → `AMBIGUOUS`
- Valid PASS line with a non-zero exit → `CRASHED`
- Verdict addressed to a different criterion → `NO_SIGNAL`
- **Id-prefix collision**: `id=ISC-30 verdict=PASS` does not close `ISC-3` → `NO_SIGNAL`
- Malformed or missing verdict key → `AMBIGUOUS`
- Empty and whitespace-only output → `NO_SIGNAL`
- Genuine PASS closes, genuine FAIL reports as FAIL, both alone and embedded in surrounding output
- Regression FAIL captured from the structured line while prose mentioning another id near "PASS" is ignored

## Note for review

This changes the worker contract, so a worker still emitting the old `RESULT: <id> PASS` shape now yields `NO_SIGNAL` and its criterion stays open. That is the intended direction — fail closed rather than open — but it is a behaviour change worth being deliberate about, since an in-flight run started before the upgrade will not close criteria until its workers use the new line.
