### PR TITLE
feat(pulse): schedule data-freshness daemons via Pulse cron so they run on Linux

### DIFF
--- a/LifeOS/install/LIFEOS/PULSE/PULSE.toml
+++ b/LifeOS/install/LIFEOS/PULSE/PULSE.toml
@@ -193,6 +193,39 @@ command = "bun run checks/life-morning-brief.ts"
 output = "voice"
 enabled = true
 
+# ── Data-freshness daemons ──
+# Ported from the macOS-only launchd installers
+# (TOOLS/Install{DerivedSync,UsageAggregator,WorkSweep}.ts) onto Pulse's own cron
+# heartbeat so they run on Linux too — the same cross-platform move as the Conduit
+# jobs above. All are bun scripts (cwd = PULSE/, hence the ../TOOLS paths); Pulse's
+# missing-script preflight + failure ceiling disable any that can't run on a given
+# install. NOTE for macOS: if you also bootstrapped the launchd agents, disable one
+# path to avoid double-scheduling (the jobs are idempotent, but still).
+
+[[job]]
+name = "derived-sync"
+schedule = "*/30 * * * *"
+type = "script"
+command = "bun run ../TOOLS/DerivedSync.ts"
+output = "log"
+enabled = true
+
+[[job]]
+name = "usage-aggregator"
+schedule = "30 3 * * *"
+type = "script"
+command = "bun run ../TOOLS/UsageAggregator.ts"
+output = "log"
+enabled = true
+
+[[job]]
+name = "work-sweep"
+schedule = "0 * * * *"
+type = "script"
+command = "bun run ../TOOLS/WorkSweep.ts"
+output = "log"
+enabled = true
+
 # ── Migration note (2026-05-03) ──
 # All personal/{{PRINCIPAL_NAME}}-specific jobs (cost-tracker, monitor-*, lifelog-digest,
 # apple-health-ingest, local-intelligence-refresh, update-pai-state, the


### PR DESCRIPTION
## Problem

Three data-freshness daemons ship with **macOS-only launchd installers** and no other install path:

| Daemon | Installer | What it keeps fresh |
|--------|-----------|---------------------|
| `DerivedSync` | `TOOLS/InstallDerivedSync.ts` | USER-tree derivatives (e.g. `PRINCIPAL_TELOS.md`) when their sources change |
| `UsageAggregator` | `TOOLS/InstallUsageAggregator.ts` | per-day Claude Code usage store that Pulse's cost views read |
| `WorkSweep` | `TOOLS/InstallWorkSweep.ts` | Work capture surfaces → GitHub issues |

All three use `~/Library/LaunchAgents` + `launchctl`, so on Linux they never run and their outputs silently drift. (Observed on a headless Linux box: `PRINCIPAL_TELOS.md` and 22 other derivatives were stale because DerivedSync had never fired.)

## Fix

Schedule them through **Pulse's built-in cron heartbeat** — the same cross-platform move as the Conduit jobs — by adding three `[[job]]` entries to the template `PULSE.toml`:

- `derived-sync` — every 30 min
- `usage-aggregator` — nightly 03:30
- `work-sweep` — hourly (self-disables cleanly until `USER/WORK/work_repo.json` is configured)

Commands run with `cwd = PULSE/`, hence the `../TOOLS/…` paths. Pulse's existing missing-script preflight and consecutive-failure ceiling disable any job that can't run on a given install, so this is safe by construction.

## Verified (headless Linux)

All three run cleanly via `--dry-run` and then live under Pulse's cron:

- `DerivedSync` — regenerated the drifted derivatives; re-run reports 0 drift.
- `UsageAggregator` — rolled up real per-day usage.
- `WorkSweep` — self-disabled cleanly (no work repo configured), exit 0.

## Note for macOS users

If you also bootstrapped the launchd agents, disable one of the two paths to avoid double-scheduling. The jobs are idempotent, but running each twice is wasteful. Longer term these launchd installers can be retired in favor of the Pulse-cron path.

_(Depends conceptually on #1652, which fixes a `DeriveDenyHashes` crash that would otherwise abort every `derived-sync` run.)_
