### PR TITLE
fix(memory): recover stale write locks instead of jamming a note forever

### DIFF
--- a/LifeOS/install/LIFEOS/DOCUMENTATION/Memory/MemorySystem.md
+++ b/LifeOS/install/LIFEOS/DOCUMENTATION/Memory/MemorySystem.md
@@ -1,5 +1,5 @@
 ---
-version: 1.5.19
+version: 1.5.20
 ---
 
 # Memory System
@@ -127,6 +127,7 @@ Defined in `LIFEOS/TOOLS/MutationTier.ts` — code-only allowlist, default-deny 
 - **`LIFEOS/TOOLS/MemoryTypes.ts`** — type registry. Resolvers for storage path per item.
 - **`LIFEOS/TOOLS/MemoryWriter.ts`** — set-overwrite primitive for Tier A memory files. Atomic rename, lock sidecar, prefix soft-convention, dedupe, cap enforcement.
 - **`LIFEOS/TOOLS/MemorySystem.ts`** — the single public API. `add(item)` routes by type; `find(query, options)` returns BM25 top-K.
+- **`LIFEOS/TOOLS/MemoryLock.ts`** — crash-safe per-note write lock. Stamps pid + host into the lockfile; a contender breaks the lock when `kill(pid, 0)` proves the holder is gone, falls back to a `LOCK_STALE_MS` age rule when liveness is unverifiable, and respects a live holder. Recovery and refusal both append to `MEMORY/OBSERVABILITY/memory-locks.jsonl` and print to stderr.
 - **`LIFEOS/TOOLS/MemoryRetriever.ts`** — BM25 retriever over the typed-item corpus including the two hot-layer memory files. Pure-function, no LLM call, ~30ms over 500+ notes.
 - **`LIFEOS/TOOLS/MemoryReviewer.ts`** — the autonomic centerpiece. Single-pass orchestrator: locate most-recent harness transcript, extract last N exchanges, call `Inference.ts` (Sonnet, env-scrubbed subscription billing, `--tools ""`), parse `{items:[...]}` JSON, route each typed item through `MemorySystem.add()`.
 - **`LIFEOS/TOOLS/MutationTier.ts`** — tier classifier. Pure function, no config file (code-only allowlist).

