### PR TITLE
feat(tmux): add TMUX agent-cockpit skill — CMUX parity on Linux and any SSH host

### DIFF
--- a/LifeOS/install/skills/TMUX/DESIGN.md
+++ b/LifeOS/install/skills/TMUX/DESIGN.md
@@ -1,0 +1,63 @@
+# TMUX — design and CMUX parity
+
+## Verdict
+
+`CMUX` gives LifeOS a scriptable agent cockpit on macOS. It cannot run anywhere else, and its own SKILL.md says so: *"No Linux/WSL — that path is tmux."* This skill is that path. tmux is not a downgrade substitute; it wins on most axes and loses on two, both visual.
+
+The object model maps cleanly. CMUX is `window ⊃ workspace ⊃ pane ⊃ surface`; tmux is `server ⊃ session ⊃ window ⊃ pane`. Throughout this skill: **a CMUX workspace is a tmux session** (one per agent team), **a CMUX surface is a tmux pane**.
+
+## Parity matrix
+
+| # | CMUX capability | CMUX mechanism | TMUX mechanism | Parity |
+|---|---|---|---|---|
+| 1 | `ping` — up + version | auto-launch GUI app, socket handshake | `tmux -V` + `list-sessions` exit code | **full, simpler** |
+| 2 | `send --enter` | `send` + `send-key Enter` | `send-keys -l` + `Enter`, newline-refusing | **full, safer** |
+| 3 | `read --lines N` | `read-screen` | `capture-pane -p -J -S -`, last N | **full** |
+| 4 | `boot-team --tiers` | new-workspace + splits + rename-tab | `new-session` + lead-splits + `main-vertical` + `select-pane -T` | **full** |
+| 5 | `race --agents N` | N surfaces, one command | N panes, one command, `race-N` titles | **full** |
+| 6 | `fleet --grid RxC` | grid of surfaces | explicit row/column splits, geometry-verified | **full** |
+| 7 | `mini-fleet` | SSH pane per host from USER config | identical, config under `SKILLS/TMUX/fleet.json` | **full** |
+| 8 | `monitor` | poll `surface-health` + screen regex | poll `list-panes -F` + layered signals | **full, better** |
+| 9 | `list` / `tree` | `tree --all`, regex-scraped refs | `list-panes -a -F`, real fields | **full, better** |
+| 10 | `flash` | GUI pulse (`trigger-flash`) | `display-message` + bell + transient border | **degraded** |
+| 11 | `voice` | POST `/notify` | identical | **full** |
+| 12 | Flat comms, any agent → any agent | `send` to any surface | `send` to any pane ID | **full** |
+| 13 | Per-team colour identity | cmux themes / `workspace-action` | session-scoped border + status styling | **partial** |
+| 14 | In-app browser pane | `new-pane --type browser --url` | none | **absent** |
+| 15 | Reusable boot recipes | the command is the recipe | identical | **full** |
+| 16 | Teardown | `close-surface` | `kill --target` by ID, generation-checked | **full, safer** |
+
+Thirteen full, two degraded, one absent.
+
+## Where tmux is better, and why it matters
+
+**Structured output instead of regex archaeology.** `cmux.ts` carries `extractFirstRef`/`extractRefs`, ~30 lines of regex trying to recover object references from human-readable stdout, with a UUID fallback when that fails. tmux `-F` templates return exactly the fields requested. The failure mode where a ref silently comes back `undefined` and a recipe proceeds against nothing does not exist here.
+
+**Real done-detection.** CMUX's `classifyScreen()` matches prompt characters and the words "done" or "complete" against screen text. That is genuinely all cmux exposes. tmux gives `#{pane_dead}` and `#{pane_dead_status}` — the process exited, and its actual exit code. A crashed agent is distinguishable from a finished one, which CMUX cannot do at all.
+
+**Persistence across disconnection.** A GUI multiplexer's sessions die with the app. tmux sessions are owned by a server that outlives clients, so an agent team survives SSH dropping, the leader exiting, and the operator going home. On a remote host this is the single most valuable property, and it has no CMUX equivalent.
+
+**No auth wall.** CMUX's socket is default-deny and its own docs call this "the #1 gotcha" — driving it needs either a socket password in the environment or the orchestrator running inside a cmux surface. tmux's socket is uid-scoped filesystem permissions. Nothing to configure, nothing to leak.
+
+## Where tmux is worse
+
+**No browser surface (#14).** CMUX can place a live browser pane beside an agent so the agent edits and the page updates next to it. tmux is a terminal multiplexer; there is no such object. Not a gap that can be closed.
+
+**Attention is text (#10, #13).** CMUX flashes a workspace and themes it by colour. tmux offers `display-message`, the terminal bell, and border/status styling. All of it requires an attached client to see, and the operator is usually detached — which is precisely the situation this skill is built for. `flash` is therefore honest about being a weak signal, and `monitor`'s voice notification through Pulse is the real attention mechanism.
+
+## Safety design
+
+Six behaviours were measured on tmux 3.6 during two adversarial reviews and shaped the wrapper. They are documented in SKILL.md § Gotchas; the short form:
+
+1. Newlines execute regardless of send mechanism, so the payload is validated rather than the transport trusted.
+2. `-t` prefix-matches, so destruction is ID-only with a generation token.
+3. `remain-on-exit` is a window option whose session-scoped form silently no-ops.
+4. `capture-pane -S -N` is an offset, not a count.
+5. `select-layout tiled` ignores the requested grid.
+6. Global (`-g`) options and hooks reach sessions this tool never created, and their cleanup damages the operator's own configuration.
+
+## What this deliberately does not do
+
+**It does not replace the built-in split-pane teammates.** Claude Code's `teammateMode` accepts `in-process`, `auto`, `tmux` and `iterm2`, and `auto` selects tmux when the leader is already running inside tmux. When a human is sitting at a terminal driving a team, that is the right path: teammates inherit the lead's permission mode, their prompts bubble up for approval, and no keystrokes are involved. This skill is for the case that setting cannot serve — a leader with no attached terminal, work that must outlive the connection, non-Claude processes, and TUIs with no API.
+
+**It does not pretend keystroke-spawned agents are teammates.** An agent started by typing into a pane is a sibling process outside the session's control plane. SKILL.md says so where a reader will see it.

--- a/LifeOS/install/skills/TMUX/SKILL.md
+++ b/LifeOS/install/skills/TMUX/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: TMUX
+version: 1.0.0
+description: "Drives tmux as an agent cockpit — boot, race, monitor and steer visible agent teams on Linux, macOS or any SSH-reachable host, and keep them running after you disconnect. USE WHEN tmux, agent cockpit, boot an agent team, orchestrate agents, three-tier orchestration, agent race, needle-in-haystack hotfix, agent fleet, 2x2 fleet, watch/monitor my agents, send a prompt to a running agent, multiplexer, terminal cockpit, orchestrator lead worker, detach, reattach, survive disconnect, keep running after I log off, drive a TUI that has no API. NOT FOR one-shot in-harness subagents with no terminal to watch (use Delegation), split-pane teammates when a human is at a terminal (that is the built-in `teammateMode` setting, not a skill), the Pulse dashboard itself (use Pulse), browser deploy-verification (use Interceptor), or macOS GUI cockpit work (use CMUX)."
+effort: medium
+---
+
+# TMUX
+
+An agent you can't see is an agent you can't improve — and on a headless box, tmux is the only cockpit there is. One command boots a named team of agents you can watch, prompt, and steer, and unlike a GUI multiplexer the team **survives your connection dropping**.
+
+Everything routes through one wrapper: `bun ~/.claude/skills/TMUX/Tools/Tmux.ts <subcommand>`. No socket password, no GUI, no app to launch. tmux starts its own server on demand.
+
+This is the Linux/SSH counterpart to `CMUX`, which is macOS-only. Same subcommands, same recipes, different substrate. See `DESIGN.md` for the full parity matrix including the two things tmux cannot do.
+
+## Workflow Routing
+
+| Trigger | Workflow |
+|---------|----------|
+| "boot a team", "3-tier team", "orchestrator/lead/workers" | `Workflows/BootTeam.md` |
+| "race agents", "hotfix race", "throw N agents at this", "needle in a haystack" | `Workflows/AgentRace.md` |
+| "fleet", "2x2 fleet", "named teams", "the remote fleet", "mini-fleet" | `Workflows/Fleet.md` |
+| "watch/monitor my agents", "tell me when they're done" | `Workflows/Monitor.md` |
+| "detach", "reattach", "survive disconnect", "keep running after I log off" | `Workflows/Persist.md` |
+
+## Quick Reference
+
+```bash
+T=~/.claude/skills/TMUX/Tools/Tmux.ts
+bun $T doctor                                            # environment + safety self-check
+bun $T ping                                              # version + server reachability
+bun $T boot-team --name debug --tiers orchestrator,lead,worker,worker
+bun $T race --feature login-500 --agents 4               # first-to-solve wins
+bun $T fleet --name alpha --grid 2x2 --cmds "claude;codex;claude;bun test --watch"
+bun $T mini-fleet                                        # SSH panes from USER fleet.json
+bun $T send --target %3 "run the tests" --enter
+bun $T read --target %3 --lines 40
+bun $T monitor --session '$1'                            # classify + voice on transition
+bun $T kill --target '$1'                                # ID-targeted teardown
+```
+
+**The loop:** `send` (type) → `--enter` (submit) → `read` (confirm it ran) → `kill` (tear down). A `send` without `--enter` that claims the agent is working is a false done-claim; round-trip through `read` before believing anything.
+
+**What stays underneath:** Pulse (`localhost:31337`) is still the dashboard, voice still fires via `/notify`, the Algorithm, memory and model routing are untouched. This replaces the terminal-watching layer only.
+
+## Gotchas
+
+The highest-value section here. Every one was measured on tmux 3.6, not inferred.
+
+- **A newline in the text executes it, and no send mechanism prevents that.** `send-keys -l`, `paste-buffer`, `paste-buffer -p`, `paste-buffer -r` and `paste-buffer -p -r` all ran the payload in testing. `man tmux`: LF in a buffer is replaced with a separator (CR by default) on output, and `-p` inserts bracket codes only *if the application requested bracketed paste mode* — which no `#{...}` format exposes, so you cannot detect whether it did anything. **The control is the payload, not the transport:** the wrapper refuses text containing `\r`/`\n` unless `--enter` was explicitly passed. Never send agent output, file contents, or fetched pages into a pane without stripping newlines first.
+
+- **`-t` prefix-matches, so name-targeting kills the wrong thing.** Targets resolve exact → fnmatch → *unambiguous prefix*. With sessions `prod` and `production-work`, `kill-session -t production` destroys `production-work` with exit 0 and no warning. The wrapper only destroys by ID (`$N`/`@N`/`%N`) captured at creation, and `=`-anchors any name it must use. `kill-session -a` (kill all *except* the target) is refused outright.
+
+- **IDs are scoped to a server incarnation, not forever.** Kill the server and the next session is `$0` again, so a stored ID silently retargets something else. The wrapper stamps every ID with a generation token from `#{pid}` + `#{start_time}` and refuses to act when it no longer matches.
+
+- **`remain-on-exit` is a WINDOW option; the session-scoped form silently no-ops.** `set-option -t "$SID" remain-on-exit on` returns success and does nothing. Without it set correctly with `-w`, an exited pane is destroyed: no `pane_dead`, no exit status, hooks never fire, and `capture-pane` errors. A crashed agent leaves no evidence it ever ran.
+
+- **`capture-pane -S -N` is a scrollback start offset, not a line count.** On a 24-row pane, `-S -10` returns 34 lines. Use `-S -` and take the last N.
+
+- **`select-layout tiled` ignores the grid you asked for.** It computes its own near-square shape from the pane count: `1x5` and `5x1` both produce 3 rows × 2 columns. `fleet --grid RxC` builds rows and columns explicitly and verifies the geometry, rather than trusting `tiled`.
+
+- **Naive successive splits halve exponentially** and fail with `no space for new pane` around seven panes. Split the lead pane each time and re-apply `main-vertical`. Also pass explicit `-x`/`-y` to `new-session -d`, or you get an 80×24 window that fails past four panes.
+
+- **Pane titles are invisible until you turn the border on.** `pane-border-status` defaults to `off`, so role titles render nowhere. `pane_title` also defaults to the machine hostname rather than empty, so raw topology output can carry a hostname — set titles explicitly and don't paste raw dumps anywhere public.
+
+- **`pane_current_command` resolves one level only.** A process under a wrapper reports the wrapper: `bash run.sh` shows `bash` while the real work runs, so "back to a shell" never means "finished". `monitor` layers its signals and labels the weak ones as low-confidence in its JSON.
+
+- **Never set anything with `-g`.** A global hook fires for sessions you did not create, and `set-hook -gu` cleanup strips the operator's own global hooks for that event. Everything is scoped to the session this tool created.
+
+- **An agent you start by typing `claude ...` into a pane is a sibling process, not a teammate.** It does not appear in the subagent registry, does not count against concurrency caps, returns screen text rather than a result object, and carries whatever permission flags its own invocation gave it. A teammate spawned by the built-in `teammateMode` inherits the lead's permission mode and its prompts bubble up for approval. Reach for the built-in path when a human is at a terminal; reach for this skill when nobody is.
+
+- **Sessions are memory-resident.** They survive disconnection, the leader exiting, and SSH dropping. They do not survive a reboot or the server being killed.
+
+## What this cannot do
+
+Stated plainly so nobody expects parity that isn't there:
+
+- **No in-app browser pane.** CMUX can put a live browser beside an agent. tmux has no such surface. Use `Interceptor` in a separate flow.
+- **Attention and identity are text, not chrome.** `flash` is `display-message` plus the terminal bell plus a transient border colour. There is no GUI pulse, and none of it is visible to someone who is currently detached.
+
+Everything else in CMUX has a working equivalent here, plus three things CMUX cannot do: detach/reattach persistence, real exit-status capture, and structured topology without regex-scraping stdout.
+
+## Examples
+
+**Boot a debugging team and drive the lead:**
+```
+User: "boot a tmux team to chase the flaky test"
+→ bun $T boot-team --name flaky --tiers orchestrator,lead,worker,worker
+→ bun $T send --target %2 "find why auth.test.ts flakes; delegate repro to a worker" --enter
+→ bun $T monitor --session '$1'
+```
+
+**Race a production hotfix:**
+```
+User: "prod login is 500ing — race it"
+→ bun $T race --feature login-500 --agents 4
+→ (four agents attack the same repo; first with a root cause wins)
+→ bun $T read --target %7 ; bun $T kill --target <losers>
+```
+
+**Start something that outlives the session:**
+```
+User: "run the migration and let it finish after I log off"
+→ bun $T boot-team --name migration --tiers runner
+→ bun $T send --target %1 "bun run migrate:prod" --enter
+→ disconnect; reattach later with tmux attach -t '$N'
+```

--- a/LifeOS/install/skills/TMUX/Tools/Tmux.help.md
+++ b/LifeOS/install/skills/TMUX/Tools/Tmux.help.md
@@ -1,0 +1,320 @@
+# Tmux.ts — reference
+
+JSON-in / JSON-out wrapper that drives tmux as an agent cockpit. Every subcommand prints **exactly one JSON object** to stdout and exits `0` when `ok` is `true`, non-zero otherwise. `monitor` without `--once` prints one JSON object per poll pass. Errors are always structured objects with an `error` string and a machine-readable `code`; a stack trace never reaches stdout.
+
+```bash
+T=~/.claude/skills/TMUX/Tools/Tmux.ts
+bun $T <subcommand> [flags]
+```
+
+Every tmux call is made with `Bun.spawn` and an argv array. There is no shell anywhere in this tool, so no payload is ever interpolated into a command string.
+
+## Global flags
+
+| Flag | Meaning |
+|---|---|
+| `--socket <name>` | Talk to a private server via `tmux -L <name>` instead of the default socket. Also settable as `TMUX_SKILL_SOCKET`. Must match `^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$`. |
+| `--help`, `-h` | Usage text (plain text, not JSON). |
+
+**State file.** Sessions this tool creates are recorded at `~/.claude/LIFEOS/USER/CUSTOMIZATIONS/SKILLS/TMUX/state.json` (override with `TMUX_SKILL_STATE`). `kill` consults it, so a teardown can only reach objects this tool created. The file is an optimisation for safety, not for correctness: if it cannot be written, read-only subcommands still succeed and `kill` simply refuses more often.
+
+## Targeting rules
+
+`--target` and `--session` accept **only tmux object IDs**: `$N` (session), `@N` (window), `%N` (pane). Names are refused with `code: "not-an-id"`.
+
+This is not pedantry. `tmux -t` resolves a target exact → fnmatch → **unambiguous prefix**. With sessions `prod` and `production-work` present, `kill-session -t production` destroys `production-work`, exits `0`, and prints no warning. Where a name is unavoidable internally (the duplicate-name check), it is anchored as `=name`, which defeats prefix resolution.
+
+Get IDs from `list` / `tree`, or from the object each creating subcommand returns.
+
+## Subcommands
+
+### `ping`
+
+Server reachability and version.
+
+```json
+{"ok":true,"version":"tmux 3.6","socket":"default","serverRunning":true,
+ "sessions":1,"generation":"3265593:1785086482","nested":false}
+```
+
+`ok:true` with `serverRunning:false` is a normal answer, not a failure — tmux is installed and no server is up. `start-server` is deliberately not used to test reachability: it does not leave a server running when there are no sessions, because it exits as soon as the invoking command returns. Reachability is the exit code of `list-sessions`; the version is `tmux -V`.
+
+### `send --target <id> "<text>" [--enter]`
+
+Types literal text into a pane. A session or window ID resolves to its active pane.
+
+| Flag | Meaning |
+|---|---|
+| `--target <id>` | Required. `%N` preferred; `$N`/`@N` resolve to the active pane. |
+| `--enter` | Press Enter after the text, and **consent to newlines in the payload**. |
+
+```json
+{"ok":true,"target":"%1","bytes":20,"entered":true}
+```
+
+**The newline rule.** `send` refuses text containing `\r` or `\n` unless `--enter` was explicitly passed (`code: "multiline-refused"`, exit 1). This is the tool's single most important control, because **no transport prevents a newline from executing**. Measured on tmux 3.6 against a ready bash pane, all of `send-keys -l`, `paste-buffer`, `paste-buffer -p`, `paste-buffer -r` and `paste-buffer -p -r` ran the payload. `man tmux` explains why: on output, LF in a buffer is replaced with a separator (CR by default), and `-p` inserts bracketed-paste codes only *if the application requested bracketed paste mode* — a state no `#{...}` format variable exposes, so you cannot even detect whether it applied. **The control is therefore the payload, not the transport.** Never treat `paste-buffer` as a safe way to move untrusted text into a pane.
+
+Practical consequence: before sending agent output, file contents, or a fetched page into a pane, strip newlines yourself. Passing `--enter` on multi-line text is allowed and will execute every line — that is what the flag means.
+
+Two smaller guards:
+- Keys are always sent with `send-keys -l` (literal). Without `-l`, a payload word like `Enter` or `C-c` is interpreted as a keypress.
+- `--` terminates flag parsing, so a payload starting with `-` is not read as an option. This is required, not decorative: `send-keys -l "-x-plain"` fails with `unknown flag -x`.
+- If the wrapper is running inside the pane it is targeting (`$TMUX_PANE` matches on the same server), it refuses with `code: "self-target"`.
+
+### `read --target <id> [--lines N]`
+
+Captures pane text. Default `--lines 80`.
+
+```json
+{"ok":true,"target":"%1","requestedLines":5,"returnedLines":3,
+ "scrollbackLines":3,"text":"...$ echo hi\nhi\n...$ "}
+```
+
+Implemented as `capture-pane -p -J -S -` with the tail sliced in TypeScript, because **`capture-pane -S -N` is a scrollback START OFFSET, not a line count** — on a 24-row pane, `-S -10` returns 34 lines. Trailing blank rows are dropped before slicing, since `capture-pane` emits every row of the pane and a mostly-empty pane would otherwise return N empty strings that read as "the agent printed nothing".
+
+`returnedLines` may be smaller than `requestedLines`; `scrollbackLines` is the total non-blank content available.
+
+### `boot-team --name <n> --tiers a,b,c [--cwd <path>]`
+
+One session, one titled pane per tier. Default tiers: `orchestrator,lead,worker,worker`.
+
+```json
+{"ok":true,"session":"$0","name":"debug","window":"@0",
+ "generation":"3265593:1785086482","socket":"default","layout":"main-vertical",
+ "panes":[{"id":"%0","role":"orchestrator","left":0,"top":1,"width":80,"height":49}],
+ "verified":true}
+```
+
+`verified` is `true` when the number of panes tmux reports matches the number of tiers requested; the geometry in `panes` is read back from `#{pane_left}`/`#{pane_top}`, not assumed.
+
+Two sizing behaviours are worked around. **Naive successive splits halve the remaining space exponentially** and fail with `no space for new pane` around seven panes, so each new pane splits the LEAD pane and the window is re-flowed with `select-layout main-vertical`. **`new-session -d` without `-x`/`-y` gives an 80×24 window** that fails past four panes, so explicit dimensions are passed, scaled to the tier count. Verified working at nine tiers.
+
+Every window this tool creates is configured with `remain-on-exit on`, `allow-rename off`, `automatic-rename off`, `pane-border-status top` and a `pane-border-format`. See *Window options* below.
+
+### `race --feature <f> --agents N [--cmd "<command>"] [--cwd <path>]`
+
+N panes in one session, titled `race-1` … `race-N`, each optionally running the same command. Session is named `race-<feature>`. `--feature` must match `^[A-Za-z0-9][A-Za-z0-9 ._-]{0,63}$`. `--cmd` must be a single line. Without `--cmd` the panes are created but nothing is typed.
+
+```json
+{"ok":true,"session":"$1","name":"race-login-500","window":"@1","feature":"login-500",
+ "command":"echo racer-online","panes":[{"id":"%4","role":"race-1"}],
+ "geometry":[...],"verified":true}
+```
+
+### `fleet --name <n> --grid RxC [--cmds "a;b;c"] [--cwd <path>]`
+
+A **deterministic** R×C grid. Cells fill row-major; `--cmds` are assigned in the same order and any shortfall leaves cells empty. Maximum 64 panes.
+
+```json
+{"ok":true,"session":"$2","name":"alpha","window":"@2","grid":{"rows":3,"cols":2},
+ "cells":[[{"id":"%8","row":0,"col":0,"cmd":"echo a","left":0,"top":1,"width":59,"height":11}]],
+ "verified":true,"measured":{"distinctRows":3,"panesPerRow":[2,2,2]}}
+```
+
+`select-layout tiled` is **not** used, because it ignores the requested shape and computes its own near-square arrangement from the pane count — `1x5` and `5x1` both produce 3 rows × 2 columns. The grid is built explicitly with `split-window -v` / `-h` and percentage sizing, then **verified from `#{pane_left}`/`#{pane_top}`**: `verified` is `true` only when the count of distinct `pane_top` values equals R and every row holds exactly C panes. `measured` shows what was actually observed, so a `false` is diagnosable rather than mysterious.
+
+If the window is too small for the requested grid, `split-window` fails and the error carries `hint: "the window may be too small for the requested grid"` along with the session ID so the partial session can be torn down.
+
+### `mini-fleet [--hosts <csv>] [--name <n>]`
+
+One SSH pane per host, titled with the host name.
+
+Hosts come from `--hosts name=ssh-target,name2=ssh-target2` (an entry with no `=` uses the same string for both), or, when the flag is absent, from `~/.claude/LIFEOS/USER/CUSTOMIZATIONS/SKILLS/TMUX/fleet.json`:
+
+```json
+{"hosts":[{"name":"alpha","ssh":"user@host"},{"name":"beta","ssh":"user@other"}]}
+```
+
+No host is ever hardcoded. A missing config returns `code: "no-fleet-config"` with the path and expected shape. Host names must match the safe-name charset and SSH targets must match `^[A-Za-z0-9._@:%+/-]+$` — anything shell-metacharacter-shaped is refused with `code: "bad-host"`, because the target is typed into a live shell as a word of an `ssh` command.
+
+### `monitor [--session <id>] [--once] [--interval N] [--no-voice]`
+
+Classifies every pane and voices key transitions. Default interval 3 seconds; runs until SIGINT unless `--once`. Without `--session` it covers every pane on the socket.
+
+```json
+{"ok":true,"socket":"default","panes":[{
+  "id":"%1","session":"$0","window":"@0","title":"lead",
+  "state":"failed","confidence":"definitive",
+  "signals":{
+    "exit":{"present":true,"dead":true,"status":"7","state":"failed"},
+    "process":{"present":false,"descendants":0},
+    "screen":{"present":true,"state":"working"}},
+  "disagreements":["screen=working (weak) overruled by failed (definitive)"],
+  "currentCommand":"bash","commandResolvedOneLevelOnly":true,
+  "textTail":"..."}]}
+```
+
+**States:** `done`, `failed`, `working`, `idle`, `awaiting-input`.
+
+**Three layers, each labelled with its own confidence:**
+
+| Layer | Signal | Confidence | Answers |
+|---|---|---|---|
+| `exit` | `#{pane_dead}` + `#{pane_dead_status}` | `definitive` | The process exited, and with what status. |
+| `process` | count of direct children of `#{pane_pid}`, from `ps -eo pid=,ppid=` | `strong` | Is anything running. |
+| `screen` | regex over the last 40 captured lines | `weak` | Guesswork. |
+
+**Resolution:** the exit layer wins outright when the pane is dead. Otherwise, a `screen` reading of `awaiting-input` wins — this is the one case where the weak layer decides, because the process layer answers "is something running" and structurally *cannot* express "waiting for a human" (a shell blocked in `read` has zero children and looks identical to an idle shell). Otherwise the process layer wins. Every time the screen layer disagrees with the chosen state, the disagreement is listed in `disagreements` rather than hidden, and `confidence` always names the layer that actually decided.
+
+`currentCommand` is reported but **never used for classification**, because `pane_current_command` resolves one level only: `bash run.sh` reports `bash` while the real work runs underneath. `commandResolvedOneLevelOnly` is in every record as a standing warning. The process layer is immune to this, since it counts children rather than matching names.
+
+**Voice** fires via `voice` on a *transition* into `done`, `failed`, `awaiting-input`, or `working → idle`. That last one matters on tmux: a command that finishes while its shell survives never produces a dead pane, so "back at a prompt" is the ordinary completion signal. `--no-voice` suppresses notifications while keeping the JSON.
+
+### `list` / `tree` [--session <id>]
+
+Structured topology — sessions → windows → panes, with real fields rather than regex-scraped stdout. `tracked` marks sessions this tool created on the current server generation, and `role` carries the title assigned at creation.
+
+Two fields are deliberately handled with care. **`pane_current_path` never appears**, in any template: it carries raw filesystem bytes that can contain the field delimiter or a newline, producing extra fields or extra records, and neither `#{q:}` nor a base64 modifier (which does not exist in tmux 3.6) can escape it. Query it alone if you need it. **`pane_title` is always the last field**, so a delimiter inside a title rejoins into the title rather than shifting every column.
+
+Note that `pane_title` defaults to the **machine hostname**, not an empty string, so an untitled pane is not `""` and raw topology output can contain a hostname. Do not paste `tree` output anywhere public unmodified.
+
+### `flash --target <id> [--bell]`
+
+Attention signal. **Degraded relative to CMUX, and the JSON says so on every call.**
+
+```json
+{"ok":true,"target":"%0","window":"@0",
+ "actions":["display-message","transient-border-style","select-pane"],
+ "bell":"skipped","degraded":true,"degradedReason":"..."}
+```
+
+tmux has no GUI pulse, so `flash` does what tmux can: a `display-message` on the status line, a red pane border held for ~1.2 s and then restored with `set-option -u`, and `select-pane` to move focus. **All of it is visible only to an ATTACHED client** — and the operator this skill is built for is usually detached, in which case `flash` accomplishes nothing they will see. `monitor`'s voice notification through Pulse is the real attention mechanism.
+
+`--bell` is opt-in and reports `bell: "sent-as-input-byte"`, because the only way to ring a terminal from tmux is `send-keys -H 07`, which writes byte `0x07` into the pane's **input** stream. A live prompt or TUI may echo or swallow it, and it lands in whatever the agent is typing. That is why it is not the default.
+
+Border styling is scoped with `-w` to the window this tool created and restored with `-u`. Nothing is ever set with `-g`.
+
+### `voice "<message>"`
+
+`POST http://localhost:31337/notify` with `{"message": "...", "voice_enabled": true}`, 5 s timeout.
+
+```json
+{"ok":true,"notified":true,"endpoint":"http://localhost:31337/notify"}
+```
+
+`ok:true` with `notified:false` means Pulse was unreachable — a notification failure never fails the caller.
+
+### `kill --target <id>`
+
+Teardown. Accepts `$N`, `@N` or `%N` and dispatches to `kill-session`, `kill-window` or `kill-pane`.
+
+```json
+{"ok":true,"killed":"$2","kind":"session","session":"$2","generation":"3265593:1785086482"}
+```
+
+Four refusals, all returning exit 1:
+
+| `code` | When |
+|---|---|
+| `not-an-id` | The target is a name. Prefix resolution makes name-targeted destruction unsafe. |
+| `not-owned` | The ID is not in the state file for this socket — this tool did not create it. There is no override flag. |
+| `stale-generation` | The ID was recorded against a different server incarnation. |
+| `refused` | `--all` / `-a` was passed. |
+
+`--all` is refused outright because tmux's `kill-session -a` kills every session *except* the target — on a shared server that destroys the operator's work, and the flag name reads like it means the opposite.
+
+**Generation tokens.** tmux object IDs restart at `$0`/`@0`/`%0` for every new server incarnation, so a stored ID silently retargets a different object after a restart. Every recorded ID is stamped with `#{pid}:#{start_time}` (both change on restart). If the running server's token does not match the recorded one, `kill` refuses and reports both values rather than guessing.
+
+### `doctor`
+
+Environment and safety self-check. Always `ok:true` unless tmux itself is missing.
+
+```json
+{"ok":true,"version":"tmux 3.6","socket":"default","serverRunning":true,
+ "generation":"3374884:1785086678","nested":false,"nestedPane":null,
+ "statePath":"~/.claude/LIFEOS/USER/CUSTOMIZATIONS/SKILLS/TMUX/state.json",
+ "trackedSessions":[{"id":"$0","name":"big","kind":"boot-team","panes":9,
+   "windows":[{"window":"@0","remainOnExit":"on","paneBorderStatus":"top","allowRename":"off"}]}],
+ "orphanedSessions":[],"leakedBuffers":["lifeos-tmux-orphan"],
+ "warnings":["1 named buffer(s) with prefix lifeos-tmux- are still on the server"],
+ "usesPasteBuffer":false}
+```
+
+Reports the tmux version; server reachability; whether it is running **nested** inside a tmux pane; per-window `remain-on-exit`, `pane-border-status` and `allow-rename` for every session this tool created, with a warning for each that is wrong; **orphaned sessions** (tracked but gone, or recorded against a dead generation); and **leaked named buffers** with the `lifeos-tmux-` prefix.
+
+## Window options
+
+Set with `-w` on every window this tool creates, never with `-g`:
+
+| Option | Value | Why |
+|---|---|---|
+| `remain-on-exit` | `on` | Without it an exited pane is destroyed: no `pane_dead`, no `pane_dead_status`, hooks never fire, `capture-pane` errors, and a crashed agent leaves no evidence it ever ran. **This is a WINDOW option — the session-scoped form `set-option -t "$SID" remain-on-exit on` returns success and silently does nothing.** Panes added later by `split-window` inherit it (verified); windows added later by `new-window` do **not**, so it is applied per window. |
+| `pane-border-status` | `top` | Defaults to `off`, which makes every role title invisible. |
+| `pane-border-format` | `#{pane_index}:#{pane_title}` | Renders the role in the border. |
+| `allow-rename` | `off` | Defaults to `off`, but an operator's config may set it `on`, which lets a pane's OSC 2 escape clobber its role title. Pinned per window. |
+| `automatic-rename` | `off` | Defaults **on** and tracks the running command, so window names drift. (`rename-window` also turns it off implicitly.) |
+
+**Nothing is ever set with `-g`.** A global option or hook reaches sessions this tool never created, and `set-hook -gu` cleanup would strip the operator's own global hooks for that event. No hooks are installed at all.
+
+## Paste buffers
+
+**This tool never uses `paste-buffer`.** `send-keys -l` is sufficient, and named buffers are a liability: they are server-global and readable with `show-buffer -b <name>` from any session, a same-name `load-buffer` silently overwrites a concurrent caller, `buffer-limit` only trims *automatic* buffers so named ones persist indefinitely, and `paste-buffer -d` does **not** delete the buffer when the paste fails. `doctor` still reports any buffer with the `lifeos-tmux-` prefix so a leak from another caller or an older build is visible.
+
+## Nested operation
+
+`$TMUX` is set when this tool runs inside a pane. `ping` and `doctor` report `nested`, `doctor` warns about it, and `send` refuses to write into the pane the wrapper itself occupies. Running on one socket while targeting another with `--socket` is supported and is the recommended pattern for testing: it keeps the default socket, where the operator's real work lives, untouched.
+
+## Degraded and absent capabilities
+
+| Capability | Status | Detail |
+|---|---|---|
+| GUI flash / pulse | **degraded** | `display-message` + transient border + optional input-byte bell, attached clients only. See `flash`. |
+| Per-team colour identity | **partial** | Border and status styling scoped to the session; no theming. |
+| In-app browser pane | **absent** | tmux is a terminal multiplexer; there is no such object. Use `Interceptor` separately. |
+| Screen-text done-detection | **weak by construction** | Reported at `confidence: "weak"` and overruled by stronger layers, rather than presented as fact. |
+
+Three things this has that a GUI multiplexer does not: sessions that survive disconnection, real exit statuses via `pane_dead_status`, and structured topology without regex-scraping stdout.
+
+## Error codes
+
+`missing-flag`, `bad-flag`, `bad-name`, `bad-cwd`, `bad-host`, `name-taken`, `not-an-id`, `target-missing`, `self-target`, `multiline-refused`, `not-owned`, `stale-generation`, `refused`, `no-server`, `no-generation`, `no-hosts`, `no-fleet-config`, `bad-fleet-config`, `split-failed`, `capture-failed`, `kill-failed`, `tmux-missing`, `tmux-failed`, `unexpected-output`, `unknown-subcommand`, `unhandled`.
+
+## Reproducing the verification run
+
+Everything below runs on a private socket and destroys only what it creates.
+
+```bash
+T=~/.claude/skills/TMUX/Tools/Tmux.ts
+export TMUX_SKILL_STATE=/tmp/tmux-skill-verify.json   # keep the real state file out of it
+S=tmuxskill-verify                                    # never the default socket
+rm -f "$TMUX_SKILL_STATE"; tmux -L $S kill-server 2>/dev/null
+
+bun $T doctor  --socket $S                            # no server yet
+bun $T ping    --socket $S
+bun $T boot-team --socket $S --name debug --tiers orchestrator,lead,worker,worker
+bun $T tree    --socket $S --session '$0'
+bun $T send    --socket $S --target %1 "echo hello-from-lead" --enter
+bun $T read    --socket $S --target %1 --lines 5
+
+# anti-test: multi-line payload without --enter  -> multiline-refused, exit 1
+bun $T send    --socket $S --target %2 "$(printf 'echo one\necho two')"
+# anti-test: a name instead of an ID             -> not-an-id, exit 1
+bun $T send    --socket $S --target debug "hi"
+
+bun $T monitor --socket $S --session '$0' --once --no-voice
+bun $T flash   --socket $S --target %0
+bun $T race    --socket $S --feature login-500 --agents 4 --cmd "echo racer-online"
+bun $T fleet   --socket $S --name alpha --grid 3x2 --cmds "echo a;echo b;echo c"
+bun $T fleet   --socket $S --name wide  --grid 1x5   # must NOT come out as 3x2
+bun $T fleet   --socket $S --name tall  --grid 5x1   # must NOT match 1x5
+bun $T mini-fleet --socket $S --hosts "alpha=user@10.0.0.1,beta=user@10.0.0.2"
+bun $T voice   --socket $S "verification run complete"
+
+# anti-test: prefix targeting cannot reach an operator session
+tmux -L $S new-session -d -s production-work
+tmux -L $S display-message -p -t production "raw tmux resolves to #{session_name}"  # production-work
+bun $T kill --socket $S --target production          # -> not-an-id, exit 1
+bun $T kill --socket $S --target '$6'                # -> not-owned, exit 1 (untracked)
+bun $T kill --socket $S --target '$1' --all          # -> refused, exit 1
+
+bun $T kill --socket $S --target '$1'                # succeeds: this tool created it
+
+# anti-test: stale generation
+tmux -L $S kill-server; tmux -L $S new-session -d -s somebody-elses-work
+bun $T kill --socket $S --target '$0'                # -> stale-generation, exit 1
+bun $T doctor --socket $S                            # lists the orphans
+
+tmux -L $S kill-server; rm -f "$TMUX_SKILL_STATE"    # clean up
+```
+
+Type check with `bun build --target bun ~/.claude/skills/TMUX/Tools/Tmux.ts --outdir /tmp/tmux-build`.

--- a/LifeOS/install/skills/TMUX/Tools/Tmux.ts
+++ b/LifeOS/install/skills/TMUX/Tools/Tmux.ts
@@ -1,0 +1,1942 @@
+#!/usr/bin/env bun
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+type FlagValue = string | boolean;
+type ParsedArgs = {
+  positionals: string[];
+  flags: Record<string, FlagValue>;
+};
+
+type ExecResult = {
+  code: number;
+  stdout: string;
+  stderr: string;
+};
+
+type JsonPrimitive = string | number | boolean | null;
+type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+type JsonObject = { [key: string]: JsonValue | undefined };
+
+type HostConfig = {
+  name: string;
+  ssh: string;
+};
+
+type PaneGeometry = {
+  id: string;
+  title: string;
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+};
+
+type TrackedPane = {
+  id: string;
+  role: string;
+};
+
+type TrackedSession = {
+  id: string;
+  name: string;
+  socket: string;
+  generation: string;
+  kind: string;
+  createdAt: string;
+  windows: string[];
+  panes: TrackedPane[];
+};
+
+type ToolState = {
+  version: 1;
+  sessions: TrackedSession[];
+  buffers: string[];
+};
+
+type Confidence = "definitive" | "strong" | "weak";
+type PaneStateName = "done" | "failed" | "working" | "idle" | "awaiting-input";
+
+type PaneSignals = {
+  exit: { present: boolean; dead: boolean; status: string; state?: PaneStateName };
+  process: { present: boolean; descendants: number; state?: PaneStateName };
+  screen: { present: boolean; state?: PaneStateName };
+};
+
+type MonitorPane = {
+  id: string;
+  session: string;
+  window: string;
+  title: string;
+  state: PaneStateName;
+  confidence: Confidence;
+  signals: PaneSignals;
+  disagreements: string[];
+  currentCommand: string;
+  commandResolvedOneLevelOnly: true;
+  textTail: string;
+};
+
+const DEFAULT_TIMEOUT_MS = 20_000;
+const MONITOR_TAIL_LINES = 40;
+const READ_DEFAULT_LINES = 80;
+const FLASH_HOLD_MS = 1_200;
+const VOICE_URL = "http://localhost:31337/notify";
+const FIELD_DELIMITER = "|";
+const BUFFER_PREFIX = "lifeos-tmux-";
+const DEFAULT_SOCKET_LABEL = "default";
+
+/** Name charset for anything that becomes a tmux session or window name. */
+const SAFE_NAME = /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/;
+/** Charset for a --feature value, which is embedded in a generated session name. */
+const SAFE_FEATURE = /^[A-Za-z0-9][A-Za-z0-9 ._-]{0,63}$/;
+/** SSH destinations are passed as a single shell word typed into a pane. */
+const SAFE_SSH_TARGET = /^[A-Za-z0-9._@:%+/-]+$/;
+
+let socketLabel: string | undefined;
+
+function usageText(): string {
+  return `Tmux.ts - JSON CLI wrapper driving tmux as an agent cockpit
+
+USAGE:
+  bun ~/.claude/skills/TMUX/Tools/Tmux.ts <subcommand> [options]
+
+SUBCOMMANDS:
+  ping                                       Server reachability and tmux version
+  send --target <id> "<text>" [--enter]      Type literal text into a pane
+  read --target <id> [--lines N]             Capture pane text, last N lines
+  boot-team --name <n> --tiers a,b,c [--cwd] Session with one titled pane per tier
+  race --feature <f> --agents N [--cmd]      N panes running the same command
+  fleet --name <n> --grid RxC [--cmds "a;b"] Deterministic RxC grid of panes
+  mini-fleet [--hosts <csv>]                 One SSH pane per host from USER config
+  monitor [--session <id>] [--once] [--interval N]
+  list | tree [--session <id>]               Structured topology
+  flash --target <id> [--bell]               Attention signal (degraded, see help doc)
+  voice "<msg>"                              Pulse voice notification
+  kill --target <id>                         Teardown, ID-only, generation-checked
+  doctor                                     Environment and safety self-check
+
+GLOBAL:
+  --socket <name>                            Use a private server via tmux -L <name>
+  --help, -h                                 Show this help text
+
+OUTPUT:
+  Every subcommand prints exactly one JSON object to stdout and exits 0 when ok is true.
+  monitor without --once prints one JSON object per poll pass.
+`;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const positionals: string[] = [];
+  const flags: Record<string, FlagValue> = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--") {
+      positionals.push(...argv.slice(index + 1));
+      break;
+    }
+    if (token.startsWith("--")) {
+      const name = token.slice(2);
+      const next = argv[index + 1];
+      if (next !== undefined && !next.startsWith("--")) {
+        flags[name] = next;
+        index += 1;
+      } else {
+        flags[name] = true;
+      }
+    } else {
+      positionals.push(token);
+    }
+  }
+
+  return { positionals, flags };
+}
+
+function flagString(args: ParsedArgs, name: string): string | undefined {
+  const value = args.flags[name];
+  return typeof value === "string" ? value : undefined;
+}
+
+function flagBoolean(args: ParsedArgs, name: string): boolean {
+  return args.flags[name] === true;
+}
+
+function requireFlag(args: ParsedArgs, name: string): string | JsonObject {
+  const value = flagString(args, name);
+  if (value === undefined || value.trim() === "") {
+    return { ok: false, error: `Missing required --${name}`, code: "missing-flag" };
+  }
+  return value;
+}
+
+function parsePositiveInteger(value: string | undefined, fallback: number, label: string): number | JsonObject {
+  if (value === undefined) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0 || String(parsed) !== value.trim()) {
+    return { ok: false, error: `${label} must be a positive integer`, code: "bad-flag" };
+  }
+  return parsed;
+}
+
+function expandHome(pathValue: string): string {
+  if (pathValue === "~") {
+    return homedir();
+  }
+  if (pathValue.startsWith("~/")) {
+    return join(homedir(), pathValue.slice(2));
+  }
+  return pathValue;
+}
+
+function isSessionId(value: string): boolean {
+  return /^\$\d+$/.test(value);
+}
+
+function isWindowId(value: string): boolean {
+  return /^@\d+$/.test(value);
+}
+
+function isPaneId(value: string): boolean {
+  return /^%\d+$/.test(value);
+}
+
+function isTmuxId(value: string): boolean {
+  return isSessionId(value) || isWindowId(value) || isPaneId(value);
+}
+
+function idKind(value: string): "session" | "window" | "pane" | "invalid" {
+  if (isSessionId(value)) return "session";
+  if (isWindowId(value)) return "window";
+  if (isPaneId(value)) return "pane";
+  return "invalid";
+}
+
+function rejectNonId(value: string, flag: string): JsonObject {
+  return {
+    ok: false,
+    code: "not-an-id",
+    error:
+      `--${flag} must be a tmux object ID ($N session, @N window, %N pane), got ${JSON.stringify(value)}. ` +
+      "Names are refused because tmux -t resolves exact, then fnmatch, then unambiguous prefix: " +
+      "with sessions 'prod' and 'production-work' present, targeting 'production' hits 'production-work' " +
+      "and exits 0 with no warning. Use list/tree to get IDs.",
+  };
+}
+
+async function processText(stream: ReadableStream<Uint8Array> | null): Promise<string> {
+  if (stream === null) {
+    return "";
+  }
+  return await new Response(stream).text();
+}
+
+async function runProcess(command: string[], timeoutMs: number): Promise<ExecResult> {
+  let proc: Bun.Subprocess<"pipe", "pipe", "pipe">;
+  try {
+    proc = Bun.spawn(command, { stdout: "pipe", stderr: "pipe", stdin: "pipe" });
+  } catch (error) {
+    return { code: 127, stdout: "", stderr: error instanceof Error ? error.message : String(error) };
+  }
+
+  let timedOut = false;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    proc.kill();
+  }, timeoutMs);
+
+  try {
+    const [code, stdout, stderr] = await Promise.all([
+      proc.exited,
+      processText(proc.stdout),
+      processText(proc.stderr),
+    ]);
+    clearTimeout(timeout);
+    if (timedOut) {
+      return { code: code === 0 ? 124 : code, stdout, stderr: stderr || "Process timed out" };
+    }
+    return { code, stdout, stderr };
+  } catch (error) {
+    clearTimeout(timeout);
+    proc.kill();
+    return { code: 1, stdout: "", stderr: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+/**
+ * Every tmux invocation goes through here as an argv array. There is no shell in
+ * this tool, so no payload can ever be interpolated into a command string.
+ */
+function tmuxCommand(args: string[]): string[] {
+  if (socketLabel !== undefined) {
+    return ["tmux", "-L", socketLabel, ...args];
+  }
+  return ["tmux", ...args];
+}
+
+async function tmuxExec(args: string[], timeoutMs = DEFAULT_TIMEOUT_MS): Promise<ExecResult> {
+  return await runProcess(tmuxCommand(args), timeoutMs);
+}
+
+function resultError(result: ExecResult, context: string, code = "tmux-failed"): JsonObject {
+  const detail = (result.stderr || result.stdout || "unknown tmux error").trim();
+  return { ok: false, code, error: `${context}: ${detail}` };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function socketKey(): string {
+  return socketLabel ?? DEFAULT_SOCKET_LABEL;
+}
+
+// ---------------------------------------------------------------------------
+// Server identity: generation tokens
+// ---------------------------------------------------------------------------
+
+/**
+ * tmux object IDs restart at $0/@0/%0 for every new server incarnation, so a
+ * stored ID silently retargets a different object after a restart. #{pid} and
+ * #{start_time} both change on restart, so their pair identifies the incarnation.
+ */
+async function currentGeneration(): Promise<string | undefined> {
+  const result = await tmuxExec(["display-message", "-p", "#{pid}:#{start_time}"]);
+  if (result.code !== 0) {
+    return undefined;
+  }
+  const token = result.stdout.trim();
+  return token === "" || token.startsWith(":") ? undefined : token;
+}
+
+async function serverRunning(): Promise<boolean> {
+  const result = await tmuxExec(["list-sessions", "-F", "#{session_id}"]);
+  if (result.code === 0) {
+    return true;
+  }
+  return !/no server running|error connecting|No such file/i.test(`${result.stdout}${result.stderr}`);
+}
+
+// ---------------------------------------------------------------------------
+// State: what this tool created, and on which server incarnation
+// ---------------------------------------------------------------------------
+
+function statePath(): string {
+  const override = process.env.TMUX_SKILL_STATE;
+  if (override !== undefined && override.trim() !== "") {
+    return expandHome(override);
+  }
+  return join(homedir(), ".claude/LIFEOS/USER/CUSTOMIZATIONS/SKILLS/TMUX/state.json");
+}
+
+function emptyState(): ToolState {
+  return { version: 1, sessions: [], buffers: [] };
+}
+
+function isTrackedSession(value: unknown): value is TrackedSession {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.id === "string" &&
+    typeof record.name === "string" &&
+    typeof record.socket === "string" &&
+    typeof record.generation === "string" &&
+    Array.isArray(record.windows) &&
+    Array.isArray(record.panes)
+  );
+}
+
+function loadState(): ToolState {
+  const path = statePath();
+  if (!existsSync(path)) {
+    return emptyState();
+  }
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+    if (typeof parsed !== "object" || parsed === null) {
+      return emptyState();
+    }
+    const record = parsed as Record<string, unknown>;
+    const sessions = Array.isArray(record.sessions) ? record.sessions.filter(isTrackedSession) : [];
+    const buffers = Array.isArray(record.buffers) ? record.buffers.filter((b) => typeof b === "string") : [];
+    return { version: 1, sessions, buffers: buffers as string[] };
+  } catch {
+    return emptyState();
+  }
+}
+
+function saveState(state: ToolState): void {
+  const path = statePath();
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    const temporary = `${path}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+    renameSync(temporary, path);
+  } catch {
+    // State is an optimisation for teardown safety, not a correctness requirement
+    // for read-only paths. A failed write must not fail the caller's subcommand.
+  }
+}
+
+function recordSession(entry: TrackedSession): void {
+  const state = loadState();
+  state.sessions = state.sessions.filter(
+    (session) => !(session.socket === entry.socket && session.id === entry.id && session.generation === entry.generation),
+  );
+  state.sessions.push(entry);
+  saveState(state);
+}
+
+function trackedForSocket(state: ToolState): TrackedSession[] {
+  return state.sessions.filter((session) => session.socket === socketKey());
+}
+
+// ---------------------------------------------------------------------------
+// Field queries. pane_current_path is deliberately never in a delimited template.
+// ---------------------------------------------------------------------------
+
+/**
+ * Splits a delimited -F record. Any field that can carry arbitrary bytes (only
+ * pane_title, which defaults to the machine hostname and can be set by the pane
+ * via OSC 2) must be LAST in the template so a delimiter inside it rejoins here
+ * instead of shifting every column. #{q:} does not escape delimiters and
+ * #{b64:} does not exist in tmux 3.6, so ordering is the only defence.
+ */
+function splitRecord(line: string, fixedFields: number): string[] {
+  const parts = line.split(FIELD_DELIMITER);
+  if (parts.length <= fixedFields) {
+    return parts;
+  }
+  return [...parts.slice(0, fixedFields), parts.slice(fixedFields).join(FIELD_DELIMITER)];
+}
+
+function nonEmptyLines(text: string): string[] {
+  return text.split("\n").filter((line) => line.trim() !== "");
+}
+
+async function listPaneGeometry(windowOrSession: string): Promise<PaneGeometry[] | JsonObject> {
+  const scope = isSessionId(windowOrSession) ? ["-s"] : [];
+  const result = await tmuxExec([
+    "list-panes",
+    ...scope,
+    "-t",
+    windowOrSession,
+    "-F",
+    ["#{pane_id}", "#{pane_left}", "#{pane_top}", "#{pane_width}", "#{pane_height}", "#{pane_title}"].join(
+      FIELD_DELIMITER,
+    ),
+  ]);
+  if (result.code !== 0) {
+    return resultError(result, "list-panes failed");
+  }
+  return nonEmptyLines(result.stdout).map((line) => {
+    const [id, left, top, width, height, title] = splitRecord(line, 5);
+    return {
+      id,
+      left: Number.parseInt(left, 10),
+      top: Number.parseInt(top, 10),
+      width: Number.parseInt(width, 10),
+      height: Number.parseInt(height, 10),
+      title: title ?? "",
+    };
+  });
+}
+
+function geometryJson(panes: PaneGeometry[]): JsonValue {
+  return panes.map((pane) => ({
+    id: pane.id,
+    left: pane.left,
+    top: pane.top,
+    width: pane.width,
+    height: pane.height,
+    title: pane.title,
+  })) as unknown as JsonValue;
+}
+
+// ---------------------------------------------------------------------------
+// Target resolution
+// ---------------------------------------------------------------------------
+
+async function resolvePane(target: string): Promise<string | JsonObject> {
+  if (!isTmuxId(target)) {
+    return rejectNonId(target, "target");
+  }
+  // display-message exits 0 and prints an EMPTY string for a target that does
+  // not exist, so the exit code alone is not proof of resolution. The returned
+  // value has to be checked, or a missing pane silently becomes target "".
+  const resolved = await tmuxExec(["display-message", "-p", "-t", target, "#{pane_id}"]);
+  if (resolved.code !== 0) {
+    return resultError(resolved, `could not resolve ${target} to a pane`, "target-missing");
+  }
+  const paneId = resolved.stdout.trim();
+  if (!isPaneId(paneId)) {
+    return { ok: false, code: "target-missing", error: `${target} does not resolve to a live pane on socket ${socketKey()}` };
+  }
+  return paneId;
+}
+
+/**
+ * $TMUX is set when this process runs inside a pane. Writing keys into our own
+ * pane would echo the wrapper's own payload into the transcript driving it.
+ */
+async function selfPaneGuard(paneId: string): Promise<JsonObject | undefined> {
+  const insideTmux = process.env.TMUX;
+  const ownPane = process.env.TMUX_PANE;
+  if (insideTmux === undefined || ownPane === undefined || ownPane !== paneId) {
+    return undefined;
+  }
+  const ownSocket = insideTmux.split(",")[0];
+  const targetSocket = await tmuxExec(["display-message", "-p", "#{socket_path}"]);
+  if (targetSocket.code === 0 && targetSocket.stdout.trim() !== ownSocket) {
+    return undefined;
+  }
+  return {
+    ok: false,
+    code: "self-target",
+    error: `Refusing to send keys into the pane this wrapper is running in (${paneId}).`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Window configuration
+// ---------------------------------------------------------------------------
+
+/**
+ * Applied per window. remain-on-exit is a WINDOW option: the session-scoped form
+ * returns success and silently does nothing. Panes added later by split-window
+ * inherit it (verified), but a window added later by new-window does not, so
+ * this runs for every window this tool creates. Nothing here uses -g: a global
+ * option reaches sessions this tool never created, and unsetting it would strip
+ * the operator's own configuration.
+ */
+async function configureWindow(windowId: string, borderFormat: string): Promise<JsonObject | undefined> {
+  const settings: Array<[string, string]> = [
+    ["remain-on-exit", "on"],
+    ["allow-rename", "off"],
+    ["automatic-rename", "off"],
+    ["pane-border-status", "top"],
+    ["pane-border-format", borderFormat],
+  ];
+  for (const [option, value] of settings) {
+    const result = await tmuxExec(["set-option", "-w", "-t", windowId, option, value]);
+    if (result.code !== 0) {
+      return resultError(result, `set-option -w ${option} failed`);
+    }
+  }
+  return undefined;
+}
+
+async function sessionExists(name: string): Promise<boolean> {
+  // "=name" anchors the target to an exact match, defeating prefix resolution.
+  const result = await tmuxExec(["has-session", "-t", `=${name}`]);
+  return result.code === 0;
+}
+
+type CreatedSession = {
+  sessionId: string;
+  windowId: string;
+  paneId: string;
+  generation: string;
+};
+
+async function createSession(
+  name: string,
+  cwd: string | undefined,
+  width: number,
+  height: number,
+): Promise<CreatedSession | JsonObject> {
+  if (!SAFE_NAME.test(name)) {
+    return {
+      ok: false,
+      code: "bad-name",
+      error: `Session name must match ${SAFE_NAME.source} (tmux forbids '.' and ':' in names)`,
+    };
+  }
+  if (await sessionExists(name)) {
+    return { ok: false, code: "name-taken", error: `A session named ${name} already exists on this server` };
+  }
+
+  const args = [
+    "new-session",
+    "-d",
+    "-s",
+    name,
+    "-x",
+    String(width),
+    "-y",
+    String(height),
+    "-P",
+    "-F",
+    ["#{session_id}", "#{window_id}", "#{pane_id}"].join(FIELD_DELIMITER),
+  ];
+  if (cwd !== undefined) {
+    const resolved = expandHome(cwd);
+    if (!existsSync(resolved)) {
+      return { ok: false, code: "bad-cwd", error: `--cwd does not exist: ${cwd}` };
+    }
+    args.splice(2, 0, "-c", resolved);
+  }
+
+  const result = await tmuxExec(args);
+  if (result.code !== 0) {
+    return resultError(result, "new-session failed");
+  }
+  const [sessionId, windowId, paneId] = result.stdout.trim().split(FIELD_DELIMITER);
+  if (!isSessionId(sessionId) || !isWindowId(windowId) || !isPaneId(paneId)) {
+    return { ok: false, code: "unexpected-output", error: `new-session returned unparseable IDs: ${result.stdout.trim()}` };
+  }
+
+  const generation = await currentGeneration();
+  if (generation === undefined) {
+    return { ok: false, code: "no-generation", error: "Could not read the server generation token after creating the session" };
+  }
+  return { sessionId, windowId, paneId, generation };
+}
+
+async function splitPane(fromPane: string, vertical: boolean, percent: number | undefined, cwd: string | undefined): Promise<string | JsonObject> {
+  const args = ["split-window", vertical ? "-v" : "-h", "-t", fromPane];
+  if (percent !== undefined) {
+    args.push("-l", `${percent}%`);
+  }
+  if (cwd !== undefined) {
+    args.push("-c", expandHome(cwd));
+  }
+  args.push("-P", "-F", "#{pane_id}");
+
+  const result = await tmuxExec(args);
+  if (result.code !== 0) {
+    return resultError(result, `split-window from ${fromPane} failed`, "split-failed");
+  }
+  const paneId = result.stdout.trim();
+  if (!isPaneId(paneId)) {
+    return { ok: false, code: "unexpected-output", error: `split-window returned unparseable pane id: ${paneId}` };
+  }
+  return paneId;
+}
+
+async function titlePane(paneId: string, title: string): Promise<JsonObject | undefined> {
+  const result = await tmuxExec(["select-pane", "-t", paneId, "-T", title]);
+  if (result.code !== 0) {
+    return resultError(result, `select-pane -T failed for ${paneId}`);
+  }
+  return undefined;
+}
+
+async function applyLayout(windowId: string, layout: string): Promise<void> {
+  // A single-pane window has no layout to apply; tmux errors and it is not fatal.
+  await tmuxExec(["select-layout", "-t", windowId, layout]);
+}
+
+async function sendLiteral(paneId: string, text: string, enter: boolean): Promise<JsonObject | undefined> {
+  // -l sends the payload literally. Without it a payload word like "Enter" or
+  // "C-c" is interpreted as a keypress. "--" stops flag parsing so a payload
+  // starting with "-" is not read as an option (verified: it is required).
+  const sent = await tmuxExec(["send-keys", "-t", paneId, "-l", "--", text]);
+  if (sent.code !== 0) {
+    return resultError(sent, "send-keys failed");
+  }
+  if (enter) {
+    const key = await tmuxExec(["send-keys", "-t", paneId, "Enter"]);
+    if (key.code !== 0) {
+      return resultError(key, "send-keys Enter failed");
+    }
+  }
+  return undefined;
+}
+
+async function capturePane(paneId: string, lines: number): Promise<{ text: string; total: number } | JsonObject> {
+  // -S -N is a scrollback START OFFSET, not a line count: on a 24-row pane
+  // "-S -10" returns 34 lines. "-S -" takes the whole history and the tail is
+  // sliced here, which is the only way to honour a real "last N lines".
+  const result = await tmuxExec(["capture-pane", "-p", "-J", "-S", "-", "-t", paneId]);
+  if (result.code !== 0) {
+    return resultError(result, `capture-pane failed for ${paneId}`, "capture-failed");
+  }
+  const all = result.stdout.replace(/\n$/, "").split("\n");
+  // capture-pane emits every ROW of the pane, so a mostly-empty pane returns its
+  // full height as trailing blank rows. Slicing the tail without dropping those
+  // returns N empty strings and reads as "the agent printed nothing".
+  let end = all.length;
+  while (end > 0 && all[end - 1].trim() === "") {
+    end -= 1;
+  }
+  const content = all.slice(0, end);
+  return { text: content.slice(-lines).join("\n"), total: content.length };
+}
+
+// ---------------------------------------------------------------------------
+// Process-tree layer for monitor
+// ---------------------------------------------------------------------------
+
+async function processChildCounts(): Promise<Map<number, number>> {
+  const counts = new Map<number, number>();
+  const result = await runProcess(["ps", "-eo", "pid=,ppid="], DEFAULT_TIMEOUT_MS);
+  if (result.code !== 0) {
+    return counts;
+  }
+  for (const line of nonEmptyLines(result.stdout)) {
+    const parts = line.trim().split(/\s+/);
+    const parent = Number.parseInt(parts[1], 10);
+    if (Number.isFinite(parent)) {
+      counts.set(parent, (counts.get(parent) ?? 0) + 1);
+    }
+  }
+  return counts;
+}
+
+/**
+ * Weak layer. Screen text is guesswork: a prompt-looking tail can be a finished
+ * agent, a paused one, or an agent that printed a prompt character inside its
+ * output. Everything derived here is reported with confidence "weak".
+ */
+function classifyScreen(text: string): PaneStateName {
+  const tail = text.trimEnd();
+  if (/(do you want|\[y\/n\]|\(y\/n\)|press enter|continue\?|password:|passphrase)/i.test(tail) || /\?\s*$/.test(tail)) {
+    return "awaiting-input";
+  }
+  if (/(^|\n)\s*(done|completed|finished|exit code:\s*0)\b/i.test(tail) || /[✓✔]\s*(done|complete|completed)?/i.test(tail)) {
+    return "done";
+  }
+  if (/(^|\n)[^\n]*[$%#❯]\s*$/.test(tail)) {
+    return "idle";
+  }
+  return "working";
+}
+
+function resolveSignals(signals: PaneSignals): { state: PaneStateName; confidence: Confidence; disagreements: string[] } {
+  const disagreements: string[] = [];
+  let state: PaneStateName;
+  let confidence: Confidence;
+
+  if (signals.exit.present && signals.exit.dead) {
+    state = signals.exit.state ?? "done";
+    confidence = "definitive";
+  } else if (signals.screen.present && signals.screen.state === "awaiting-input") {
+    // The strong layer answers "is a process running", which cannot express
+    // awaiting-input at all. This is the one case where the weak layer decides,
+    // and the JSON says so.
+    state = "awaiting-input";
+    confidence = "weak";
+  } else if (signals.process.present && signals.process.state !== undefined) {
+    state = signals.process.state;
+    confidence = "strong";
+  } else if (signals.screen.present && signals.screen.state !== undefined) {
+    state = signals.screen.state;
+    confidence = "weak";
+  } else {
+    state = "idle";
+    confidence = "weak";
+  }
+
+  if (signals.screen.present && signals.screen.state !== undefined && signals.screen.state !== state) {
+    disagreements.push(`screen=${signals.screen.state} (weak) overruled by ${state} (${confidence})`);
+  }
+  if (
+    signals.process.present &&
+    signals.process.state !== undefined &&
+    signals.process.state !== state &&
+    confidence === "definitive"
+  ) {
+    disagreements.push(`process=${signals.process.state} (strong) overruled by ${state} (definitive)`);
+  }
+  return { state, confidence, disagreements };
+}
+
+// ---------------------------------------------------------------------------
+// Voice
+// ---------------------------------------------------------------------------
+
+async function notifyVoice(message: string): Promise<boolean> {
+  try {
+    const response = await fetch(VOICE_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message, voice_enabled: true }),
+      signal: AbortSignal.timeout(5_000),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Subcommands
+// ---------------------------------------------------------------------------
+
+async function commandPing(): Promise<JsonObject> {
+  const version = await runProcess(["tmux", "-V"], DEFAULT_TIMEOUT_MS);
+  if (version.code !== 0) {
+    return resultError(version, "tmux -V failed (is tmux installed?)", "tmux-missing");
+  }
+
+  // start-server does not leave a server running when there are no sessions: it
+  // exits as soon as the invoking command returns. Reachability is therefore the
+  // exit code of list-sessions, not an attempt to start anything.
+  const sessions = await tmuxExec(["list-sessions", "-F", "#{session_id}"]);
+  const running = sessions.code === 0;
+
+  return {
+    ok: true,
+    version: version.stdout.trim(),
+    socket: socketKey(),
+    serverRunning: running,
+    sessions: running ? nonEmptyLines(sessions.stdout).length : 0,
+    generation: running ? ((await currentGeneration()) ?? null) : null,
+    nested: process.env.TMUX !== undefined,
+  };
+}
+
+async function commandSend(args: ParsedArgs): Promise<JsonObject> {
+  const targetValue = requireFlag(args, "target");
+  if (typeof targetValue !== "string") {
+    return targetValue;
+  }
+
+  const text = args.positionals.join(" ");
+  if (text === "") {
+    return { ok: false, code: "missing-text", error: "Missing text positional" };
+  }
+
+  const entered = flagBoolean(args, "enter");
+  if (/[\r\n]/.test(text) && !entered) {
+    // Measured on tmux 3.6: send-keys -l, paste-buffer, paste-buffer -p,
+    // paste-buffer -r and paste-buffer -p -r ALL executed the payload in a ready
+    // shell. No transport is safe, and bracketed-paste state is not exposed by
+    // any format variable, so the payload is what gets validated.
+    return {
+      ok: false,
+      code: "multiline-refused",
+      error:
+        "Refusing multi-line text without --enter. A carriage return or newline in the payload EXECUTES the " +
+        "line it terminates, and no tmux send mechanism prevents that. Strip newlines, or pass --enter to " +
+        "state that submitting is intended.",
+      offendingCharacters: text.includes("\r") ? "CR and/or LF" : "LF",
+    };
+  }
+
+  const paneId = await resolvePane(targetValue);
+  if (typeof paneId !== "string") {
+    return paneId;
+  }
+  const guard = await selfPaneGuard(paneId);
+  if (guard !== undefined) {
+    return guard;
+  }
+
+  const error = await sendLiteral(paneId, text, entered);
+  if (error !== undefined) {
+    return error;
+  }
+  return { ok: true, target: paneId, bytes: Buffer.byteLength(text, "utf8"), entered };
+}
+
+async function commandRead(args: ParsedArgs): Promise<JsonObject> {
+  const targetValue = requireFlag(args, "target");
+  if (typeof targetValue !== "string") {
+    return targetValue;
+  }
+  const lines = parsePositiveInteger(flagString(args, "lines"), READ_DEFAULT_LINES, "--lines");
+  if (typeof lines !== "number") {
+    return lines;
+  }
+
+  const paneId = await resolvePane(targetValue);
+  if (typeof paneId !== "string") {
+    return paneId;
+  }
+  const captured = await capturePane(paneId, lines);
+  if (!("text" in captured)) {
+    return captured;
+  }
+  const returned = captured.text === "" ? 0 : captured.text.split("\n").length;
+  return {
+    ok: true,
+    target: paneId,
+    requestedLines: lines,
+    returnedLines: returned,
+    scrollbackLines: captured.total,
+    text: captured.text,
+  };
+}
+
+async function commandBootTeam(args: ParsedArgs): Promise<JsonObject> {
+  const nameValue = requireFlag(args, "name");
+  if (typeof nameValue !== "string") {
+    return nameValue;
+  }
+  const tiers = (flagString(args, "tiers") ?? "orchestrator,lead,worker,worker")
+    .split(",")
+    .map((role) => role.trim())
+    .filter((role) => role.length > 0);
+  if (tiers.length === 0) {
+    return { ok: false, code: "bad-flag", error: "--tiers must include at least one role" };
+  }
+  for (const role of tiers) {
+    if (!SAFE_NAME.test(role)) {
+      return { ok: false, code: "bad-flag", error: `Tier role must match ${SAFE_NAME.source}, got ${JSON.stringify(role)}` };
+    }
+  }
+
+  const cwd = flagString(args, "cwd");
+  // An 80x24 default window runs out of space around four panes. Size the
+  // session up front so the lead-split strategy has room.
+  const created = await createSession(nameValue, cwd, Math.max(200, 40 * tiers.length), Math.max(50, 8 * tiers.length));
+  if (!("sessionId" in created)) {
+    return created;
+  }
+
+  const configureError = await configureWindow(created.windowId, "#{pane_index}:#{pane_title}");
+  if (configureError !== undefined) {
+    return configureError;
+  }
+  await tmuxExec(["rename-window", "-t", created.windowId, nameValue]);
+
+  const panes: TrackedPane[] = [{ id: created.paneId, role: tiers[0] }];
+  const titleError = await titlePane(created.paneId, tiers[0]);
+  if (titleError !== undefined) {
+    return titleError;
+  }
+
+  for (let index = 1; index < tiers.length; index += 1) {
+    // Splitting the newest pane each time halves the remaining space
+    // exponentially and dies at "no space for new pane" around seven panes.
+    // Splitting the LEAD pane and re-flowing with main-vertical does not.
+    const paneId = await splitPane(created.paneId, false, undefined, cwd);
+    if (typeof paneId !== "string") {
+      return { ...paneId, createdSoFar: panes as unknown as JsonValue, session: created.sessionId };
+    }
+    await applyLayout(created.windowId, "main-vertical");
+    const roleError = await titlePane(paneId, tiers[index]);
+    if (roleError !== undefined) {
+      return roleError;
+    }
+    panes.push({ id: paneId, role: tiers[index] });
+  }
+
+  await applyLayout(created.windowId, "main-vertical");
+
+  const geometry = await listPaneGeometry(created.windowId);
+  if (!Array.isArray(geometry)) {
+    return geometry;
+  }
+
+  recordSession({
+    id: created.sessionId,
+    name: nameValue,
+    socket: socketKey(),
+    generation: created.generation,
+    kind: "boot-team",
+    createdAt: new Date().toISOString(),
+    windows: [created.windowId],
+    panes,
+  });
+
+  const byId = new Map(geometry.map((pane) => [pane.id, pane]));
+  return {
+    ok: true,
+    session: created.sessionId,
+    name: nameValue,
+    window: created.windowId,
+    generation: created.generation,
+    socket: socketKey(),
+    layout: "main-vertical",
+    panes: panes.map((pane) => ({
+      id: pane.id,
+      role: pane.role,
+      left: byId.get(pane.id)?.left ?? null,
+      top: byId.get(pane.id)?.top ?? null,
+      width: byId.get(pane.id)?.width ?? null,
+      height: byId.get(pane.id)?.height ?? null,
+    })) as unknown as JsonValue,
+    verified: geometry.length === tiers.length,
+  };
+}
+
+async function commandRace(args: ParsedArgs): Promise<JsonObject> {
+  const featureValue = requireFlag(args, "feature");
+  if (typeof featureValue !== "string") {
+    return featureValue;
+  }
+  if (!SAFE_FEATURE.test(featureValue)) {
+    return { ok: false, code: "bad-flag", error: `--feature must match ${SAFE_FEATURE.source}` };
+  }
+  const agents = parsePositiveInteger(flagString(args, "agents"), 0, "--agents");
+  if (typeof agents !== "number") {
+    return agents;
+  }
+  if (agents < 1) {
+    return { ok: false, code: "bad-flag", error: "--agents is required and must be positive" };
+  }
+
+  const command = flagString(args, "cmd");
+  if (command !== undefined && /[\r\n]/.test(command)) {
+    return { ok: false, code: "multiline-refused", error: "--cmd must be a single line" };
+  }
+
+  const sessionName = `race-${featureValue.replace(/ /g, "-")}`;
+  const cwd = flagString(args, "cwd");
+  const created = await createSession(sessionName, cwd, Math.max(200, 40 * agents), Math.max(50, 8 * agents));
+  if (!("sessionId" in created)) {
+    return created;
+  }
+  const configureError = await configureWindow(created.windowId, "#{pane_index}:#{pane_title}");
+  if (configureError !== undefined) {
+    return configureError;
+  }
+  await tmuxExec(["rename-window", "-t", created.windowId, sessionName]);
+
+  const panes: TrackedPane[] = [{ id: created.paneId, role: "race-1" }];
+  for (let index = 1; index < agents; index += 1) {
+    const paneId = await splitPane(created.paneId, false, undefined, cwd);
+    if (typeof paneId !== "string") {
+      return { ...paneId, createdSoFar: panes as unknown as JsonValue, session: created.sessionId };
+    }
+    await applyLayout(created.windowId, "main-vertical");
+    panes.push({ id: paneId, role: `race-${index + 1}` });
+  }
+  await applyLayout(created.windowId, "main-vertical");
+
+  for (const pane of panes) {
+    const titleError = await titlePane(pane.id, pane.role);
+    if (titleError !== undefined) {
+      return titleError;
+    }
+    if (command !== undefined) {
+      const sendError = await sendLiteral(pane.id, command, true);
+      if (sendError !== undefined) {
+        return sendError;
+      }
+    }
+  }
+
+  recordSession({
+    id: created.sessionId,
+    name: sessionName,
+    socket: socketKey(),
+    generation: created.generation,
+    kind: "race",
+    createdAt: new Date().toISOString(),
+    windows: [created.windowId],
+    panes,
+  });
+
+  const geometry = await listPaneGeometry(created.windowId);
+  return {
+    ok: true,
+    session: created.sessionId,
+    name: sessionName,
+    window: created.windowId,
+    generation: created.generation,
+    socket: socketKey(),
+    feature: featureValue,
+    command: command ?? null,
+    panes: panes as unknown as JsonValue,
+    geometry: Array.isArray(geometry) ? geometryJson(geometry) : null,
+    verified: Array.isArray(geometry) && geometry.length === agents,
+  };
+}
+
+function parseGrid(value: string | undefined): { rows: number; cols: number } | JsonObject {
+  const grid = value ?? "2x2";
+  const match = grid.match(/^([1-9][0-9]*)x([1-9][0-9]*)$/i);
+  if (!match) {
+    return { ok: false, code: "bad-flag", error: "--grid must be in RxC form, for example 2x2" };
+  }
+  const rows = Number.parseInt(match[1], 10);
+  const cols = Number.parseInt(match[2], 10);
+  if (rows * cols > 64) {
+    return { ok: false, code: "bad-flag", error: "--grid may not exceed 64 panes" };
+  }
+  return { rows, cols };
+}
+
+/**
+ * select-layout tiled ignores the requested shape and computes its own
+ * near-square arrangement from the pane count: 1x5 and 5x1 both yield 3 rows by
+ * 2 columns. A real RxC grid has to be built explicitly. Percentages are chosen
+ * so each successive split leaves equal-sized siblings: splitting off (n-1)/n of
+ * the remaining space n-1 times produces n equal tracks.
+ */
+async function buildGrid(firstPane: string, rows: number, cols: number, cwd: string | undefined): Promise<string[][] | JsonObject> {
+  const rowPanes: string[] = [firstPane];
+  let cursor = firstPane;
+  for (let index = 0; index < rows - 1; index += 1) {
+    const percent = Math.round((100 * (rows - 1 - index)) / (rows - index));
+    const paneId = await splitPane(cursor, true, percent, cwd);
+    if (typeof paneId !== "string") {
+      return paneId;
+    }
+    rowPanes.push(paneId);
+    cursor = paneId;
+  }
+
+  const grid: string[][] = [];
+  for (const rowPane of rowPanes) {
+    const row = [rowPane];
+    let columnCursor = rowPane;
+    for (let index = 0; index < cols - 1; index += 1) {
+      const percent = Math.round((100 * (cols - 1 - index)) / (cols - index));
+      const paneId = await splitPane(columnCursor, false, percent, cwd);
+      if (typeof paneId !== "string") {
+        return paneId;
+      }
+      row.push(paneId);
+      columnCursor = paneId;
+    }
+    grid.push(row);
+  }
+  return grid;
+}
+
+async function commandFleet(args: ParsedArgs): Promise<JsonObject> {
+  const nameValue = requireFlag(args, "name");
+  if (typeof nameValue !== "string") {
+    return nameValue;
+  }
+  const grid = parseGrid(flagString(args, "grid"));
+  if (!("rows" in grid)) {
+    return grid;
+  }
+  const commands = (flagString(args, "cmds") ?? "")
+    .split(";")
+    .map((cmd) => cmd.trim())
+    .filter((cmd) => cmd.length > 0);
+  for (const command of commands) {
+    if (/[\r\n]/.test(command)) {
+      return { ok: false, code: "multiline-refused", error: "--cmds entries must each be a single line" };
+    }
+  }
+
+  const cwd = flagString(args, "cwd");
+  const created = await createSession(nameValue, cwd, Math.max(120, 60 * grid.cols), Math.max(30, 12 * grid.rows));
+  if (!("sessionId" in created)) {
+    return created;
+  }
+  const configureError = await configureWindow(created.windowId, "#{pane_index}:#{pane_title}");
+  if (configureError !== undefined) {
+    return configureError;
+  }
+  await tmuxExec(["rename-window", "-t", created.windowId, nameValue]);
+
+  const built = await buildGrid(created.paneId, grid.rows, grid.cols, cwd);
+  if (!Array.isArray(built)) {
+    return { ...built, session: created.sessionId, hint: "the window may be too small for the requested grid" };
+  }
+
+  const flat = built.flat();
+  const panes: TrackedPane[] = flat.map((id, index) => ({ id, role: `cell-${index + 1}` }));
+  for (let index = 0; index < panes.length; index += 1) {
+    const titleError = await titlePane(panes[index].id, panes[index].role);
+    if (titleError !== undefined) {
+      return titleError;
+    }
+    const command = commands[index];
+    if (command !== undefined) {
+      const sendError = await sendLiteral(panes[index].id, command, true);
+      if (sendError !== undefined) {
+        return sendError;
+      }
+    }
+  }
+
+  recordSession({
+    id: created.sessionId,
+    name: nameValue,
+    socket: socketKey(),
+    generation: created.generation,
+    kind: "fleet",
+    createdAt: new Date().toISOString(),
+    windows: [created.windowId],
+    panes,
+  });
+
+  // Geometry is measured, not assumed: distinct pane_top values must equal the
+  // requested row count, and every row must hold exactly the column count.
+  const geometry = await listPaneGeometry(created.windowId);
+  if (!Array.isArray(geometry)) {
+    return geometry;
+  }
+  const tops = [...new Set(geometry.map((pane) => pane.top))].sort((a, b) => a - b);
+  const perRow = tops.map((top) => geometry.filter((pane) => pane.top === top).length);
+  const verified = tops.length === grid.rows && perRow.every((count) => count === grid.cols);
+
+  return {
+    ok: true,
+    session: created.sessionId,
+    name: nameValue,
+    window: created.windowId,
+    generation: created.generation,
+    socket: socketKey(),
+    grid: { rows: grid.rows, cols: grid.cols },
+    cells: built.map((row, rowIndex) =>
+      row.map((id, colIndex) => {
+        const pane = geometry.find((candidate) => candidate.id === id);
+        return {
+          id,
+          row: rowIndex,
+          col: colIndex,
+          cmd: commands[rowIndex * grid.cols + colIndex] ?? null,
+          left: pane?.left ?? null,
+          top: pane?.top ?? null,
+          width: pane?.width ?? null,
+          height: pane?.height ?? null,
+        };
+      }),
+    ) as unknown as JsonValue,
+    verified,
+    measured: { distinctRows: tops.length, panesPerRow: perRow as unknown as JsonValue },
+  };
+}
+
+function parseHostsCsv(value: string): HostConfig[] {
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+    .map((entry) => {
+      const equalsIndex = entry.indexOf("=");
+      if (equalsIndex === -1) {
+        return { name: entry, ssh: entry };
+      }
+      return { name: entry.slice(0, equalsIndex).trim(), ssh: entry.slice(equalsIndex + 1).trim() };
+    });
+}
+
+function isHostConfig(value: unknown): value is HostConfig {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return typeof record.name === "string" && typeof record.ssh === "string";
+}
+
+const FLEET_CONFIG_RELATIVE = ".claude/LIFEOS/USER/CUSTOMIZATIONS/SKILLS/TMUX/fleet.json";
+
+function loadFleetConfig(): HostConfig[] | JsonObject {
+  const configPath = join(homedir(), FLEET_CONFIG_RELATIVE);
+  if (!existsSync(configPath)) {
+    return {
+      ok: false,
+      code: "no-fleet-config",
+      error:
+        "No hosts configured. Pass --hosts name=ssh,name2=ssh2 or create " +
+        `~/${FLEET_CONFIG_RELATIVE.replace(/^\.claude\//, ".claude/")} with ` +
+        '{"hosts":[{"name":"...","ssh":"..."}]}',
+    };
+  }
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(configPath, "utf8"));
+    if (typeof parsed !== "object" || parsed === null) {
+      return { ok: false, code: "bad-fleet-config", error: "fleet.json must contain an object" };
+    }
+    const hosts = (parsed as Record<string, unknown>).hosts;
+    if (!Array.isArray(hosts) || !hosts.every(isHostConfig)) {
+      return {
+        ok: false,
+        code: "bad-fleet-config",
+        error: 'fleet.json must have shape {"hosts":[{"name":"...","ssh":"..."}]}',
+      };
+    }
+    return hosts;
+  } catch (error) {
+    return {
+      ok: false,
+      code: "bad-fleet-config",
+      error: `Failed to read fleet.json: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+function validateHost(host: HostConfig): JsonObject | undefined {
+  if (!SAFE_NAME.test(host.name)) {
+    return { ok: false, code: "bad-host", error: `Host name must match ${SAFE_NAME.source}` };
+  }
+  if (!SAFE_SSH_TARGET.test(host.ssh)) {
+    return { ok: false, code: "bad-host", error: `SSH target for ${host.name} contains unsupported characters` };
+  }
+  return undefined;
+}
+
+async function commandMiniFleet(args: ParsedArgs): Promise<JsonObject> {
+  const hostFlag = flagString(args, "hosts");
+  const hosts = hostFlag !== undefined ? parseHostsCsv(hostFlag) : loadFleetConfig();
+  if (!Array.isArray(hosts)) {
+    return hosts;
+  }
+  if (hosts.length === 0) {
+    return { ok: false, code: "no-hosts", error: "No hosts configured" };
+  }
+  for (const host of hosts) {
+    const invalid = validateHost(host);
+    if (invalid !== undefined) {
+      return invalid;
+    }
+  }
+
+  const sessionName = flagString(args, "name") ?? "mini-fleet";
+  const created = await createSession(sessionName, undefined, Math.max(200, 40 * hosts.length), Math.max(50, 8 * hosts.length));
+  if (!("sessionId" in created)) {
+    return created;
+  }
+  const configureError = await configureWindow(created.windowId, "#{pane_index}:#{pane_title}");
+  if (configureError !== undefined) {
+    return configureError;
+  }
+  await tmuxExec(["rename-window", "-t", created.windowId, sessionName]);
+
+  const panes: TrackedPane[] = [{ id: created.paneId, role: hosts[0].name }];
+  for (let index = 1; index < hosts.length; index += 1) {
+    const paneId = await splitPane(created.paneId, false, undefined, undefined);
+    if (typeof paneId !== "string") {
+      return { ...paneId, session: created.sessionId };
+    }
+    await applyLayout(created.windowId, "main-vertical");
+    panes.push({ id: paneId, role: hosts[index].name });
+  }
+  await applyLayout(created.windowId, "main-vertical");
+
+  for (let index = 0; index < panes.length; index += 1) {
+    const titleError = await titlePane(panes[index].id, panes[index].role);
+    if (titleError !== undefined) {
+      return titleError;
+    }
+    const sendError = await sendLiteral(panes[index].id, `ssh ${hosts[index].ssh}`, true);
+    if (sendError !== undefined) {
+      return sendError;
+    }
+  }
+
+  recordSession({
+    id: created.sessionId,
+    name: sessionName,
+    socket: socketKey(),
+    generation: created.generation,
+    kind: "mini-fleet",
+    createdAt: new Date().toISOString(),
+    windows: [created.windowId],
+    panes,
+  });
+
+  const geometry = await listPaneGeometry(created.windowId);
+  return {
+    ok: true,
+    session: created.sessionId,
+    name: sessionName,
+    window: created.windowId,
+    generation: created.generation,
+    socket: socketKey(),
+    source: hostFlag !== undefined ? "--hosts" : `~/${FLEET_CONFIG_RELATIVE}`,
+    hosts: panes.map((pane, index) => ({ pane: pane.id, name: hosts[index].name, ssh: hosts[index].ssh })) as unknown as JsonValue,
+    geometry: Array.isArray(geometry) ? geometryJson(geometry) : null,
+    verified: Array.isArray(geometry) && geometry.length === hosts.length,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Topology
+// ---------------------------------------------------------------------------
+
+type TopologyPane = {
+  id: string;
+  index: number;
+  dead: boolean;
+  deadStatus: string;
+  pid: number;
+  currentCommand: string;
+  width: number;
+  height: number;
+  left: number;
+  top: number;
+  title: string;
+};
+
+async function listPanesDetailed(sessionFilter: string | undefined): Promise<Array<TopologyPane & { session: string; sessionName: string; window: string; windowName: string }> | JsonObject> {
+  const scope = sessionFilter === undefined ? ["-a"] : ["-s", "-t", sessionFilter];
+  const result = await tmuxExec([
+    "list-panes",
+    ...scope,
+    "-F",
+    [
+      "#{session_id}",
+      "#{session_name}",
+      "#{window_id}",
+      "#{window_name}",
+      "#{pane_id}",
+      "#{pane_index}",
+      "#{pane_dead}",
+      "#{pane_dead_status}",
+      "#{pane_pid}",
+      "#{pane_current_command}",
+      "#{pane_width}",
+      "#{pane_height}",
+      "#{pane_left}",
+      "#{pane_top}",
+      // pane_title is LAST and is the only free-form field. pane_current_path is
+      // never included: it carries raw filesystem bytes that can contain the
+      // delimiter or a newline, and neither #{q:} nor a base64 modifier can
+      // escape it in tmux 3.6.
+      "#{pane_title}",
+    ].join(FIELD_DELIMITER),
+  ]);
+  if (result.code !== 0) {
+    if (/no server running|error connecting/i.test(result.stderr)) {
+      return [];
+    }
+    return resultError(result, "list-panes failed");
+  }
+
+  return nonEmptyLines(result.stdout).map((line) => {
+    const f = splitRecord(line, 14);
+    return {
+      session: f[0],
+      sessionName: f[1],
+      window: f[2],
+      windowName: f[3],
+      id: f[4],
+      index: Number.parseInt(f[5], 10),
+      dead: f[6] === "1",
+      deadStatus: f[7] ?? "",
+      pid: Number.parseInt(f[8], 10),
+      currentCommand: f[9] ?? "",
+      width: Number.parseInt(f[10], 10),
+      height: Number.parseInt(f[11], 10),
+      left: Number.parseInt(f[12], 10),
+      top: Number.parseInt(f[13], 10),
+      title: f[14] ?? "",
+    };
+  });
+}
+
+async function commandTree(args: ParsedArgs): Promise<JsonObject> {
+  const sessionFilter = flagString(args, "session");
+  if (sessionFilter !== undefined && !isSessionId(sessionFilter)) {
+    return rejectNonId(sessionFilter, "session");
+  }
+
+  const panes = await listPanesDetailed(sessionFilter);
+  if (!Array.isArray(panes)) {
+    return panes;
+  }
+
+  const generation = await currentGeneration();
+  const tracked = trackedForSocket(loadState());
+  const trackedIds = new Set(tracked.filter((s) => s.generation === generation).map((s) => s.id));
+  const roleByPane = new Map<string, string>();
+  for (const session of tracked) {
+    if (session.generation !== generation) continue;
+    for (const pane of session.panes) {
+      roleByPane.set(pane.id, pane.role);
+    }
+  }
+
+  const sessions = new Map<string, { id: string; name: string; tracked: boolean; windows: Map<string, JsonObject> }>();
+  for (const pane of panes) {
+    let session = sessions.get(pane.session);
+    if (session === undefined) {
+      session = { id: pane.session, name: pane.sessionName, tracked: trackedIds.has(pane.session), windows: new Map() };
+      sessions.set(pane.session, session);
+    }
+    let window = session.windows.get(pane.window);
+    if (window === undefined) {
+      window = { id: pane.window, name: pane.windowName, panes: [] };
+      session.windows.set(pane.window, window);
+    }
+    (window.panes as JsonValue[]).push({
+      id: pane.id,
+      index: pane.index,
+      role: roleByPane.get(pane.id) ?? null,
+      title: pane.title,
+      dead: pane.dead,
+      deadStatus: pane.deadStatus,
+      pid: pane.pid,
+      currentCommand: pane.currentCommand,
+      left: pane.left,
+      top: pane.top,
+      width: pane.width,
+      height: pane.height,
+    });
+  }
+
+  return {
+    ok: true,
+    socket: socketKey(),
+    generation: generation ?? null,
+    sessions: [...sessions.values()].map((session) => ({
+      id: session.id,
+      name: session.name,
+      tracked: session.tracked,
+      windows: [...session.windows.values()] as unknown as JsonValue,
+    })) as unknown as JsonValue,
+    notes: [
+      "pane_current_path is deliberately absent: its raw bytes can contain the field delimiter or a newline.",
+      "pane_title defaults to the machine hostname, so an untitled pane is not an empty string.",
+      "currentCommand resolves one level only: a process under a wrapper reports the wrapper.",
+    ] as unknown as JsonValue,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Monitor
+// ---------------------------------------------------------------------------
+
+async function monitorPass(sessionFilter: string | undefined): Promise<MonitorPane[] | JsonObject> {
+  const panes = await listPanesDetailed(sessionFilter);
+  if (!Array.isArray(panes)) {
+    return panes;
+  }
+  const childCounts = await processChildCounts();
+
+  const states: MonitorPane[] = [];
+  for (const pane of panes) {
+    const signals: PaneSignals = {
+      exit: {
+        present: true,
+        dead: pane.dead,
+        status: pane.deadStatus,
+        state: pane.dead ? (pane.deadStatus === "0" ? "done" : "failed") : undefined,
+      },
+      process: { present: false, descendants: 0 },
+      screen: { present: false },
+    };
+
+    if (!pane.dead && Number.isFinite(pane.pid)) {
+      const descendants = childCounts.get(pane.pid) ?? 0;
+      signals.process = { present: true, descendants, state: descendants > 0 ? "working" : "idle" };
+    }
+
+    let textTail = "";
+    const captured = await capturePane(pane.id, MONITOR_TAIL_LINES);
+    if ("text" in captured) {
+      textTail = captured.text;
+      signals.screen = { present: true, state: classifyScreen(textTail) };
+    }
+
+    const resolved = resolveSignals(signals);
+    states.push({
+      id: pane.id,
+      session: pane.session,
+      window: pane.window,
+      title: pane.title,
+      state: resolved.state,
+      confidence: resolved.confidence,
+      signals,
+      disagreements: resolved.disagreements,
+      currentCommand: pane.currentCommand,
+      commandResolvedOneLevelOnly: true,
+      textTail,
+    });
+  }
+  return states;
+}
+
+async function commandMonitor(args: ParsedArgs): Promise<number> {
+  const interval = parsePositiveInteger(flagString(args, "interval"), 3, "--interval");
+  if (typeof interval !== "number") {
+    console.log(JSON.stringify(interval));
+    return 1;
+  }
+  const sessionFilter = flagString(args, "session");
+  if (sessionFilter !== undefined && !isSessionId(sessionFilter)) {
+    console.log(JSON.stringify(rejectNonId(sessionFilter, "session")));
+    return 1;
+  }
+
+  const once = flagBoolean(args, "once");
+  const quiet = flagBoolean(args, "no-voice");
+  const previous = new Map<string, PaneStateName>();
+  let stopping = false;
+
+  process.on("SIGINT", () => {
+    stopping = true;
+    process.stdout.write(`${JSON.stringify({ ok: true, stopped: true })}\n`);
+    process.exit(0);
+  });
+
+  while (!stopping) {
+    const pass = await monitorPass(sessionFilter);
+    if (!Array.isArray(pass)) {
+      console.log(JSON.stringify(pass));
+      return 1;
+    }
+
+    for (const pane of pass) {
+      const before = previous.get(pane.id);
+      // done/failed mean the pane's process exited and remain-on-exit preserved
+      // it. working->idle is the other completion signal and the common one: a
+      // command finished but its shell is still alive, so the pane never dies.
+      const label =
+        pane.state === "awaiting-input"
+          ? "awaiting input"
+          : pane.state === "failed"
+            ? `failed with status ${pane.signals.exit.status}`
+            : pane.state === "done"
+              ? "done"
+              : pane.state === "idle" && before === "working"
+                ? "back at a prompt"
+                : undefined;
+      if (before !== undefined && before !== pane.state && label !== undefined && !quiet) {
+        await notifyVoice(`tmux pane ${pane.id} ${pane.title} is ${label}`);
+      }
+      previous.set(pane.id, pane.state);
+    }
+
+    console.log(JSON.stringify({ ok: true, socket: socketKey(), panes: pass as unknown as JsonValue }));
+    if (once) {
+      return 0;
+    }
+    // tmux has no push API for pane state, so this polls until SIGINT.
+    await sleep(interval * 1_000);
+  }
+
+  console.log(JSON.stringify({ ok: true, stopped: true }));
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Flash
+// ---------------------------------------------------------------------------
+
+async function commandFlash(args: ParsedArgs): Promise<JsonObject> {
+  const targetValue = requireFlag(args, "target");
+  if (typeof targetValue !== "string") {
+    return targetValue;
+  }
+  if (!isTmuxId(targetValue)) {
+    return rejectNonId(targetValue, "target");
+  }
+
+  const windowResult = await tmuxExec(["display-message", "-p", "-t", targetValue, "#{window_id}"]);
+  if (windowResult.code !== 0) {
+    return resultError(windowResult, `could not resolve ${targetValue}`, "target-missing");
+  }
+  const windowId = windowResult.stdout.trim();
+  if (!isWindowId(windowId)) {
+    return { ok: false, code: "target-missing", error: `${targetValue} does not resolve to a live window on socket ${socketKey()}` };
+  }
+
+  const actions: string[] = [];
+  const message = await tmuxExec(["display-message", "-t", targetValue, `ATTENTION: ${targetValue}`]);
+  if (message.code === 0) {
+    actions.push("display-message");
+  }
+
+  try {
+    const styled = await tmuxExec(["set-option", "-w", "-t", windowId, "pane-border-style", "fg=red,bold"]);
+    const activeStyled = await tmuxExec(["set-option", "-w", "-t", windowId, "pane-active-border-style", "fg=red,bold"]);
+    if (styled.code === 0 && activeStyled.code === 0) {
+      actions.push("transient-border-style");
+    }
+    if (isPaneId(targetValue)) {
+      const selected = await tmuxExec(["select-pane", "-t", targetValue]);
+      if (selected.code === 0) {
+        actions.push("select-pane");
+      }
+    }
+    await sleep(FLASH_HOLD_MS);
+  } finally {
+    // Scoped to the window this tool created; -u restores the inherited value
+    // rather than writing the operator's global configuration.
+    await tmuxExec(["set-option", "-w", "-t", windowId, "-u", "pane-border-style"]);
+    await tmuxExec(["set-option", "-w", "-t", windowId, "-u", "pane-active-border-style"]);
+  }
+
+  let bell: string;
+  if (flagBoolean(args, "bell")) {
+    const paneId = await resolvePane(targetValue);
+    if (typeof paneId === "string") {
+      const rung = await tmuxExec(["send-keys", "-t", paneId, "-H", "07"]);
+      bell = rung.code === 0 ? "sent-as-input-byte" : "failed";
+      if (rung.code === 0) {
+        actions.push("bell");
+      }
+    } else {
+      bell = "failed";
+    }
+  } else {
+    bell = "skipped";
+  }
+
+  return {
+    ok: true,
+    target: targetValue,
+    window: windowId,
+    actions: actions as unknown as JsonValue,
+    bell,
+    degraded: true,
+    degradedReason:
+      "tmux has no GUI pulse. All of this is text on an ATTACHED client only: a detached operator sees none " +
+      "of it. --bell writes byte 0x07 into the pane's INPUT stream, which a live prompt or TUI may swallow or " +
+      "echo, so it is opt-in. Voice via monitor is the real attention mechanism.",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Voice
+// ---------------------------------------------------------------------------
+
+async function commandVoice(args: ParsedArgs): Promise<JsonObject> {
+  const message = args.positionals.join(" ");
+  if (message.trim() === "") {
+    return { ok: false, code: "missing-text", error: "Missing voice message positional" };
+  }
+  const notified = await notifyVoice(message);
+  return { ok: true, notified, endpoint: VOICE_URL };
+}
+
+// ---------------------------------------------------------------------------
+// Kill
+// ---------------------------------------------------------------------------
+
+async function commandKill(args: ParsedArgs): Promise<JsonObject> {
+  if (args.flags.all === true || args.flags.a === true) {
+    return {
+      ok: false,
+      code: "refused",
+      error:
+        "Refusing --all. tmux's kill-session -a kills every session EXCEPT the target, which on a shared server " +
+        "destroys the operator's own work. Kill IDs one at a time.",
+    };
+  }
+
+  const targetValue = requireFlag(args, "target");
+  if (typeof targetValue !== "string") {
+    return targetValue;
+  }
+  const kind = idKind(targetValue);
+  if (kind === "invalid") {
+    return rejectNonId(targetValue, "target");
+  }
+
+  const generation = await currentGeneration();
+  if (generation === undefined) {
+    return { ok: false, code: "no-server", error: "No tmux server is running on this socket" };
+  }
+
+  const state = loadState();
+  const tracked = trackedForSocket(state);
+  const owning = tracked.find(
+    (session) =>
+      session.id === targetValue ||
+      session.windows.includes(targetValue) ||
+      session.panes.some((pane) => pane.id === targetValue),
+  );
+
+  if (owning === undefined) {
+    return {
+      ok: false,
+      code: "not-owned",
+      error:
+        `${targetValue} was not created by this tool on socket ${socketKey()}, so it will not be destroyed. ` +
+        "This is the guard that stops a teardown reaching the operator's own sessions.",
+    };
+  }
+  if (owning.generation !== generation) {
+    return {
+      ok: false,
+      code: "stale-generation",
+      error:
+        `${targetValue} was recorded against server generation ${owning.generation} but the running server is ` +
+        `${generation}. tmux restarts IDs at $0/@0/%0, so this ID now points at a different object. Refusing.`,
+      recordedGeneration: owning.generation,
+      currentGeneration: generation,
+    };
+  }
+
+  const command = kind === "session" ? "kill-session" : kind === "window" ? "kill-window" : "kill-pane";
+  const result = await tmuxExec([command, "-t", targetValue]);
+  if (result.code !== 0) {
+    return resultError(result, `${command} failed`, "kill-failed");
+  }
+
+  if (kind === "session") {
+    state.sessions = state.sessions.filter((session) => !(session.socket === socketKey() && session.id === targetValue));
+  } else if (kind === "window") {
+    owning.windows = owning.windows.filter((window) => window !== targetValue);
+  } else {
+    owning.panes = owning.panes.filter((pane) => pane.id !== targetValue);
+  }
+  saveState(state);
+
+  return { ok: true, killed: targetValue, kind, session: owning.id, generation };
+}
+
+// ---------------------------------------------------------------------------
+// Doctor
+// ---------------------------------------------------------------------------
+
+async function commandDoctor(): Promise<JsonObject> {
+  const version = await runProcess(["tmux", "-V"], DEFAULT_TIMEOUT_MS);
+  if (version.code !== 0) {
+    return resultError(version, "tmux -V failed (is tmux installed?)", "tmux-missing");
+  }
+
+  const running = await serverRunning();
+  const generation = running ? await currentGeneration() : undefined;
+  const state = loadState();
+  const tracked = trackedForSocket(state);
+
+  const live: JsonValue[] = [];
+  const orphaned: JsonValue[] = [];
+  const warnings: string[] = [];
+
+  for (const session of tracked) {
+    if (session.generation !== generation) {
+      orphaned.push({
+        id: session.id,
+        name: session.name,
+        recordedGeneration: session.generation,
+        reason: "server generation no longer matches; IDs may now point elsewhere",
+        createdAt: session.createdAt,
+      });
+      continue;
+    }
+    const exists = await tmuxExec(["has-session", "-t", `=${session.name}`]);
+    if (exists.code !== 0) {
+      orphaned.push({ id: session.id, name: session.name, reason: "session no longer exists", createdAt: session.createdAt });
+      continue;
+    }
+
+    const windowChecks: JsonValue[] = [];
+    for (const windowId of session.windows) {
+      const remain = await tmuxExec(["show-options", "-w", "-t", windowId, "-v", "remain-on-exit"]);
+      const border = await tmuxExec(["show-options", "-w", "-t", windowId, "-v", "pane-border-status"]);
+      const rename = await tmuxExec(["show-options", "-w", "-t", windowId, "-v", "allow-rename"]);
+      const remainValue = remain.stdout.trim();
+      const borderValue = border.stdout.trim();
+      const renameValue = rename.stdout.trim();
+      if (remainValue !== "on") {
+        warnings.push(`${windowId} (${session.name}): remain-on-exit is ${remainValue || "off"}; an exited pane will vanish with no exit status`);
+      }
+      if (borderValue !== "top" && borderValue !== "bottom") {
+        warnings.push(`${windowId} (${session.name}): pane-border-status is ${borderValue || "off"}; role titles are invisible`);
+      }
+      if (renameValue === "on") {
+        warnings.push(`${windowId} (${session.name}): allow-rename is on; a pane's OSC 2 escape can clobber its role title`);
+      }
+      windowChecks.push({ window: windowId, remainOnExit: remainValue || "off", paneBorderStatus: borderValue || "off", allowRename: renameValue || "off" });
+    }
+
+    live.push({
+      id: session.id,
+      name: session.name,
+      kind: session.kind,
+      createdAt: session.createdAt,
+      panes: session.panes.length,
+      windows: windowChecks as unknown as JsonValue,
+    });
+  }
+
+  // This tool never uses paste-buffer, because named buffers are server-global,
+  // readable from any session, silently overwritten by a same-name load-buffer,
+  // and not trimmed by buffer-limit (which only trims automatic buffers).
+  // doctor still reports any that leaked from an older build or another caller.
+  const buffers = await tmuxExec(["list-buffers", "-F", "#{buffer_name}"]);
+  const leaked = buffers.code === 0 ? nonEmptyLines(buffers.stdout).filter((name) => name.startsWith(BUFFER_PREFIX)) : [];
+  if (leaked.length > 0) {
+    warnings.push(`${leaked.length} named buffer(s) with prefix ${BUFFER_PREFIX} are still on the server`);
+  }
+  if (orphaned.length > 0) {
+    warnings.push(`${orphaned.length} tracked session(s) are orphaned; they are ignored by kill and can be cleared from the state file`);
+  }
+  if (process.env.TMUX !== undefined) {
+    warnings.push("Running nested inside a tmux pane: this tool refuses to send keys into its own pane, and --socket targets a different server than the one hosting it");
+  }
+
+  return {
+    ok: true,
+    version: version.stdout.trim(),
+    socket: socketKey(),
+    serverRunning: running,
+    generation: generation ?? null,
+    nested: process.env.TMUX !== undefined,
+    nestedPane: process.env.TMUX_PANE ?? null,
+    statePath: statePath().replace(homedir(), "~"),
+    trackedSessions: live as unknown as JsonValue,
+    orphanedSessions: orphaned as unknown as JsonValue,
+    leakedBuffers: leaked as unknown as JsonValue,
+    warnings: warnings as unknown as JsonValue,
+    usesPasteBuffer: false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch
+// ---------------------------------------------------------------------------
+
+async function dispatch(command: string, args: ParsedArgs): Promise<JsonObject | number> {
+  switch (command) {
+    case "ping":
+      return await commandPing();
+    case "send":
+      return await commandSend(args);
+    case "read":
+      return await commandRead(args);
+    case "boot-team":
+      return await commandBootTeam(args);
+    case "race":
+      return await commandRace(args);
+    case "fleet":
+      return await commandFleet(args);
+    case "mini-fleet":
+      return await commandMiniFleet(args);
+    case "monitor":
+      return await commandMonitor(args);
+    case "list":
+    case "tree":
+      return await commandTree(args);
+    case "flash":
+      return await commandFlash(args);
+    case "voice":
+      return await commandVoice(args);
+    case "kill":
+      return await commandKill(args);
+    case "doctor":
+      return await commandDoctor();
+    default:
+      return { ok: false, code: "unknown-subcommand", error: `Unknown subcommand: ${command}` };
+  }
+}
+
+async function main(): Promise<number> {
+  const argv = process.argv.slice(2);
+  if (argv.length === 0 || argv[0] === "--help" || argv[0] === "-h" || argv[0] === "help") {
+    console.log(usageText());
+    return 0;
+  }
+
+  const command = argv[0];
+  const parsed = parseArgs(argv.slice(1));
+
+  const socketFlag = flagString(parsed, "socket") ?? process.env.TMUX_SKILL_SOCKET;
+  if (socketFlag !== undefined && socketFlag.trim() !== "") {
+    if (!SAFE_NAME.test(socketFlag)) {
+      console.log(JSON.stringify({ ok: false, code: "bad-flag", error: `--socket must match ${SAFE_NAME.source}` }));
+      return 1;
+    }
+    socketLabel = socketFlag;
+  }
+
+  const result = await dispatch(command, parsed);
+  if (typeof result === "number") {
+    return result;
+  }
+  console.log(JSON.stringify(result));
+  return result.ok === true ? 0 : 1;
+}
+
+try {
+  const code = await main();
+  process.exit(code);
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.log(JSON.stringify({ ok: false, code: "unhandled", error: message }));
+  process.exit(1);
+}

--- a/LifeOS/install/skills/TMUX/Workflows/AgentRace.md
+++ b/LifeOS/install/skills/TMUX/Workflows/AgentRace.md
@@ -1,0 +1,39 @@
+# AgentRace
+
+Race N agents at the same problem in one session, first to solve wins, kill the rest.
+
+## When
+
+A production bug where any one agent might solve it, but you cannot predict which framing lands. Instead of serial guessing, fan out and take the first correct answer. You spend compute, not wall-clock.
+
+## Run it
+
+```bash
+T=~/.claude/skills/TMUX/Tools/Tmux.ts
+bun $T race --feature checkout-500 --agents 4 --cwd ~/Projects/App \
+  --cmd "claude 'The /checkout endpoint 500s on empty cart. Find and fix it.'"
+```
+
+One session, four panes titled `race-1`..`race-4`, the same command in each, and the pane IDs returned. Omit `--cmd` to get bare shells you `send` into afterwards.
+
+## Watch for a winner
+
+```bash
+bun $T monitor --session '$7' --interval 3
+```
+
+`monitor` classifies each pane and speaks through Pulse the moment one finishes. Because `remain-on-exit` is set at boot, a pane that exits is retained with its real exit status, so a crash is distinguishable from a win — something a screen-text heuristic cannot do.
+
+## Take the winner, kill the losers
+
+```bash
+bun $T read --target %32 --lines 80        # the one that finished first
+bun $T kill --target %30                   # by ID, never by name
+bun $T kill --target %31
+```
+
+Teardown is ID-only by design. A name like `race` would prefix-match a longer session such as `race-archive` and destroy it silently, so the wrapper refuses bare names.
+
+## Why race instead of retry
+
+Serial retries pay the full latency of every failed attempt before you learn anything. A race pays one attempt's latency total and lets the problem's shape pick the winner: the agent whose framing fit the bug finishes first.

--- a/LifeOS/install/skills/TMUX/Workflows/BootTeam.md
+++ b/LifeOS/install/skills/TMUX/Workflows/BootTeam.md
@@ -1,0 +1,61 @@
+# BootTeam
+
+Boot a 3-tier orchestrator → lead → worker team in one tmux session, then drive it with send/read.
+
+## When
+
+You want a team laid out so you can watch every agent at once: a lead pane on the left, a worker column on the right, all in one session named after the team. Unlike a GUI cockpit, this survives your connection dropping.
+
+## Boot it
+
+```bash
+T=~/.claude/skills/TMUX/Tools/Tmux.ts
+bun $T boot-team --name auth-fix --cwd ~/Projects/App \
+  --tiers orchestrator,lead,worker,worker
+```
+
+Creates session `auth-fix`, puts the lead pane left and a worker column right, titles each pane by role, sets `remain-on-exit` so a crashed agent leaves evidence, and returns the session ID plus one pane ID per role:
+
+```json
+{"ok":true,"session":"$3",
+ "panes":[{"role":"orchestrator","pane":"%10"},
+          {"role":"lead","pane":"%11"},
+          {"role":"worker","pane":"%12"},
+          {"role":"worker","pane":"%13"}]}
+```
+
+Those IDs are your address book. Hold them, not pane indexes — indexes shift as panes open and close, IDs do not.
+
+## Drive it
+
+```bash
+# prompt the lead; --enter types AND submits
+bun $T send --target %11 --enter \
+  "You lead this team. Break the JWT refresh bug into two tasks, one per worker."
+
+# fan out
+bun $T send --target %12 --enter "Fix the token expiry check in src/auth/refresh.ts."
+
+# read anyone back
+bun $T read --target %12 --lines 40
+```
+
+`send` without `--enter` types without submitting. That distinction is real but it is **not a safety boundary**: any newline inside the text executes it regardless, which is why the wrapper refuses multi-line text unless `--enter` was passed. Never pipe another agent's output, a file, or a fetched page into `send` without stripping newlines.
+
+## Flat comms
+
+Every agent is a pane, so any agent can prompt any other agent. A worker that finishes early hands results sideways:
+
+```bash
+bun $T send --target %11 --enter "Task A merged, tests green. Free for more."
+```
+
+The tiers are a convention for layout and thinking, not a routing constraint.
+
+## Scale
+
+Verified from 1 to 9 tiers. The lead pane is split each time and the layout re-applied, so tier 7 does not hit `no space for new pane` the way naive successive splitting does.
+
+## Watch it
+
+Hand long-running observation to `Workflows/Monitor.md`, which classifies each pane and speaks when one finishes. To leave the team running and reattach later, see `Workflows/Persist.md`.

--- a/LifeOS/install/skills/TMUX/Workflows/Fleet.md
+++ b/LifeOS/install/skills/TMUX/Workflows/Fleet.md
@@ -1,0 +1,40 @@
+# Fleet
+
+Stand up named fleets — a local grid of agents, or one SSH pane per remote host.
+
+## Local grid
+
+```bash
+T=~/.claude/skills/TMUX/Tools/Tmux.ts
+bun $T fleet --name alpha --grid 2x2 \
+  --cmds "claude 'watch src/api';claude 'watch src/web';bun test --watch;btop"
+```
+
+Session `alpha`, a real 2×2 of panes, one command per cell, IDs returned. Fewer commands than cells leaves the extras as shells.
+
+The grid is built by explicit row and column splits and the geometry is verified, because `select-layout tiled` ignores the shape you asked for: it computes its own near-square arrangement from the pane count, so `1x5` and `5x1` both come out as 3 rows by 2 columns. `--grid 1x5` here gives one row of five.
+
+## Remote mini-fleet
+
+```bash
+bun $T mini-fleet                                    # hosts from USER config
+bun $T mini-fleet --hosts "box-a=user@box-a,box-b=user@box-b"   # ad hoc
+```
+
+Config lives at `~/.claude/LIFEOS/USER/CUSTOMIZATIONS/SKILLS/TMUX/fleet.json`, shape `{"hosts":[{"name":"box-a","ssh":"user@box-a"}]}`. No hostnames live in this skill — the config is private and user-owned.
+
+Each host becomes its own pane; from there `send` and `read` work exactly as they do locally. An SSH pane whose connection drops shows as a dead pane with its exit status rather than silently vanishing.
+
+## Identity and attention
+
+tmux has no GUI chrome, so per-fleet identity is pane titles, border status, and session-scoped styling:
+
+```bash
+bun $T flash --target %20 --bell
+```
+
+`flash` is `display-message` plus the terminal bell plus a transient border. It is a genuinely weaker signal than a GUI pulse and it only reaches an attached client. When nobody is attached — the normal case here — `monitor`'s voice notification is the real attention mechanism.
+
+## Reusable recipes
+
+The command IS the recipe. Save the exact `fleet` or `mini-fleet` invocation as a shell alias or one-line script and re-run it to rebuild the same team. Sessions also persist across disconnection, so a fleet often does not need rebuilding at all — reattach instead (`Workflows/Persist.md`).

--- a/LifeOS/install/skills/TMUX/Workflows/Monitor.md
+++ b/LifeOS/install/skills/TMUX/Workflows/Monitor.md
@@ -1,0 +1,36 @@
+# Monitor
+
+Watch a team without watching a screen, and get told when something finishes.
+
+## Run it
+
+```bash
+T=~/.claude/skills/TMUX/Tools/Tmux.ts
+bun $T monitor --session '$3'              # continuous, until SIGINT
+bun $T monitor --session '$3' --once       # single pass, for scripts
+bun $T monitor --session '$3' --interval 5 # poll spacing in seconds
+```
+
+Each pass prints one JSON object: every pane, its classification, and **how confident that classification is**.
+
+## How a state is decided
+
+Three signals, strongest first. The JSON says which one produced the answer, so a caller can tell a fact from a guess.
+
+| Signal | Strength | What it proves |
+|---|---|---|
+| `pane_dead` + `pane_dead_status` | definitive | the process exited, and its real exit code |
+| child-process walk from `pane_pid` | strong | something is genuinely still running |
+| screen-text heuristic | weak | the screen *looks* idle, done, or prompting |
+
+When signals disagree, the stronger one wins and the disagreement is reported rather than hidden.
+
+The weak layer is weak for a concrete reason: `pane_current_command` resolves only one level, so a process under a wrapper reports the wrapper. An agent launched as `bash run.sh` shows `bash` while the real work runs, which makes "back to a shell" a false finish signal from the first tick. Treat anything tagged low-confidence as a hint, not a result.
+
+## Voice
+
+On a transition into done or awaiting-input, `monitor` POSTs to Pulse at `localhost:31337/notify` so you hear about it. This is the attention mechanism that actually works when nobody is attached to the terminal.
+
+## What a false done costs
+
+A wrong "done" fires a notification, may cause an orchestrator to collect an empty result and move on, and may get a pane killed. That is why exit status is preferred over screen text wherever it exists, and why `remain-on-exit` is set at boot — without it an exited pane is destroyed and there is no status left to read.

--- a/LifeOS/install/skills/TMUX/Workflows/Persist.md
+++ b/LifeOS/install/skills/TMUX/Workflows/Persist.md
@@ -1,0 +1,45 @@
+# Persist
+
+Leave a team running after you disconnect, and pick it back up later. This is the capability CMUX does not have.
+
+## Why it works
+
+tmux sessions belong to a server that outlives its clients. Your SSH connection dropping, your terminal closing, and the leader process exiting all leave the work running. This is the reason to reach for this skill on a remote host rather than a GUI cockpit.
+
+What it does not survive: a reboot, or the tmux server being killed. Sessions are memory-resident.
+
+## Detach and reattach
+
+```bash
+T=~/.claude/skills/TMUX/Tools/Tmux.ts
+bun $T boot-team --name migration --tiers runner
+bun $T send --target %40 --enter "bun run migrate:prod"
+# ...disconnect, go home, come back...
+
+tmux ls -F '#{session_id} #{session_name} #{session_attached}'
+tmux attach -t '$5'          # detach again with the prefix key, then d
+```
+
+From inside an attached session the prefix key (`C-b` by default) then `d` detaches without stopping anything.
+
+## Inspect without attaching
+
+Reading does not require a client, which matters when you are checking on work from a script or another machine:
+
+```bash
+bun $T read --target %40 --lines 100
+bun $T monitor --session '$5' --once
+```
+
+## Cleaning up
+
+```bash
+bun $T kill --target '$5'      # ID, never a name
+bun $T doctor                  # lists sessions this tool created and any leaked buffers
+```
+
+`doctor` exists because detached work is easy to forget. It reports orphaned sessions from earlier runs so they do not accumulate silently.
+
+## The one thing to be careful about
+
+Never tear down by name. tmux resolves a target as exact match, then glob, then **unambiguous prefix** — so `kill-session -t migration` will destroy `migration-archive` if that is the only other match, with exit code 0 and no warning. The wrapper refuses bare names for this reason; if you are typing raw tmux instead, anchor the name (`-t '=migration'`) or use the session ID.


### PR DESCRIPTION
## What this is

`CMUX` gives LifeOS a scriptable agent cockpit, and it is macOS-only. Its own SKILL.md says where the gap is: *"No Linux/WSL — that path is tmux."* That path was never built. This is it — same subcommand surface, same recipes, different substrate, so the two skills read alike and muscle memory transfers.

## Parity with CMUX

**13 of 16 capabilities full or better, 2 degraded, 1 absent.** The gaps are stated in SKILL.md rather than quietly omitted:

- **Degraded:** `flash` and per-team colour identity become `display-message` + terminal bell + border styling instead of GUI chrome, and none of it reaches a detached client. `monitor`'s voice notification through Pulse is the attention mechanism that actually works headless.
- **Absent:** the in-app browser pane. tmux has no such object; not closeable.

Three capabilities tmux adds that CMUX cannot do at all: sessions survive disconnection, `#{pane_dead_status}` gives real exit codes so a crashed agent is distinguishable from a finished one, and `-F` templates return structured topology instead of the ~30 lines of regex in `cmux.ts` that try to recover object refs from human-readable stdout.

## Gotchas, all measured

Several of these were found because they broke a first attempt. They are in SKILL.md because the next person will hit them too.

| Behaviour | Consequence |
|---|---|
| A newline executes the text — `send-keys -l` **and all four `paste-buffer` variants** ran the payload | The control is the payload, not the transport. The wrapper refuses multi-line text unless `--enter` was passed. Nothing here claims paste-buffer is safe. |
| `-t` resolves exact → fnmatch → **unambiguous prefix** | `kill-session -t production` destroys `production-work`, exit 0, no warning. Teardown is ID-only, with a server-generation token so a stale ID cannot retarget after a restart. |
| `remain-on-exit` is a **window** option; the session-scoped form silently no-ops | Without it set with `-w`, an exited pane is destroyed and the exit status goes with it — a crashed agent leaves no evidence. |
| `capture-pane -S -N` is a scrollback **offset**, not a line count | Asking for 10 on a 24-row pane returns 34. Uses `-S -` and takes the last N. |
| `select-layout tiled` **ignores the requested grid** | `1x5` and `5x1` both produce 3×2. Grids are built by explicit row/column splits and the geometry is verified. |
| Naive successive splits halve exponentially | `no space for new pane` around 7 panes. Splits the lead each time and re-applies `main-vertical`. |
| `pane_current_command` resolves one level | `bash run.sh` reports `bash`, so "back to a shell" is a false finish signal. `monitor` layers signals and labels the weak one low-confidence in its JSON. |
| Global `-g` hooks/options reach sessions you never created | And `set-hook -gu` cleanup strips the operator's own. Everything is session-scoped. |

## Verification

A 25-case parity suite against a real tmux 3.6 server, on a private `-L` socket. **25 passed, 0 failed**, including the cases that break naive implementations:

```
✓ 4 tiers -> 4 panes                    ✓ 7 tiers -> 7 panes, no space error
✓ role titles applied                   ✓ send --enter then read sees output
✓ no-enter does not execute             ✓ multi-line send refused, for the right reason
✓ race --agents 4 -> 4 panes            ✓ race-N titles applied
✓ 2x2 -> 2 rows x 2 cols                ✓ 1x5 -> 1 row x 5 cols (tiled fails this)
✓ 2 hosts -> 2 panes                    ✓ monitor labels signal confidence
✓ exited pane retained, status=7        ✓ list parses as structured JSON
✓ kill refuses a bare name / prefix     ✓ neighbouring session survived
✓ kill by session ID works              ✓ killed session is gone
```

The refusal assertions check the *reason*, not just `ok:false` — an earlier version of the suite passed those cases because the command had errored for an unrelated reason, which is exactly the false green this skill is meant to prevent.

`Tools/Tmux.ts` type-checks clean under `bun build --target bun`. Public-clean grep for identity, home paths and hostnames returns zero matches; remote hosts come from `USER/CUSTOMIZATIONS/SKILLS/TMUX/fleet.json`.

## Scope note

This does not replace the built-in split-pane teammates. `teammateMode` (`in-process` | `auto` | `tmux` | `iterm2`) already gives visible teammate panes when the leader is running inside tmux, and those teammates inherit the lead's permission mode with prompts bubbling up for approval. This skill is for what that cannot serve: a leader with no attached terminal, work that must outlive the connection, non-Claude processes, and TUIs with no API. SKILL.md states plainly that an agent started by typing `claude ...` into a pane is a sibling process outside the session's permission envelope.
