### PR TITLE
fix(security): close procfs credential read + wire MCP/ToolSearch into the injection scan

### DIFF
--- a/LifeOS/install/hooks/Safety.hook.ts
+++ b/LifeOS/install/hooks/Safety.hook.ts
@@ -296,7 +296,10 @@ function isAttackerWritableSource(toolName: string): boolean {
   // ToolSchemaLoaded hook event) is an upstream Claude Code feature request.
   if (toolName === "ToolSearch") return true;
   if (!toolName.startsWith("mcp__")) return false;
-  return /gmail|mail|drive|calendar|inbox/i.test(toolName);
+  // dropbox joins the list for the same reason drive is on it: file content
+  // pulled from a sync service is third-party-authored text that a stranger
+  // can put there (shared folders, file requests).
+  return /gmail|mail|drive|calendar|inbox|dropbox/i.test(toolName);
 }
 
 function annotate(input: { tool_name?: string; tool_response?: unknown }): void {

--- a/LifeOS/install/hooks/hooks.json
+++ b/LifeOS/install/hooks/hooks.json
@@ -62,17 +62,7 @@
         ]
       },
       {
-        "matcher": "WebFetch",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "$HOME/.claude/hooks/Safety.hook.ts",
-            "timeout": 5
-          }
-        ]
-      },
-      {
-        "matcher": "WebSearch",
+        "matcher": "WebFetch|WebSearch|ToolSearch|mcp__.*([Mm]ail|[Dd]rive|[Cc]alendar|[Ii]nbox|[Dd]ropbox)",
         "hooks": [
           {
             "type": "command",

--- a/LifeOS/install/hooks/lib/safety-classifier.ts
+++ b/LifeOS/install/hooks/lib/safety-classifier.ts
@@ -90,6 +90,13 @@ export const CREDENTIAL_PATHS: readonly RegExp[] = [
   /\.aws\/credentials\b/,
   /\.gnupg\/(private-keys|secring)/,
   /(^|\s|=|@|"|')([~\$\{\}\/A-Za-z0-9._-]+\/)?\.env(\.[a-zA-Z0-9_-]+)?(\s|$|"|')/,
+  // procfs reaches the same secrets the entries above guard: `environ` is the
+  // process environment (API keys, tokens), `mem`/`maps` are its address space.
+  // `cat` is in SEARCH_TOOLS, so without this `cat /proc/self/environ` takes the
+  // read-only-command allow at classifyCommand() and prints every secret in the
+  // environment without a prompt. Covers literal pids, `self`, and the shell
+  // forms that reach the same file (`$$`, `$PID`, `${PID}`).
+  /\/proc\/(?:self|\d+|\$\$|\$\{?[A-Za-z_][A-Za-z0-9_]*\}?)\/(?:environ|mem|maps|cmdline)\b/,
 ];
 
 export const READ_ONLY_COMMAND_PATTERNS: readonly RegExp[] = [


### PR DESCRIPTION
Two fixes to the same subsystem: both close a gap between what the security layer says it does and what it actually covers.

## `cat /proc/self/environ` auto-allowed

`CREDENTIAL_PATHS` guards `~/.ssh` keys, `~/.aws/credentials`, GPG keyrings and `.env` files. procfs reaches the same secrets by another route — `environ` is the process environment (API keys, tokens), `mem`/`maps` are its address space.

Because `cat` is in `SEARCH_TOOLS`, `classifyCommand()` reached the read-only-command allow branch and returned `allow`, printing the whole environment with no prompt. The credential check runs *before* that branch, so a procfs entry in `CREDENTIAL_PATHS` closes it cleanly — these reads now return `neutral` and defer to the native permission prompt.

Covers literal pids, `self`, and the shell forms (`$$`, `$PID`, `${PID}`) that reach the same file.

**Verified** — 16 cases through the real `classifyCommand()`:
- now `neutral`: `/proc/self/environ`, `/proc/1234/environ`, `/proc/$$/environ`, `/proc/${PID}/environ`, `/proc/self/mem`, `/proc/self/cmdline`, `/proc/self/maps`, `grep -a TOKEN /proc/self/environ`
- still `allow`: `/proc/cpuinfo`, `/proc/meminfo`, `/proc/loadavg`, `/proc/sys/vm/swappiness`, `ls /proc`, `cat README.md`, `rg TODO src/`

No regression on ordinary procfs reads.

## MCP and ToolSearch results were never injection-scanned

`Safety.hook.ts` documents the intended wiring in `isAttackerWritableSource`:

> The settings.json PostToolUse matcher only routes WebFetch/WebSearch + the qualifying mcp__ names here; this gate is the defensive in-code backstop so a broad future matcher can't silently widen it.

The matcher only ever carried the WebFetch/WebSearch half. The `ToolSearch` and mcp mail/drive/calendar branches of that predicate were unreachable, so third-party-authored text arriving over those tools never got the data-not-instructions framing or the injection-shape scan.

Merges the two matcher entries into one alternation covering all four classes. The in-code gate still does the precise filtering, so unrelated MCP servers cost one neutral passthrough.

Also adds `dropbox` to the gate: file content pulled from a sync service is attacker-writable for the same reason `drive` already is — shared folders and file requests let a stranger put text there.

**Verified** — matcher compiled and asserted against real tool names. Routes `WebFetch`, `WebSearch`, `ToolSearch`, `mcp__claude_ai_Gmail__*`, `mcp__claude_ai_Google_Drive__*`, `mcp__claude_ai_Google_Calendar__*`, `mcp__claude_ai_Dropbox__*`. Skips `Bash`, `Read`, `Edit`, `Agent`, `Skill`, `mcp__claude_ai_Indeed__*`, `mcp__claude_ai_Kiwi_com__*`. Matcher and in-code gate agree on every case tested.