--- a/LifeOS/install/LIFEOS/TOOLS/MemoryLock.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/MemoryLock.ts
@@ -1,0 +1,320 @@
+#!/usr/bin/env bun
+/**
+ * MemoryLock — crash-safe per-file write lock for the memory subsystem.
+ *
+ * The problem this exists to solve: memory writes run inside hook-spawned
+ * subprocesses. If the harness times one out — or the machine loses power —
+ * after the lockfile is created but before the release runs, the `.lock` file
+ * survives on disk forever. Without a staleness check, every later write to
+ * that note fails with "Lock held", permanently and silently.
+ *
+ * Recovery is decided on EVIDENCE first, age second:
+ *
+ *   1. The holder stamps its pid + host into the lockfile at acquire time.
+ *   2. A contender that finds the lock held reads that stamp. If the holder
+ *      ran on this host and `kill(pid, 0)` says the process is gone, the lock
+ *      is stale — the holder died. Break it immediately; no waiting on a TTL.
+ *   3. If liveness can't be established (unreadable/empty stamp, a lockfile
+ *      written by an older build, or a holder recorded on a different host)
+ *      we fall back to age: older than `LOCK_STALE_MS` is stale.
+ *   4. A holder that is provably alive is RESPECTED — up to `LOCK_STALE_MS`.
+ *      Past that it is broken anyway, because a per-note append that has held
+ *      the lock for minutes is either hung or a recycled pid, and neither may
+ *      jam memory writes forever.
+ *
+ * Every unknown resolves toward "assume alive" so the failure mode is a
+ * refused write (loud, recoverable) rather than two concurrent writers
+ * corrupting the same note.
+ *
+ * Breaking a stale lock is done by renaming it aside and then re-creating with
+ * O_EXCL, so at most one of several concurrent recoverers wins. The inode
+ * observed when the staleness call was made is re-checked after the rename; if
+ * it changed, we raced a fresh holder, put its lock back, and refuse.
+ *
+ * Recovery and contention are both appended to
+ * `LIFEOS/MEMORY/OBSERVABILITY/memory-locks.jsonl` and echoed to stderr, so an
+ * operator can tell "recovered from a crash" from "nothing ever went wrong".
+ *
+ * `LOCK_STALE_MS` matches DerivedSync.ts's constant of the same name — this is
+ * the same convention, with the liveness probe added.
+ */
+
+import {
+  appendFileSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join as pathJoin } from "node:path";
+import { homedir, hostname } from "node:os";
+
+// ── Constants ──
+
+/** Age past which a lock is stale when liveness can't be proven (or the holder hung). */
+export const LOCK_STALE_MS = 5 * 60 * 1000;
+
+// ── Types ──
+
+interface Holder {
+  pid: number;
+  host: string;
+  ts: string;
+}
+
+export interface LockHandle {
+  ok: true;
+  /** True when acquisition required breaking a stale lock left by a dead/hung holder. */
+  recovered: boolean;
+  release(): void;
+}
+
+export type LockError =
+  | { ok: false; code: "ELOCK_HELD"; message: string }
+  | { ok: false; code: "ELOCK_ERROR"; message: string };
+
+export type LockResult = LockHandle | LockError;
+
+export interface AcquireOptions {
+  /** Override the staleness window. Defaults to LOCK_STALE_MS. */
+  staleMs?: number;
+  /** Prefix for stderr lines and the `label` field on log rows. */
+  label?: string;
+}
+
+// ── Observability ──
+
+function lockLogPath(): string {
+  const base = process.env.LIFEOS_DIR || pathJoin(homedir(), ".claude", "LIFEOS");
+  return pathJoin(base, "MEMORY", "OBSERVABILITY", "memory-locks.jsonl");
+}
+
+/**
+ * Append one JSONL row and echo to stderr. Every event here is abnormal — a
+ * recovered crash, a refused write — so it always earns an operator-visible
+ * line. Best-effort: observability must never be the reason a write fails.
+ */
+export function logLockEvent(row: {
+  event: "stale_lock_recovered" | "lock_contended" | "write_failed";
+  label?: string;
+  message: string;
+  [key: string]: unknown;
+}): void {
+  const label = row.label ?? "MemoryLock";
+  const line = { ts: new Date().toISOString(), pid: process.pid, ...row, label };
+  try {
+    const path = lockLogPath();
+    mkdirSync(dirname(path), { recursive: true });
+    appendFileSync(path, JSON.stringify(line) + "\n", "utf8");
+  } catch {
+    /* observability is best-effort */
+  }
+  console.error(`[${label}] ${row.event}: ${row.message}`);
+}
+
+// ── Liveness ──
+
+/**
+ * Is `pid` a process on this machine right now? Signal 0 does no work, it only
+ * runs the kernel's permission + existence checks. ESRCH is the only answer
+ * that proves absence: EPERM means the process exists under another uid, and
+ * any other error means we simply don't know. Both resolve to "alive" so an
+ * ambiguous probe can never break a live lock.
+ */
+function isProcessAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 1) return true;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e: any) {
+    return e?.code !== "ESRCH";
+  }
+}
+
+// ── Lockfile primitives ──
+
+function holderRecord(): string {
+  const holder: Holder = { pid: process.pid, host: hostname(), ts: new Date().toISOString() };
+  return JSON.stringify(holder) + "\n";
+}
+
+/** O_CREAT | O_EXCL create. True if we now hold the lock, false if someone else does. */
+function tryCreate(lockPath: string): boolean {
+  try {
+    writeFileSync(lockPath, holderRecord(), { flag: "wx" });
+    return true;
+  } catch (e: any) {
+    if (e?.code === "EEXIST") return false;
+    throw e;
+  }
+}
+
+function readHolder(lockPath: string): Holder | null {
+  try {
+    const raw = readFileSync(lockPath, "utf8").trim();
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (typeof parsed?.pid !== "number" || typeof parsed?.host !== "string") return null;
+    return { pid: parsed.pid, host: parsed.host, ts: String(parsed.ts ?? "") };
+  } catch {
+    return null;
+  }
+}
+
+type Verdict = {
+  stale: boolean;
+  reason: string;
+  ageMs: number;
+  ino: number | null;
+  holder: Holder | null;
+};
+
+function inspect(lockPath: string, staleMs: number): Verdict {
+  let ino: number | null = null;
+  let ageMs = 0;
+  try {
+    const st = statSync(lockPath);
+    ino = st.ino;
+    ageMs = Date.now() - st.mtimeMs;
+  } catch {
+    // Vanished between the failed create and the stat — the holder released it.
+    return { stale: true, reason: "lock-vanished", ageMs: 0, ino: null, holder: null };
+  }
+
+  const holder = readHolder(lockPath);
+  const verifiable = holder !== null && holder.host === hostname();
+
+  if (verifiable && !isProcessAlive(holder!.pid)) {
+    return { stale: true, reason: "holder-process-gone", ageMs, ino, holder };
+  }
+  if (ageMs > staleMs) {
+    return {
+      stale: true,
+      reason: verifiable ? "holder-alive-but-expired" : "expired-unverifiable-holder",
+      ageMs,
+      ino,
+      holder,
+    };
+  }
+  return {
+    stale: false,
+    reason: verifiable ? "holder-alive" : "unverifiable-holder-within-ttl",
+    ageMs,
+    ino,
+    holder,
+  };
+}
+
+/**
+ * Break a lock judged stale and take it. Rename-aside then O_EXCL create means
+ * concurrent recoverers can't both end up holding it. `expectedIno` is the
+ * inode the staleness call was made against — a mismatch means a live holder
+ * created a new lock in between, so we put it back and refuse.
+ */
+function breakAndTake(lockPath: string, expectedIno: number | null): boolean {
+  const asidePath = `${lockPath}.stale.${process.pid}.${Math.random().toString(36).slice(2, 8)}`;
+  try {
+    renameSync(lockPath, asidePath);
+  } catch {
+    // Someone else already moved it; just race for the create.
+    return tryCreate(lockPath);
+  }
+
+  if (expectedIno !== null) {
+    let actualIno: number | null = null;
+    try {
+      actualIno = statSync(asidePath).ino;
+    } catch {
+      actualIno = null;
+    }
+    if (actualIno !== expectedIno) {
+      try {
+        renameSync(asidePath, lockPath);
+      } catch {
+        /* nothing safe left to do */
+      }
+      return false;
+    }
+  }
+
+  try {
+    rmSync(asidePath, { force: true });
+  } catch {
+    /* the rename already freed the lock path */
+  }
+  return tryCreate(lockPath);
+}
+
+// ── Public API ──
+
+/**
+ * Acquire `lockPath`, recovering it automatically if the previous holder died.
+ * Callers MUST call `release()` in a `finally`.
+ */
+export function acquire(lockPath: string, options: AcquireOptions = {}): LockResult {
+  const staleMs = options.staleMs ?? LOCK_STALE_MS;
+  const label = options.label ?? "MemoryLock";
+
+  try {
+    mkdirSync(dirname(lockPath), { recursive: true });
+    if (tryCreate(lockPath)) return makeHandle(lockPath, false);
+  } catch (e: any) {
+    return {
+      ok: false,
+      code: "ELOCK_ERROR",
+      message: `Failed to acquire lock ${lockPath}: ${e?.message || String(e)}`,
+    };
+  }
+
+  const verdict = inspect(lockPath, staleMs);
+
+  if (!verdict.stale) {
+    const message = `Lock held: ${lockPath} (holder pid ${verdict.holder?.pid ?? "unknown"}, ${verdict.reason}, age ${verdict.ageMs}ms)`;
+    logLockEvent({ event: "lock_contended", label, message, lock: lockPath, reason: verdict.reason, age_ms: verdict.ageMs });
+    return { ok: false, code: "ELOCK_HELD", message };
+  }
+
+  let taken = false;
+  try {
+    taken = breakAndTake(lockPath, verdict.ino);
+  } catch (e: any) {
+    return {
+      ok: false,
+      code: "ELOCK_ERROR",
+      message: `Failed to recover stale lock ${lockPath}: ${e?.message || String(e)}`,
+    };
+  }
+
+  if (!taken) {
+    const message = `Lock held: ${lockPath} (lost the stale-lock recovery race)`;
+    logLockEvent({ event: "lock_contended", label, message, lock: lockPath, reason: "recovery-race-lost", age_ms: verdict.ageMs });
+    return { ok: false, code: "ELOCK_HELD", message };
+  }
+
+  logLockEvent({
+    event: "stale_lock_recovered",
+    label,
+    message: `Recovered stale lock ${lockPath} (${verdict.reason}, age ${verdict.ageMs}ms, previous holder pid ${verdict.holder?.pid ?? "unknown"})`,
+    lock: lockPath,
+    reason: verdict.reason,
+    age_ms: verdict.ageMs,
+    previous_pid: verdict.holder?.pid ?? null,
+  });
+  return makeHandle(lockPath, true);
+}
+
+function makeHandle(lockPath: string, recovered: boolean): LockHandle {
+  return {
+    ok: true,
+    recovered,
+    release(): void {
+      try {
+        rmSync(lockPath, { force: true });
+      } catch {
+        /* lockfile cleanup is best-effort */
+      }
+    },
+  };
+}

