### PR TITLE
feat(delegation): add Persist workflow for work that must outlive the session

### DIFF
--- a/LifeOS/install/skills/Delegation/SKILL.md
+++ b/LifeOS/install/skills/Delegation/SKILL.md
@@ -224,6 +224,12 @@ The tier delegation floors set a *minimum* fan-out. This gate sets the *ceiling*
 
 **Every inline brief and Workflow subagent prompt articulates the ideal state, not the procedure.** State WHAT a done result looks like (as testable outcomes), the CONSTRAINTS, and the TOOLS available — then trust the agent to find HOW. A brief that choreographs the agent's reasoning ("first search, then extract, then verify, then synthesize") is BPE-violating scaffolding: it caps a capable agent and rots as models improve. This is the highest-volume prompting surface in the system (subagent briefs are written constantly at runtime), so the discipline matters most here. Keep the four keep-classes — safety-gate, verified-gotcha, tool-contract, output-format-contract — and delete the choreography. Prefer stating the coverage OUTCOME over a hardcoded fan-out count ("trust a match only when 3+ independent sources align", not "spawn exactly 15 agents"). Full standard: `skills/Prompting/Standards.md` § Ideal-State Prompting.
 
+## Workflow Routing
+
+| Trigger | Workflow |
+|---------|----------|
+| "survive disconnect", "outlive the session", "run detached", "keep running after I log off", "long-running local process", "drive a TUI that has no API", "reattach later" | `Workflows/Persist.md` |
+
 ## Anti-Patterns (Don't Do These)
 
 - Don't delegate what Grep/Glob/Read can do in <2 seconds
@@ -240,6 +246,8 @@ The tier delegation floors set a *minimum* fan-out. This gate sets the *ceiling*
 - **3+ independent workstreams warrant delegation.** For 1-2 tasks, direct work is faster than team coordination overhead.
 - **Agent teams share a task list.** Use TaskCreate/TaskUpdate for coordination, not ad-hoc messages.
 - **Teams overkill for single-file tasks.** (Mar 2026 reflection: "one agent that can both read code and write JSX is better than three specialists who can't coordinate")
+- **Split-pane teammates are a setting, not a tool to build.** `teammateMode` accepts `in-process` (the default since v2.1.179), `auto`, `tmux`, `iterm2`. `auto` picks tmux when the leader is *already running inside tmux*, then iTerm2 with the `it2` CLI, then falls back to in-process — so a headless leader with no attached terminal gets in-process no matter what tmux is installed. Teammates inherit the lead's permission mode at spawn (including `--dangerously-skip-permissions`) and their prompts bubble up to the lead. Reach for `Workflows/Persist.md` only for what this does not cover: detached work that must outlive the session, non-Claude processes, and TUIs with no API.
+- **An agent started by typing `claude ...` into a terminal pane is a sibling process, not a teammate.** No subagent registry entry, no concurrency-cap accounting, screen text instead of a result object, and whatever permission flags its own invocation carried. That is the real cost of driving agents by keystroke, and it is why `Persist.md` is scoped to processes rather than agents.
 - **Forked subagents inherit the full main-thread conversation + share its prompt cache** (Anthropic CC v2.1.133+, enabled via `CLAUDE_CODE_FORK_SUBAGENT=1` env or agent frontmatter `context: fork`). Use forked subagents for **nuance-dependent work**: design variations, follow-on research, anything that depends on context the main thread already established. **DO NOT FORK for code review** — a forked reviewer defends its own code (R Amjad: "biased toward defending own code"). For convergence questions, run one fork + one non-fork in parallel and look at where they disagree.
 
 ## Examples

