### PR TITLE
fix(pulse): map adapter models to inference levels that exist

### DIFF
--- a/LifeOS/install/LIFEOS/PULSE/Tools/AdapterCli.ts
+++ b/LifeOS/install/LIFEOS/PULSE/Tools/AdapterCli.ts
@@ -19,7 +19,15 @@ if (!manifest) {
   process.exit(1);
 }
 
-const result = await runAdapter(manifest, { force });
+// Top-level await: an escaping rejection would kill the process with a bare
+// stack and skip the index refresh below. Name the page and exit cleanly.
+let result;
+try {
+  result = await runAdapter(manifest, { force });
+} catch (err) {
+  console.error(`error: adapter "${manifest.id}" crashed: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`);
+  process.exit(1);
+}
 
 // Refresh _index.json so the Pulse v2 sidebar reflects the new state.
 const all = loadAllManifests();

--- a/LifeOS/install/LIFEOS/PULSE/Tools/RebuildAll.ts
+++ b/LifeOS/install/LIFEOS/PULSE/Tools/RebuildAll.ts
@@ -18,6 +18,7 @@ const results = await Promise.allSettled(manifests.map((m) => runAdapter(m, { fo
 const wallMs = Date.now() - start;
 
 const entries: IndexEntry[] = [];
+const crashes: string[] = [];
 let success = 0, cached = 0, failed = 0;
 console.log("\n┌─ page ─────────────────┬─ status ──────────┬─ cost USD ─┬─ latency ms ─┐");
 for (let i = 0; i < manifests.length; i++) {
@@ -42,15 +43,22 @@ for (let i = 0; i < manifests.length; i++) {
     });
     console.log(`│ ${m.id.padEnd(22)} │ ${a.status.padEnd(17)} │ ${a.costUSD.toFixed(4).padStart(10)} │ ${String(a.latencyMs).padStart(12)} │`);
   } else {
+    // runAdapter rejected instead of returning a result — a bug in the adapter
+    // itself, not a page-level build failure. Keep the reason: "unhandled" with
+    // no message told an operator nothing about which page broke or why.
     failed++;
+    const reason = r.reason instanceof Error ? (r.reason.stack ?? r.reason.message) : String(r.reason);
+    crashes.push(`${m.id}: ${reason}`);
     entries.push({
       id: m.id, title: m.title, kind: m.dataType.replace("PageSchema", "").toLowerCase(),
       lastBuildAt: "", hasError: true, costUSD: 0, provenance: "template",
     });
-    console.log(`│ ${m.id.padEnd(22)} │ ${"unhandled".padEnd(17)} │ ${"".padStart(10)} │ ${"".padStart(12)} │`);
+    console.log(`│ ${m.id.padEnd(22)} │ ${"crashed".padEnd(17)} │ ${"".padStart(10)} │ ${"".padStart(12)} │`);
   }
 }
 console.log("└────────────────────────┴───────────────────┴────────────┴──────────────┘");
+
+for (const c of crashes) console.error(`\ncrashed — ${c}`);
 
 writeIndex(entries);
 

--- a/LifeOS/install/LIFEOS/PULSE/adapters/AdapterRunner.ts
+++ b/LifeOS/install/LIFEOS/PULSE/adapters/AdapterRunner.ts
@@ -5,20 +5,14 @@ import { type Manifest, paiRoot, resolveSources } from "../lib/manifest-loader";
 import { hashFile, combineSourceHashes } from "../lib/cache";
 import { writePage, writeError, clearError, readMeta, type DataPlaneFile, PULSE_DATA_DIR } from "../lib/data-plane";
 import { getProvenance } from "../lib/frontmatter";
-import { inference, type InferenceLevel } from "../../TOOLS/Inference";
+import { inference } from "../../TOOLS/Inference";
+import { modelToLevel } from "./model-level";
 
 const HOME = process.env.HOME!;
 const OBSERVABILITY_DIR = resolve(HOME, ".claude", "LIFEOS", "MEMORY", "OBSERVABILITY");
 const RUNS_LOG = join(OBSERVABILITY_DIR, "adapter-runs.jsonl");
 
 const ADAPTER_TIMEOUT_MS = 120_000;
-
-function modelToLevel(model: string): InferenceLevel {
-  const m = model.toLowerCase();
-  if (m.includes("haiku")) return "fast";
-  if (m.includes("opus")) return "smart";
-  return "standard";
-}
 
 export interface AdapterResult {
   manifest: Manifest;
@@ -63,13 +57,24 @@ function buildSourceBundle(sources: string[]): string {
 
 async function callInference(systemPrompt: string, model: string, sourceText: string): Promise<{ ok: true; data: unknown; rawOutput: string; costUSD: number; latencyMs: number } | { ok: false; reason: "timeout" | "exec-failed" | "parse-failed"; message: string }> {
   const userPrompt = `--- SOURCE BUNDLE ---\n\n${sourceText}\n\n--- END SOURCE BUNDLE ---\n\nReturn ONLY a single JSON object. No prose, no markdown fence.`;
-  const result = await inference({
-    systemPrompt,
-    userPrompt,
-    level: modelToLevel(model),
-    expectJson: true,
-    timeout: ADAPTER_TIMEOUT_MS,
-  });
+  // inference() REJECTS on a bad request (an unknown level throws before any
+  // model runs). Left uncaught it escapes runAdapter, killing AdapterCli's
+  // top-level await and reducing a RebuildAll page to an unlabelled row. Catch
+  // it here so a config-shaped failure lands in the same structured result as
+  // every other failure: named page, real message, error written to the data
+  // plane, batch keeps going.
+  let result: Awaited<ReturnType<typeof inference>>;
+  try {
+    result = await inference({
+      systemPrompt,
+      userPrompt,
+      level: modelToLevel(model),
+      expectJson: true,
+      timeout: ADAPTER_TIMEOUT_MS,
+    });
+  } catch (err) {
+    return { ok: false, reason: "exec-failed", message: err instanceof Error ? err.message : String(err) };
+  }
   if (!result.success) {
     if ((result.error ?? "").includes("Timeout")) {
       return { ok: false, reason: "timeout", message: result.error ?? "timeout" };

--- a/LifeOS/install/LIFEOS/PULSE/adapters/model-level.ts
+++ b/LifeOS/install/LIFEOS/PULSE/adapters/model-level.ts
@@ -1,0 +1,62 @@
+/**
+ * ============================================================================
+ * MODEL → INFERENCE LEVEL — derived from models.ts, never hand-written
+ * ============================================================================
+ *
+ * A page manifest names a MODEL (`model = "haiku"`, or a pinned id like
+ * "claude-opus-4-8"); `Inference.ts` accepts a LEVEL. This module is the only
+ * bridge between the two, and it DERIVES the answer from `EFFORT_MODEL` in
+ * LIFEOS/TOOLS/models.ts — the single source of truth for level → tier —
+ * instead of restating level names locally.
+ *
+ * WHY DERIVED: this mapping used to hardcode "fast" / "standard" / "smart".
+ * Those names were removed from Inference.ts on 2026-06-10; nothing connected
+ * the two ends, so every level this function could produce was rejected by
+ * `normalizeLevel()` and 100% of adapter builds threw. Deriving the mapping
+ * removes the class of bug rather than the instance: a lineup change or a
+ * level rename in models.ts now propagates here for free, and the levels
+ * this module can emit are exactly the levels Inference.ts accepts.
+ */
+import { ALIAS, EFFORT_MODEL, type ClaudeTier, type EffortLevel } from "../../TOOLS/models";
+import type { InferenceLevel } from "../../TOOLS/Inference";
+
+/**
+ * Levels cheapest rung first. The reverse lookup walks this order, so under a
+ * lineup where two levels share a tier the CHEAPER level wins — a manifest
+ * never silently buys a more expensive rung than the model it named.
+ *
+ * This is the one ordering fact models.ts does not encode (EFFORT_MODEL is a
+ * map, not a ladder). Its agreement with EFFORT_MODEL is asserted by test, so
+ * a level added or renamed upstream fails loudly here.
+ */
+export const LEVELS_CHEAPEST_FIRST: readonly EffortLevel[] = ["low", "medium", "high", "max"];
+
+/**
+ * Level for a manifest naming a model outside the Claude lineup. `medium` is
+ * the same balanced default `Inference.ts` applies to an omitted level — an
+ * unrecognized model must not silently escalate spend.
+ */
+export const DEFAULT_LEVEL: InferenceLevel = "medium";
+
+/**
+ * Tier for a manifest `model` value — a tier alias ("opus") or a pinned id
+ * ("claude-opus-4-8"). Tier names come from models.ts, so a new tier is
+ * recognized without editing this file. Returns null for anything outside the
+ * Claude lineup (a cross-vendor pin, a typo, an empty manifest field).
+ */
+export function tierForModel(model: string): ClaudeTier | null {
+  const m = model.toLowerCase();
+  return (Object.keys(ALIAS) as ClaudeTier[]).find((tier) => m.includes(tier)) ?? null;
+}
+
+/**
+ * Resolve a manifest `model` to the inference level that runs that model.
+ * haiku → low, sonnet → medium, opus → high, fable → max under today's
+ * EFFORT_MODEL — asking for the level that resolves back to the named model is
+ * the only mapping under which a manifest's `model` field means what it says.
+ */
+export function modelToLevel(model: string): InferenceLevel {
+  const tier = tierForModel(model);
+  if (!tier) return DEFAULT_LEVEL;
+  return LEVELS_CHEAPEST_FIRST.find((level) => EFFORT_MODEL[level] === tier) ?? DEFAULT_LEVEL;
+}

--- a/LifeOS/install/LIFEOS/TOOLS/Inference.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/Inference.ts
@@ -44,6 +44,7 @@ import { spawn } from "child_process";
 import { appendFileSync, existsSync, mkdirSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
+import { modelForEffort, pinnedModelForEffort, EFFORT_MODEL, LEVEL_TO_HARNESS_EFFORT, type EffortLevel, type HarnessEffort } from './models';
 
 /**
  * Resolve the claude binary explicitly. launchd jobs run with a minimal PATH
@@ -57,10 +58,16 @@ export function resolveClaudeBin(): string {  // exported for algorithm.ts (PR #
   return existsSync(fallback) ? fallback : "claude";
 }
 
-/** The four run levels — mirrors models.ts EffortLevel. */
-export type InferenceLevel = 'low' | 'medium' | 'high' | 'max';
+/** The run levels — IS models.ts EffortLevel, not a copy of it. Declaring the
+ * names twice is what let the 2026-06-10 rename break callers silently: a
+ * consumer typed against a stale copy still type-checked. Aliasing binds this
+ * surface to the single source of truth, so a level renamed in models.ts
+ * breaks every stale call site at the type level instead of at runtime. */
+export type InferenceLevel = EffortLevel;
 
-const VALID_LEVELS: readonly InferenceLevel[] = ['low', 'medium', 'high', 'max'] as const;
+/** Derived from EFFORT_MODEL's keys — the runtime validator follows the same
+ * source of truth as the type, so the two can never disagree. */
+const VALID_LEVELS: readonly InferenceLevel[] = Object.keys(EFFORT_MODEL) as InferenceLevel[];
 
 /** Validate a level name. Throws on anything outside the four canonical
  * names — including the pre-2026-06-10 legacy names (fast/standard/smart),
@@ -69,7 +76,7 @@ const VALID_LEVELS: readonly InferenceLevel[] = ['low', 'medium', 'high', 'max']
 export function normalizeLevel(level: string | undefined): InferenceLevel {
   if (!level) return 'medium';
   if ((VALID_LEVELS as readonly string[]).includes(level)) return level as InferenceLevel;
-  throw new Error(`[Inference] unknown level '${level}' — use low | medium | high | max (legacy fast/standard/smart names were removed 2026-06-10)`);
+  throw new Error(`[Inference] unknown level '${level}' — use ${VALID_LEVELS.join(' | ')} (legacy fast/standard/smart names were removed 2026-06-10)`);
 }
 
 export interface InferenceOptions {
@@ -111,8 +118,6 @@ export interface InferenceResult {
    * MEMORY/OBSERVABILITY/model-verification.jsonl. */
   modelDowngraded?: boolean;
 }
-
-import { modelForEffort, pinnedModelForEffort, EFFORT_MODEL, LEVEL_TO_HARNESS_EFFORT, type EffortLevel, type HarnessEffort } from './models';
 
 // Level configurations — models resolve via models.ts EFFORT_MODEL (the single
 // edit point on a lineup change). No model names appear here. `effort` is the
@@ -490,10 +495,10 @@ async function main() {
       expectJson = true;
     } else if (args[i] === '--level' && args[i + 1]) {
       const requestedLevel = args[i + 1].toLowerCase();
-      if (['low', 'medium', 'high', 'max'].includes(requestedLevel)) {
+      if ((VALID_LEVELS as readonly string[]).includes(requestedLevel)) {
         level = requestedLevel as InferenceLevel;
       } else {
-        console.error(`Invalid level: ${args[i + 1]}. Use low, medium, high, or max. (Legacy fast/standard/smart were removed 2026-06-10.)`);
+        console.error(`Invalid level: ${args[i + 1]}. Use ${VALID_LEVELS.join(', ')}. (Legacy fast/standard/smart were removed 2026-06-10.)`);
         process.exit(1);
       }
       i++;

--- a/LifeOS/install/test/pulse/adapters/model-level.test.ts
+++ b/LifeOS/install/test/pulse/adapters/model-level.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Contract between a page manifest's `model` field and the level Inference.ts
+ * accepts. The regression this file exists for: the mapping returned
+ * "fast"/"standard"/"smart" long after those names were deleted from
+ * Inference.ts, so every level it could produce was rejected and 100% of
+ * adapter builds threw.
+ *
+ * No model runs here — normalizeLevel() validates before any subprocess is
+ * spawned, so the whole contract is checkable without spending a token.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  DEFAULT_LEVEL,
+  LEVELS_CHEAPEST_FIRST,
+  modelToLevel,
+  tierForModel,
+} from "../../../LIFEOS/PULSE/adapters/model-level";
+import { normalizeLevel } from "../../../LIFEOS/TOOLS/Inference";
+import { ALIAS, CURRENT, EFFORT_MODEL, type ClaudeTier } from "../../../LIFEOS/TOOLS/models";
+
+const TIERS = Object.keys(ALIAS) as ClaudeTier[];
+
+describe("modelToLevel — per model family", () => {
+  test("every tier alias resolves to the level that runs that tier", () => {
+    for (const tier of TIERS) {
+      expect(EFFORT_MODEL[modelToLevel(ALIAS[tier])]).toBe(tier);
+    }
+  });
+
+  test("every pinned model id resolves to the level that runs that tier", () => {
+    for (const tier of TIERS) {
+      expect(EFFORT_MODEL[modelToLevel(CURRENT[tier])]).toBe(tier);
+    }
+  });
+
+  test("cheap models stay on cheap rungs, expensive models on expensive rungs", () => {
+    // Ordering, not exact names: a lineup change may move a tier, but haiku
+    // must never outrank sonnet, nor sonnet outrank opus.
+    const rung = (model: string) => LEVELS_CHEAPEST_FIRST.indexOf(modelToLevel(model));
+    expect(rung("haiku")).toBeLessThan(rung("sonnet"));
+    expect(rung("sonnet")).toBeLessThan(rung("opus"));
+    expect(rung("opus")).toBeLessThan(rung("fable"));
+  });
+
+  test("model names are matched case-insensitively", () => {
+    expect(modelToLevel("HAIKU")).toBe(modelToLevel("haiku"));
+    expect(modelToLevel("Claude-Opus-4-8")).toBe(modelToLevel("claude-opus-4-8"));
+  });
+
+  test("a model outside the Claude lineup falls back without escalating spend", () => {
+    for (const unknown of ["", "gpt-5.6-sol", "z-ai/glm-5.2", "nonsense"]) {
+      expect(tierForModel(unknown)).toBeNull();
+      expect(modelToLevel(unknown)).toBe(DEFAULT_LEVEL);
+    }
+    expect(LEVELS_CHEAPEST_FIRST.indexOf(DEFAULT_LEVEL))
+      .toBeLessThan(LEVELS_CHEAPEST_FIRST.length - 1);
+  });
+});
+
+describe("drift detection — the mapping and the inference layer cannot diverge", () => {
+  test("every level the mapping can produce is accepted by Inference.normalizeLevel", () => {
+    // THE regression test. Fails against the pre-fix mapping, which produced
+    // "fast" / "standard" / "smart" — all three throw here.
+    const models = [...TIERS.map((t) => ALIAS[t]), ...TIERS.map((t) => CURRENT[t]), "unknown-model", ""];
+    for (const model of models) {
+      const level = modelToLevel(model);
+      expect(() => normalizeLevel(level)).not.toThrow();
+      expect(normalizeLevel(level)).toBe(level);
+    }
+  });
+
+  test("LEVELS_CHEAPEST_FIRST is exactly the level set in models.ts EFFORT_MODEL", () => {
+    // Guards the one ordering fact this module holds locally: add, remove, or
+    // rename a level upstream and this fails instead of the mapping silently
+    // falling back to DEFAULT_LEVEL for a whole tier.
+    expect([...LEVELS_CHEAPEST_FIRST].sort()).toEqual(Object.keys(EFFORT_MODEL).sort());
+  });
+
+  test("Anti: no legacy level name survives anywhere in the mapping's output", () => {
+    const legacy = ["fast", "standard", "smart"];
+    const produced = new Set(
+      [...TIERS.map((t) => ALIAS[t]), ...TIERS.map((t) => CURRENT[t]), "unknown"].map(modelToLevel),
+    );
+    for (const name of legacy) {
+      expect(produced.has(name as never)).toBe(false);
+      expect(() => normalizeLevel(name)).toThrow();
+    }
+  });
+});


### PR DESCRIPTION
## The problem

`AdapterRunner.ts`'s `modelToLevel()` could only return `"fast"`, `"smart"` or `"standard"`. Those names were removed from the inference layer on 2026-06-10. `Inference.ts` now validates against `low | medium | high | max` and throws on anything else:

```
[Inference] unknown level 'smart' — use low | medium | high | max
```

So every level the adapter could produce was rejected. Nothing caught it: `callInference` and `runAdapter` have no catch, `AdapterCli.ts` top-level-awaits `runAdapter` so the process dies, and `RebuildAll.ts` uses `Promise.allSettled`, printing each rejection as an unlabelled "unhandled" row. Only the cache-hit, no-sources and missing-prompt early returns avoid inference, so **100% of actual adapter builds failed**.

## Why it compiled

This is the part worth fixing properly. `Inference.ts` declared its own copy of the level names:

```ts
export type InferenceLevel = 'low' | 'medium' | 'high' | 'max';   // a copy
```

`models.ts` already had `EffortLevel` as the real source of truth. Two hand-maintained lists of the same names means a rename in one leaves the other stale and still type-checking — which is exactly what happened. The type mismatch didn't compile-error because the adapter was typed against a copy that agreed with itself.

## The fix

**Bind both ends to one source.**

```ts
export type InferenceLevel = EffortLevel;                              // alias, not a copy
const VALID_LEVELS: readonly InferenceLevel[] = Object.keys(EFFORT_MODEL) as InferenceLevel[];
```

The type now IS `models.ts`'s level type, and the runtime validator derives from `EFFORT_MODEL`'s keys. Rename a level in `models.ts` and every stale call site fails at the type level rather than at runtime. The error message and the CLI's own validation also read from `VALID_LEVELS` instead of repeating the literals a third and fourth time.

**Mapping**, extracted to `adapters/model-level.ts` and typed `InferenceLevel`:

| model family | level |
|---|---|
| haiku | `low` |
| sonnet | `medium` |
| opus | `high` |
| fable | `max` |
| anything else | `medium` |

Cheap models map to cheap tiers, and an unrecognised model gets a sane middle default rather than the most expensive one.

**Failures stop being unlabelled.** `callInference` catches a rejection and returns the same structured failure shape as every other error path, so one bad page reports as a named page with a real message and the batch keeps going.

## Tests

`test/pulse/adapters/model-level.test.ts`, 8 cases:

```
8 pass
0 fail
49 expect() calls
```

Separately verified that every level the mapping can emit is one the inference layer actually accepts, checked against `EFFORT_MODEL`'s real keys rather than a hardcoded list:

```
VALID_LEVELS (from EFFORT_MODEL): max, high, medium, low
✓ claude-haiku-4-5       → low
✓ claude-sonnet-5        → medium
✓ claude-opus-5          → high
✓ claude-fable-5         → max
✓ gpt-5                  → medium
✓ <empty>                → medium
✓ weird-unknown-model    → medium
```

No API calls are made by the tests or the check.