--- a/LifeOS/install/LIFEOS/TOOLS/MemorySystem.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/MemorySystem.ts
@@ -67,6 +67,7 @@ import {
 } from "./MemoryTypes";
 
 import { setEntries as memoryWriterSetEntries, read as memoryWriterRead } from "./MemoryWriter";
+import { acquire as acquireLock, logLockEvent } from "./MemoryLock";
 import { getTier } from "./MutationTier";
 import { getRelevantContext, type RelevantResultItem } from "./MemoryRetriever";
 import { mintId, slugFromPath, SCHEMA_VERSION } from "./KnowledgeSchema";
@@ -128,17 +129,35 @@ function logTierBWrite(filePath: string, bytes: number, type: MemoryTypeName): v
 
 // ── Append-write primitive for Tier B types ──
 
-function appendToTierBFile(filePath: string, content: string): { ok: true; bytes: number } | AddError {
+/**
+ * A Tier B append that cannot proceed used to return EWRITE_FAILED to a caller
+ * that mostly ignores it — silent memory loss. Every failure now also lands in
+ * MEMORY/OBSERVABILITY/memory-locks.jsonl and on stderr before it is returned.
+ */
+function failTierBWrite(filePath: string, message: string, underlying?: unknown): AddError {
+  logLockEvent({
+    event: "write_failed",
+    label: "MemorySystem",
+    message,
+    file: filePath.replace(CLAUDE_ROOT + "/", ""),
+  });
+  return { ok: false, code: "EWRITE_FAILED", message, underlying };
+}
+
+/** Exported for `test/tools/MemorySystem.test.ts`; not part of the public API. */
+export function appendToTierBFile(filePath: string, content: string): { ok: true; bytes: number } | AddError {
   const lockPath = `${filePath}.lock`;
-  let fd: number | null = null;
   try {
     mkdirSync(dirname(filePath), { recursive: true });
-    fd = openSync(lockPath, "wx");
   } catch (e: any) {
-    if (e?.code === "EEXIST") {
-      return { ok: false, code: "EWRITE_FAILED", message: `Lock held: ${lockPath}` };
-    }
-    return { ok: false, code: "EWRITE_FAILED", message: `Failed to acquire lock: ${e?.message}` };
+    return failTierBWrite(filePath, `Failed to create note directory: ${e?.message}`, e);
+  }
+
+  // Crash-safe: MemoryLock recovers a lock whose holder is provably gone, so a
+  // hook subprocess killed mid-write can't jam this note forever.
+  const lock = acquireLock(lockPath, { label: "MemorySystem" });
+  if (!lock.ok) {
+    return failTierBWrite(filePath, lock.message);
   }
 
   try {
@@ -155,10 +174,9 @@ function appendToTierBFile(filePath: string, content: string): { ok: true; bytes
 
     return { ok: true, bytes: Buffer.byteLength(content, "utf8") };
   } catch (e: any) {
-    return { ok: false, code: "EWRITE_FAILED", message: `Append failed: ${e?.message}`, underlying: e };
+    return failTierBWrite(filePath, `Append failed: ${e?.message}`, e);
   } finally {
-    try { if (fd !== null) closeSync(fd); } catch { /* ignore */ }
-    try { unlinkSync(lockPath); } catch { /* ignore */ }
+    lock.release();
   }
 }
 

--- a/LifeOS/install/test/tools/MemorySystem.test.ts
+++ b/LifeOS/install/test/tools/MemorySystem.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tier B write-lock recovery.
+ *
+ * Memory writes run inside hook-spawned subprocesses. One killed after it
+ * created `<note>.lock` but before it released used to jam that note's writes
+ * forever, silently. These tests pin the three properties that fix relies on:
+ * a lock whose holder is gone gets broken, a lock whose holder is running does
+ * not, and either outcome is visible to an operator.
+ *
+ * Hermetic: notes live in a temp dir and LIFEOS_DIR points the observability
+ * log at a temp dir, so nothing here touches a real install.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { hostname, tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { appendToTierBFile } from "../../LIFEOS/TOOLS/MemorySystem";
+import { LOCK_STALE_MS } from "../../LIFEOS/TOOLS/MemoryLock";
+
+const LOCK_LOG = ["MEMORY", "OBSERVABILITY", "memory-locks.jsonl"];
+
+let root: string;
+let notePath: string;
+let lockPath: string;
+let priorLifeosDir: string | undefined;
+
+/** Children spawned by a test, killed and reaped in afterEach. */
+let children: ReturnType<typeof Bun.spawn>[] = [];
+
+/** A live process on this host. Returns its pid. */
+function spawnLiveProcess(): number {
+  const proc = Bun.spawn(["sleep", "300"], { stdout: "ignore", stderr: "ignore" });
+  children.push(proc);
+  return proc.pid;
+}
+
+/**
+ * A pid that is provably not a process: spawn one, kill it, and wait on the
+ * exit rather than on the clock. Awaiting `exited` also reaps the zombie —
+ * a zombie still answers kill(pid, 0), so an unreaped pid would read as alive.
+ */
+async function deadPid(): Promise<number> {
+  const proc = Bun.spawn(["sleep", "300"], { stdout: "ignore", stderr: "ignore" });
+  const pid = proc.pid;
+  proc.kill("SIGKILL");
+  await proc.exited;
+  return pid;
+}
+
+function writeLock(body: string, ageMs = 0): void {
+  writeFileSync(lockPath, body, "utf8");
+  if (ageMs > 0) {
+    const when = new Date(Date.now() - ageMs);
+    utimesSync(lockPath, when, when);
+  }
+}
+
+function holderRecord(pid: number, host = hostname()): string {
+  return JSON.stringify({ pid, host, ts: new Date().toISOString() }) + "\n";
+}
+
+function lockLogRows(): Record<string, any>[] {
+  const path = join(root, "lifeos", ...LOCK_LOG);
+  if (!existsSync(path)) return [];
+  return readFileSync(path, "utf8")
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line));
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "lifeos-memlock-"));
+  mkdirSync(join(root, "notes"), { recursive: true });
+  notePath = join(root, "notes", "Note.md");
+  lockPath = `${notePath}.lock`;
+  priorLifeosDir = process.env.LIFEOS_DIR;
+  process.env.LIFEOS_DIR = join(root, "lifeos");
+  children = [];
+});
+
+afterEach(async () => {
+  for (const proc of children) {
+    proc.kill("SIGKILL");
+    await proc.exited;
+  }
+  children = [];
+  if (priorLifeosDir === undefined) delete process.env.LIFEOS_DIR;
+  else process.env.LIFEOS_DIR = priorLifeosDir;
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("appendToTierBFile lock recovery", () => {
+  test("uncontended write succeeds and leaves no lockfile", () => {
+    const result = appendToTierBFile(notePath, "first line\n");
+
+    expect(result.ok).toBe(true);
+    expect(readFileSync(notePath, "utf8")).toBe("first line\n");
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  test("stale lock from a dead process is recovered and the write succeeds", async () => {
+    const pid = await deadPid();
+    writeLock(holderRecord(pid));
+
+    const result = appendToTierBFile(notePath, "recovered write\n");
+
+    expect(result.ok).toBe(true);
+    expect(readFileSync(notePath, "utf8")).toContain("recovered write");
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  test("recovery is decided on liveness, not age: a seconds-old dead holder is broken", async () => {
+    const pid = await deadPid();
+    writeLock(holderRecord(pid), 2_000);
+
+    expect(Date.now() - statSync(lockPath).mtimeMs).toBeLessThan(LOCK_STALE_MS);
+    expect(appendToTierBFile(notePath, "no TTL wait\n").ok).toBe(true);
+  });
+
+  test("stale lock recovery is logged with the dead holder's pid", async () => {
+    const pid = await deadPid();
+    writeLock(holderRecord(pid));
+
+    appendToTierBFile(notePath, "recovered write\n");
+
+    const recovered = lockLogRows().filter((row) => row.event === "stale_lock_recovered");
+    expect(recovered).toHaveLength(1);
+    expect(recovered[0].reason).toBe("holder-process-gone");
+    expect(recovered[0].previous_pid).toBe(pid);
+    expect(recovered[0].label).toBe("MemorySystem");
+    expect(recovered[0].lock).toBe(lockPath);
+  });
+
+  test("fresh lock from a live process is respected and the write is refused", () => {
+    const pid = spawnLiveProcess();
+    writeLock(holderRecord(pid));
+
+    const result = appendToTierBFile(notePath, "must not land\n");
+
+    expect(result.ok).toBe(false);
+    expect((result as { code: string }).code).toBe("EWRITE_FAILED");
+    expect((result as { message: string }).message).toContain("Lock held");
+    expect(existsSync(notePath)).toBe(false);
+    // The live holder's lock is still theirs.
+    expect(existsSync(lockPath)).toBe(true);
+    expect(JSON.parse(readFileSync(lockPath, "utf8")).pid).toBe(pid);
+  });
+
+  test("a refused write is logged, not silent", () => {
+    const pid = spawnLiveProcess();
+    writeLock(holderRecord(pid));
+
+    appendToTierBFile(notePath, "must not land\n");
+
+    const rows = lockLogRows();
+    expect(rows.some((row) => row.event === "lock_contended")).toBe(true);
+    expect(rows.some((row) => row.event === "write_failed")).toBe(true);
+    expect(rows.some((row) => row.event === "stale_lock_recovered")).toBe(false);
+  });
+
+  test("an unparseable lock is respected inside the TTL and broken past it", () => {
+    writeLock("", 1_000);
+    expect(appendToTierBFile(notePath, "too soon\n").ok).toBe(false);
+
+    utimesSync(lockPath, new Date(Date.now() - LOCK_STALE_MS - 1_000), new Date(Date.now() - LOCK_STALE_MS - 1_000));
+    expect(appendToTierBFile(notePath, "aged out\n").ok).toBe(true);
+
+    const recovered = lockLogRows().filter((row) => row.event === "stale_lock_recovered");
+    expect(recovered).toHaveLength(1);
+    expect(recovered[0].reason).toBe("expired-unverifiable-holder");
+  });
+
+  test("a live holder recorded on another host falls back to the age rule", () => {
+    const pid = spawnLiveProcess();
+    writeLock(holderRecord(pid, `${hostname()}-elsewhere`), LOCK_STALE_MS + 1_000);
+
+    const result = appendToTierBFile(notePath, "cross-host recovery\n");
+
+    expect(result.ok).toBe(true);
+    const recovered = lockLogRows().filter((row) => row.event === "stale_lock_recovered");
+    expect(recovered[0].reason).toBe("expired-unverifiable-holder");
+  });
+});


### PR DESCRIPTION
## The problem

The per-note write lock in `MemorySystem.ts` was `openSync(lockPath, "wx")` with removal in a `finally`, and no staleness check, TTL, or liveness test.

Memory writes run inside hook-spawned subprocesses. If the harness times one out, or the machine loses power, after the lock file is created but before the `finally` runs, the `.lock` survives on disk. Every later write to that note then returns:

```
{ ok: false, code: "EWRITE_FAILED", message: "Lock held: <path>.lock" }
```

Forever. There is no self-heal, and nothing surfaces that error, so the outcome is silent permanent memory loss for that note. The operator is never told their memory system stopped accepting writes for that entry.

Two files in this tree already solve exactly this — `DerivedSync.ts` with a `LOCK_STALE_MS` constant and `rmSync` recovery, and `PromptProcessing.hook.ts` with a `LOCK_STALE` window. This site simply did not use the pattern.

## The fix

**Liveness first, age as fallback.** The lock file now records the holder's pid, host and timestamp. On contention:

1. Holder ran on this host and `kill(pid, 0)` says it is gone → recover immediately, no waiting out a TTL.
2. Holder is provably alive → respect the lock.
3. Holder cannot be verified (different host, unreadable or corrupt lock file) → fall back to age, and recover only past `LOCK_STALE_MS`.

Every unknown resolves toward "assume alive", so the failure mode is a delayed write rather than two writers corrupting one note. `LOCK_STALE_MS` matches `DerivedSync.ts`'s constant rather than introducing a third number.

**Failures stop being silent.** Every lock failure and every recovery is written to `MEMORY/OBSERVABILITY/memory-locks.jsonl` and to stderr, with a reason code: `holder-process-gone`, `holder-alive`, `unverifiable-holder-within-ttl`, `expired-unverifiable-holder`. An operator can now distinguish "recovered from a crash" from "nothing ever went wrong" from "still jammed".

## Tests

`test/tools/MemorySystem.test.ts`, 8 cases:

```
8 pass
0 fail
28 expect() calls
```

Separately verified with an independent probe. The dangerous direction here is not failing to recover a dead lock — it is breaking a live one, which would put two writers on the same note — so that case got equal weight:

```
✓ dead holder on this host → recovered      (holder-process-gone)
✓ live holder, fresh → refused              (holder-alive)
✓ corrupt lock, fresh → refused             (unverifiable-holder-within-ttl, fails safe)
✓ corrupt lock, aged past window → recovered (expired-unverifiable-holder)
✓ other-host holder, fresh → refused        (unverifiable)
✓ no lock → acquired
✓ release removes the lock file
```

## Note for review

A holder that is alive but has held the lock longer than `LOCK_STALE_MS` is still broken, on the reasoning that a five-minute append is itself a failure. That is a deliberate trade-off rather than an oversight, and it is the one case where this can interrupt a genuinely running writer. Worth a second opinion on the window.