--- a/LifeOS/install/skills/Delegation/Workflows/Persist.md
+++ b/LifeOS/install/skills/Delegation/Workflows/Persist.md
@@ -1,0 +1,78 @@
+# Persist — work that must outlive the session
+
+Run something on **this** machine that survives the session ending, and stay able to inspect or steer it afterwards.
+
+## When this, and when not
+
+Delegation's other patterns end when the session does. Managed Agents survive disconnection but run in a cloud sandbox, so they cannot touch this host's filesystem, repo, or `.env`. Detached tmux is the remaining case: **local** work that must **outlive** the session.
+
+| Need | Use |
+|------|-----|
+| Parallel work inside this session | Agent teams / subagents (default) |
+| Outlives the session, cloud-acceptable | Managed Agents |
+| Outlives the session, must touch this host | **detached tmux** (this workflow) |
+| Watch teammates in split panes | `teammateMode: "tmux"` — built in, no tooling needed |
+| Long-running non-Claude process, or a TUI with no API | **detached tmux** (this workflow) |
+
+If a human is at a terminal and wants to see teammates working, that is `teammateMode` (`auto` picks tmux when the leader is already inside tmux, then iTerm2, then in-process). Do not rebuild it.
+
+## Ideal state
+
+The work runs detached under a name you chose, keeps running when the connection drops, can be reattached and read at any time, and tears down without touching anything else on the host.
+
+## The commands
+
+```bash
+# start detached — capture the session ID, do not rely on the name
+SID=$(tmux new-session -d -s build-api -P -F '#{session_id}' 'bun run build')
+
+# so a crashed pane leaves evidence instead of vanishing.
+# remain-on-exit is a WINDOW option: -w and a window target, per window.
+WID=$(tmux list-windows -t "$SID" -F '#{window_id}' | head -1)
+tmux set-option -w -t "$WID" remain-on-exit on
+
+# what is running
+tmux list-sessions -F '#{session_id} #{session_name} #{session_attached}'
+tmux list-panes -t "$SID" -F '#{pane_id} #{pane_pid} #{pane_dead} #{pane_current_command}'
+
+# read without attaching
+tmux capture-pane -p -t "$SID" -S -200
+
+# attach (from any later session, over any connection)
+tmux attach -t "$SID"      # detach again with the prefix key then d
+
+# tear down the exact thing you started
+tmux kill-session -t "$SID"
+```
+
+## Gotchas — every one of these was verified on tmux 3.6, not inferred
+
+- **`-t` prefix-matches, so name-targeting kills the wrong session.** Targets resolve exact → fnmatch → *unambiguous prefix*. With sessions `prod` and `production-work` present, `kill-session -t production` destroys `production-work` — no wildcard typed, no warning, exit 0. Capture `#{session_id}` at creation and target `$N`. Where a name is unavoidable, anchor it: `has-session -t '=prod'` matches only `prod`. Never use `kill-session -a` (it kills everything *except* the target). This bites hardest because the documented cleanup advice for orphaned team sessions is name-based.
+
+- **`send-keys` executes on an embedded newline — there is no "type without running".** `send-keys -l` writes bytes to the pty and LF *is* Enter, so text containing `\n` runs even when no Enter key is sent. Anything you did not author this turn — file contents, pane output, fetched pages, another agent's text — goes in as a paste, never as keys:
+  ```bash
+  tmux load-buffer -b tmp payload.txt
+  tmux paste-buffer -p -b tmp -t "$SID"   # -p = bracketed paste, lands in the input buffer
+  tmux delete-buffer -b tmp
+  ```
+  Belt and braces: reject `\r`/`\n` in text unless the caller explicitly asked to submit, since bracketed paste only helps if the receiving program honours it — readline does, a raw-mode TUI may not.
+
+- **Without `remain-on-exit on`, a finished pane disappears.** Default is `off`, so an exited pane is destroyed: `pane_dead` is never observable, the `pane-died`/`pane-exited` hooks never fire, and `capture-pane` on it errors. A crashed job leaves no trace it ever ran. Set it at creation or you cannot tell "finished" from "never started".
+
+- **`remain-on-exit` is a *window* option, and setting it session-scoped silently does nothing.** `tmux set-option -t "$SID" remain-on-exit on` returns success and has no effect — panes still vanish on exit. It needs `-w` against a window target, and it applies per window, so a window created later does not inherit it. With it set correctly you also get the exit status for free: `#{pane_dead}` → `1`, `#{pane_dead_status}` → the real exit code. Verified both ways; the silently-ineffective form is the easy mistake.
+
+- **`pane_current_command` resolves one level only.** A process started directly reports itself; the same process under a wrapper reports the wrapper — `bash run.sh` shows `bash` even while the real work runs. Treating "back to a shell" as "finished" is wrong from the first tick and stays wrong. Walk children from `#{pane_pid}`, or match an allowlist of expected commands.
+
+- **Never set `-g` hooks or options.** A global hook fires for sessions you did not create, and the obvious cleanup `set-hook -gu` removes the operator's own global hooks for that event too. Scope everything to `-t "$SID"`.
+
+- **Keep `pane_current_path` out of delimited `-F` templates.** It carries raw filesystem bytes and a directory name may contain your delimiter or a newline, silently producing extra fields or extra records. `#{q:...}` does not escape them and `#{b64:...}` does not exist in tmux 3.6 — it expands to empty. Query that field alone.
+
+- **Session IDs are stable per server, not forever.** `%N`/`@N`/`$N` are monotone and never recycled within a server process, but a server restart resets the counters. Do not persist an ID across a restart and assume it means the same thing.
+
+- **Sessions are memory-resident.** They survive disconnection and the leader exiting. They do not survive a reboot or the server being killed.
+
+- **An agent you start by typing `claude ...` into a pane is a sibling process, not a teammate.** It does not appear in the subagent registry, does not count against concurrency caps, returns screen text rather than a result object, and carries whatever permission flags its own invocation gave it. A teammate spawned by `teammateMode` inherits the lead's permission mode, and its prompts bubble up to the lead for approval. Reach for the built-in path unless you specifically need a process the CLI cannot spawn.
+
+## Verify before claiming it worked
+
+A detached start that failed exits silently. Confirm the session exists and the process is alive — `list-panes` showing `pane_dead=0` with the expected command — before reporting the work as running.


