### PR TITLE
feat(conduit): add Build-insights button + POST endpoint; fix command to a home-relative path

### DIFF
--- a/LifeOS/install/LIFEOS/PULSE/Observability/src/app/conduit/page.tsx
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/src/app/conduit/page.tsx
@@ -75,6 +75,24 @@ export default function ConduitPage() {
   const [sources, setSources] = useState<SourcesReport | null>(null);
   const [insight, setInsight] = useState<Insight | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [building, setBuilding] = useState(false);
+  const [buildMsg, setBuildMsg] = useState<string | null>(null);
+
+  async function runBuildInsights() {
+    setBuilding(true);
+    setBuildMsg(null);
+    try {
+      const res = await fetch("/api/conduit/build", { method: "POST" });
+      const data = await res.json().catch(() => ({ ok: res.ok }));
+      setBuildMsg(data.ok ? "Insights rebuilt." : "Build failed — see server log.");
+      const fresh = await fetch("/api/conduit/insight").then((r) => r.json());
+      setInsight(fresh);
+    } catch (e) {
+      setBuildMsg("Build error: " + String(e));
+    } finally {
+      setBuilding(false);
+    }
+  }
 
   useEffect(() => {
     fetch("/api/conduit/today").then((r) => r.json()).then(setToday).catch((e) => setError(String(e)));
@@ -136,9 +154,21 @@ export default function ConduitPage() {
                   </div>
                 ) : (
                   !insight.available && (
-                    <div className="text-xs text-ink-3">
-                      The insight job runs on the hour. Run it now:{" "}
-                      <code className="text-ink-2 mono">bun Conduit/BuildInsight.ts</code>
+                    <div className="text-xs text-ink-3 space-y-2">
+                      <div>The insight job runs on the hour. Build it now:</div>
+                      <button
+                        type="button"
+                        onClick={runBuildInsights}
+                        disabled={building}
+                        className="px-3 py-1.5 rounded-md bg-white/[0.06] hover:bg-white/[0.1] text-ink-1 text-xs font-medium disabled:opacity-50 transition-colors"
+                      >
+                        {building ? "Building…" : "Build insights now"}
+                      </button>
+                      {buildMsg && <div className="text-ink-2">{buildMsg}</div>}
+                      <div>
+                        Or from a terminal:{" "}
+                        <code className="text-ink-2 mono">bun ~/.claude/LIFEOS/PULSE/Conduit/BuildInsight.ts</code>
+                      </div>
                     </div>
                   )
                 )}

--- a/LifeOS/install/LIFEOS/PULSE/modules/conduit.ts
+++ b/LifeOS/install/LIFEOS/PULSE/modules/conduit.ts
@@ -116,8 +116,29 @@ export function todayRecordPublic(): DailyRecord {
   return todayRecord()
 }
 
+/** Run BuildInsight.ts on demand (the "Build insights now" button). Spawns the
+ *  standalone script — same as the hourly launchd job — and returns its output. */
+async function buildInsightNow(): Promise<Response> {
+  const script = join(import.meta.dir, "..", "Conduit", "BuildInsight.ts")
+  try {
+    const proc = Bun.spawn(["bun", script], { stdout: "pipe", stderr: "pipe" })
+    const [out, err, code] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+    return Response.json(
+      { ok: code === 0, output: ((out || "") + (err || "")).slice(-1500) },
+      { status: code === 0 ? 200 : 500 },
+    )
+  } catch (e) {
+    return Response.json({ ok: false, output: String(e) }, { status: 500 })
+  }
+}
+
 export async function handleRequest(req: Request, pathname: string): Promise<Response | null> {
   const sub = pathname.replace(/^\/api\/conduit/, "") || "/"
+  if (sub === "/build" && req.method === "POST") return buildInsightNow()
   if (sub === "/" || sub === "/today") return Response.json(todayRecord())
   if (sub === "/recent") {
     const days = Math.max(1, Math.min(90, Number(new URL(req.url).searchParams.get("days")) || 7))


### PR DESCRIPTION
## What this adds

The Conduit page's empty state used to only tell you to run a bun command by hand (`bun Conduit/BuildInsight.ts`, which fails unless your cwd is `LIFEOS/PULSE/`). This adds a real **Build insights now** button and fixes the fallback command.

**Backend** (`modules/conduit.ts`): a new `POST /api/conduit/build` route runs `BuildInsight.ts` (the same script the hourly launchd job runs) and returns `{ ok, output }`. GET is not handled, so only the button's POST triggers it.

**Frontend** (`conduit/page.tsx`): the empty state now shows a **Build insights now** button that POSTs to the endpoint, shows a Building… state, reports the result, and refetches the insight. The terminal fallback command is corrected to a home-relative path: `bun ~/.claude/LIFEOS/PULSE/Conduit/BuildInsight.ts`.

## Verification (live)
- `bun build modules/conduit.ts` → OK; `bun run build` (Observability) → compiled, `/conduit` route emitted.
- `curl -X POST /api/conduit/build` → `{"ok":true,"output":"[]\n"}` (runs the script; `[]` because no events today).
- `curl /conduit` → 200; `GET /api/conduit/build` → 404 (POST-only).
- Visual button interaction not browser-verified (headless host, no Chrome) — logic compiles and the endpoint it calls is confirmed working.

## Files
- `LifeOS/install/LIFEOS/PULSE/modules/conduit.ts`
- `LifeOS/install/LIFEOS/PULSE/Observability/src/app/conduit/page.tsx`
