### PR TITLE
fix(tools): DeriveDenyHashes creates its output dir before writing (unblocks DerivedSync)

### DIFF
--- a/LifeOS/install/LIFEOS/TOOLS/DeriveDenyHashes.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/DeriveDenyHashes.ts
@@ -28,9 +28,9 @@
  * token, so filtering here keeps the scan precise. Tune ALLOWLIST/STOPWORDS with
  * --show-tokens.
  */
-import { readFileSync, writeFileSync, existsSync, appendFileSync, readdirSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, appendFileSync, readdirSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
 import { createHash, randomBytes } from "node:crypto";
 
 const HOME = process.env.HOME || homedir();
@@ -198,6 +198,7 @@ function main(): void {
     note: "Salted hashes of distinctive private tokens. No plaintext. Salt in .env (never ships).",
     hashes,
   };
+  mkdirSync(dirname(OUT_PATH), { recursive: true }); // self-create output dir (e.g. skills/_LIFEOS absent on a fresh/partial install)
   writeFileSync(OUT_PATH, JSON.stringify(payload, null, 0) + "\n");
   console.log(`[DeriveDenyHashes] wrote ${hashes.length} salted hashes -> ${OUT_PATH} (no plaintext)`);
 }


### PR DESCRIPTION
## Problem

`DeriveDenyHashes.ts` writes its output to `skills/_LIFEOS/DENY_HASHES.json` but never ensures that directory exists. On any install where `skills/_LIFEOS/` isn't present — a fresh clone, or an install where that private skill hasn't been laid down yet — the write throws:

```
ENOENT: no such file or directory, open '.../skills/_LIFEOS/DENY_HASHES.json'
    at main (LIFEOS/TOOLS/DeriveDenyHashes.ts:201)
```

Because `DerivedSync.ts` runs `DeriveDenyHashes` as one of its derivation steps, that unhandled throw **aborts the whole derived-sync pass**, leaving later derivatives stale.

## Fix

Create the output directory before writing — one line, standard tool hygiene:

```ts
mkdirSync(dirname(OUT_PATH), { recursive: true });
writeFileSync(OUT_PATH, ...);
```

(`mkdirSync` added to the `node:fs` import, `dirname` to `node:path`.) The output is salted hashes only — no plaintext — so self-creating the directory changes nothing about what's written, it just stops the crash.

## Verified

- Before: `bun run DerivedSync.ts` exits 1 at the `DeriveDenyHashes` step; downstream derivatives left unregenerated.
- After: `DeriveDenyHashes` self-creates its dir, writes the file, and `DerivedSync.ts` completes cleanly (exit 0, 0 drift).