### PR DESCRIPTION
## What this adds

A `Persist` workflow in `Delegation` for the one case its other patterns don't reach: **local work that must outlive the session**. Agent teams and subagents end when the session does. Managed Agents survive disconnection but run in a cloud sandbox, so they can't touch this host's filesystem, repo, or `.env`. Detached tmux is what's left.

## Why it's this small

This started as a proposal for a full tmux cockpit skill — a wrapper plus five workflows, mirroring the macOS-only `CMUX` skill for Linux. A red team killed most of it before any code was written, and the two findings that mattered were:

- **Split-pane teammate visibility is already a setting, not something to build.** `teammateMode` accepts `in-process` (default since v2.1.179), `auto`, `tmux`, `iterm2`. `auto` selects tmux when the leader is already running inside tmux. Rebuilding boot-team/fleet/monitor would have duplicated a maintained backend.
- **Driving agents by keystroke puts them outside the control plane.** An agent started by typing `claude ...` into a pane is a sibling process — no subagent registry entry, no concurrency accounting, screen text instead of a result object, and whatever permission flags its own invocation carried. A `teammateMode` teammate inherits the lead's permission mode and its prompts bubble up to the lead. That asymmetry is now stated in the Gotchas, because it's the thing a reader most needs and nothing in the skill said it.

So the workflow is scoped to processes rather than agents: detached persistence, long-running non-Claude work, and TUIs with no API.

## The gotchas are measured, not inferred

Every one was reproduced against tmux 3.6:

| Gotcha | Evidence |
|---|---|
| `-t` resolves exact → fnmatch → **unambiguous prefix** | with `prod` and `production-work` present, `kill-session -t production` destroyed `production-work` — no wildcard, exit 0 |
| `send-keys -l` executes on an embedded newline | text containing `\n` ran with no Enter sent; the same bytes via `load-buffer` + `paste-buffer -p` did not |
| `remain-on-exit` is a **window** option | `set-option -t "$SID" remain-on-exit on` returns success and does nothing; panes still vanish. `-w` against a window target works and preserves `#{pane_dead_status}` |
| default `remain-on-exit off` destroys exited panes | exited pane absent from `list-panes`; `capture-pane` errors — a crashed job leaves no trace |
| `pane_current_command` resolves one level | `sleep 60` reports `sleep`; `bash wrap.sh` running the same thing reports `bash`, so "back to a shell" ≠ finished |
| `set-hook -gu` cleanup is destructive | removes the operator's own global hooks for that event alongside yours |
| `pane_current_path` can break `-F` templates | carries raw filesystem bytes, so a path may contain the delimiter or a newline; `#{q:}` doesn't escape them and `#{b64:}` doesn't exist in 3.6 |

The `remain-on-exit` one was found by running my own documented command sequence and watching step 5 fail — the first draft of this workflow had the silently-ineffective session-scoped form in it.

## Verification

The documented sequence was executed end to end after the fix:

```
session=$0 window=@0
  running: %0 dead=0 cmd=sleep
  after exit: %0 dead=1 status=7
teardown by ID ok
```

All probing ran on private `-L` sockets that were torn down; the default socket was never touched.

## Notes for review

- Delegation had no `## Workflow Routing` section, since its patterns aren't workflow-routed. I added one with a single row rather than restructuring the skill.
- Worth considering separately: the official troubleshooting advice for orphaned team sessions is `tmux kill-session -t <session-name>`, which is exactly the prefix-matching hazard above. A short session name there can kill a longer-named session the operator cares about.
