### PR TITLE
fix(conduit): schedule capture + insight via Pulse cron so Conduit works on Linux

### DIFF
--- a/LifeOS/install/LIFEOS/PULSE/PULSE.toml
+++ b/LifeOS/install/LIFEOS/PULSE/PULSE.toml
@@ -132,6 +132,30 @@ command = "bun run checks/airgradient-poll.ts"
 output = "log"
 enabled = true
 
+# ── Conduit (sensory capture) ──
+# Cross-platform scheduling via Pulse's own cron heartbeat — no OS-level daemon
+# (launchd/systemd) required, so Conduit works on Linux and macOS alike. These
+# replace the macOS-only launchd installers (Conduit/InstallConduit*.ts), which
+# never ran on Linux. capture is a cheap deterministic poll; the hourly insight
+# read uses the lowest inference rung (haiku, via Inference.ts — subscription
+# billing, resolves `claude` explicitly so Pulse's minimal PATH is a non-issue).
+
+[[job]]
+name = "conduit-capture"
+schedule = "*/2 * * * *"
+type = "script"
+command = "bun run Conduit/conduit.ts capture"
+output = "log"
+enabled = true
+
+[[job]]
+name = "conduit-insight"
+schedule = "0 * * * *"
+type = "script"
+command = "bun run Conduit/BuildInsight.ts"
+output = "log"
+enabled = true
+
 # NOTE: cost-tracker moved to LIFEOS/USER/CONFIG/PULSE.user.toml on 2026-05-03 —
 # scans {{PRINCIPAL_NAME}}-specific call-site fingerprint, doesn't belong in public template.
 


### PR DESCRIPTION
## Problem

Conduit's two scheduled jobs — the 120 s capture poll and the hourly insight read — are installed **only** via macOS `launchd` (`Conduit/InstallConduit.ts` and `InstallConduitInsight.ts`, which write to `~/Library/LaunchAgents` and call `launchctl`). On Linux there is no launchd, so neither job ever runs: nothing is captured, the hourly `BuildInsight.ts` never fires, and the Pulse **/conduit** page stays permanently empty. There was no non-macOS install path.

## Fix

Schedule Conduit through **Pulse's own cron heartbeat loop** instead of an OS-level daemon. Pulse already runs a cross-platform cron scheduler (`matchesCron`/`isDue` in `pulse.ts`), active on every platform Pulse runs on. Moving Conduit's two jobs there makes them work on **Linux and macOS alike**, with no launchd/systemd dependency:

```toml
[[job]]
name = "conduit-capture"
schedule = "*/2 * * * *"
type = "script"
command = "bun run Conduit/conduit.ts capture"
output = "log"
enabled = true

[[job]]
name = "conduit-insight"
schedule = "0 * * * *"
type = "script"
command = "bun run Conduit/BuildInsight.ts"
output = "log"
enabled = true
```

Jobs run with `cwd = PULSE/`, so the relative `Conduit/…` commands resolve, and Pulse's missing-script preflight already disables them cleanly on an install where the scripts aren't present.

### Why the insight job is safe under Pulse's minimal PATH

`BuildInsight.ts` uses the cheapest inference rung (haiku via `TOOLS/Inference.ts`), which resolves the `claude` binary **explicitly** (`Bun.which("claude")` → `~/.local/bin/claude` fallback). That's the same minimal-PATH problem the launchd insight installer solved by baking a PATH into the plist — so it's a non-issue here.

## Verified on Linux (headless)

- Pulse's cron loop fired `conduit-capture` on load → `captured 1 event(s)`, dispatched to log.
- `BuildInsight.ts` read the real events and wrote a content-type read (`Development 100%` with a narrative) — vs. the empty `[]` before.

## Scope / compatibility

- The macOS launchd installers are left in place for anyone who prefers standalone scheduling; this simply gives Conduit a working out-of-the-box path on every platform via Pulse.
- Single-file change to the public template `PULSE.toml`. No code changes.
