### PR TITLE
docs: correct subagent nesting default (reversed in 2.1.219) and stale Algorithm LATEST pointer

### DIFF
--- a/LifeOS/install/LIFEOS/DOCUMENTATION/Algorithm/AlgorithmSystem.md
+++ b/LifeOS/install/LIFEOS/DOCUMENTATION/Algorithm/AlgorithmSystem.md
@@ -34,7 +34,7 @@ Spend follows the work, discovered from the task and its evidence gates — neve
 |---|---|---|
 | System prompt | Constitution: modes, output contracts, security, verification doctrine | `LIFEOS/LIFEOS_SYSTEM_PROMPT.md` |
 | Dynamic context | CLAUDE.md routing table, @-imports, hook-injected session context | `DOCUMENTATION/Config/ConfigSystem.md` |
-| The Algorithm file | The done-claims — what a completed run must satisfy | `ALGORITHM/v${LATEST}.md` (resolve `ALGORITHM/LATEST`; currently 8.1.0) |
+| The Algorithm file | The done-claims — what a completed run must satisfy | `ALGORITHM/v${LATEST}.md` (resolve `ALGORITHM/LATEST`; currently 8.4.0) |
 | ISA | The artifact: done as falsifiable claims | `DOCUMENTATION/Isa/IsaSystem.md` + `IsaFormat.md` |
 | Hooks | Mechanical enforcement (the teeth that don't decay) | `DOCUMENTATION/Hooks/HookSystem.md` |
 | Pulse | The instruments | `DOCUMENTATION/Pulse/PulseSystem.md` |

--- a/LifeOS/install/LIFEOS/DOCUMENTATION/Delegation/DelegationSystem.md
+++ b/LifeOS/install/LIFEOS/DOCUMENTATION/Delegation/DelegationSystem.md
@@ -64,7 +64,10 @@ Agent({ prompt: "System design / distributed systems. Design the distributed cac
 Use the Agents skill to compose task-specific agents with unique traits, voices, and expertise:
 - Use a SINGLE message with MULTIPLE Agent tool calls
 - Each agent gets FULL CONTEXT and DETAILED INSTRUCTIONS via ComposeAgent prompt
-- Launch as many as needed (no artificial limit)
+- Launch as many as the work needs, but design around the runtime ceilings (Claude Code 2.1.219+):
+  - **Concurrency caps at 20 running subagents** — raise with `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS`. The changelog states the cap but not what happens to spawns above it, so don't build a fan-out that assumes either queueing or refusal: keep concurrent dispatches at or under the cap, or raise it deliberately.
+  - **200 subagent spawns per session**, and **200 WebSearch calls per session** — `CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION` and `CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION`. Long multi-fan-out sessions can reach these; a denied spawn late in a session usually means the session budget, not the concurrency cap.
+  - **Subagents nest to depth 3 by default.** A subagent may spawn its own subagents two levels further down. Set `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH=1` to flatten delegation back to a single tier. (This default has moved twice: 5 until 2.1.217, 1 in 2.1.217–2.1.218, 3 from 2.1.219 — check the installed version before relying on a specific depth.)
 - **ALWAYS launch a spotcheck agent after parallel work completes**
 
 **Agent routing by task type:**


### PR DESCRIPTION
Two stale-fact corrections in `DOCUMENTATION/`. No behaviour change.

## Subagent nesting default

The default has moved twice in three releases — 5 until 2.1.217, 1 in 2.1.217, 3 from 2.1.219 — and the guidance still said subagents cannot spawn subagents, steering away from a pattern the platform now enables by default. Records the current depth-3 default with `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH=1` to flatten it, plus the version history so the next move is easy to spot.

Also adds the two per-session ceilings (200 subagent spawns, 200 WebSearch calls) that a long fan-out session can actually reach.

Per your note on #1569, the concurrency-cap wording stays neutral on what happens to over-cap spawns — the changelog states the cap but not whether they queue or are refused.

## Algorithm version pointer

The row that teaches how to resolve the Algorithm version named 8.1.0 while `ALGORITHM/LATEST` reads 8.4.0. Line 26 of the same file was already correct, so this was a single missed edit rather than systemic lag.

---

Two notes so you can close this fast if it is already handled:

- #1569 is already ported, so the delegation half may be redundant. The genuinely new part is the **depth-3 correction** — #1569 covered the concurrency cap and nested-spawn-default-off, which was accurate for 2.1.217 but was reversed in 2.1.219.
- You mentioned `DelegationSystem.md` is retired to history-only status. This edit is offered on the same reasoning you gave there — a known-false claim shouldn't ride under a RETIRED banner. If the retirement means you'd rather not touch it at all, closing is fine.
