### PR TITLE
fix(upgrade): scope the claude-code-guide freshness spawn to survive its context window

### DIFF
--- a/LifeOS/install/skills/Upgrade/SKILL.md
+++ b/LifeOS/install/skills/Upgrade/SKILL.md
@@ -151,6 +151,7 @@ These output patterns are **FAILURES**:
 - **Check ALL sources in parallel** — Anthropic blog, changelog, YouTube channels, GitHub releases. Don't check sequentially.
 - **Upgrades must not break existing skills or workflows.** Verify backward compatibility before applying.
 - **Full upgrade check can take 5-7 minutes.** Use `run_in_background: true` for the outer agent.
+- **Keep the `claude-code-guide` spawn to three areas or fewer.** That agent runs on a small-context model (haiku, 200k). Asking one spawn to cover the whole API surface makes it fan out a batch of doc fetches whose results exceed the window on the next request, and it dies with `Prompt is too long` about ten seconds in — returning nothing, while the sibling `Explore` agents in the same batch all succeed. The prompt length is not the problem; the tool-result volume is. Split the surface across parallel spawns and tell it to look things up rather than pull whole pages. If one dies anyway, fall back to the `claude-code/CHANGELOG.md` raw URL in `sources.json`. *(2026-07-26.)*
 
 ## Execution Log
 

--- a/LifeOS/install/skills/Upgrade/Workflows/Upgrade.md
+++ b/LifeOS/install/skills/Upgrade/Workflows/Upgrade.md
@@ -114,7 +114,13 @@ Return within 90s; reduce per_page to 3 if slow.
 
 Spawn `Agent(subagent_type="claude-code-guide", run_in_background: true)`:
 
-Verify LifeOS's Claude Code references against the latest API surface. Check: hook event types, slash commands, agent/subagent types, settings.json fields, MCP integration, Agent SDK, Claude API. For each area, return current features, recent additions, deprecated items, and LifeOS staleness risk (LOW/MEDIUM/HIGH). Focus on changes affecting hooks, skills, or Algorithm. Return within 90s.
+Verify LifeOS's Claude Code references against the latest API surface. For each area, return current features, recent additions, deprecated items, and LifeOS staleness risk (LOW/MEDIUM/HIGH). Focus on changes affecting hooks, skills, or Algorithm. Return within 90s.
+
+**Ask for at most three areas per spawn, and say to look things up rather than pull whole pages.** `claude-code-guide` runs on a small-context model (haiku, 200k), so it is the tool-result volume that kills it, not the prompt. A single spawn covering the full surface — hook events, settings fields, slash commands, SKILL.md frontmatter, subagent frontmatter, MCP, Agent SDK, Claude API — makes it fan out a batch of doc fetches whose combined results exceed the window on the very next request, and the agent dies with `Prompt is too long` about ten seconds in, before returning anything. Observed 2026-07-26.
+
+Split the surface across parallel spawns instead — e.g. one for hooks + settings + subagent frontmatter, one for skills + slash commands + MCP, one for Agent SDK + Claude API. Losing one spawn then costs one slice rather than the whole freshness check.
+
+If a spawn does die this way, the changelog is the fallback: `WebFetch` the `claude-code/CHANGELOG.md` raw URL already listed in `sources.json` and read the version range directly.
 
 Output feeds Step 5 (Filter and Score) as source type `Claude Code Guide` and is cross-referenced against current LifeOS files for staleness.
 


### PR DESCRIPTION
## What happened

The Upgrade skill's Step 2a freshness check spawns `claude-code-guide` and asks it to cover the whole Claude Code API surface in one go — hook event types, `settings.json` fields, slash commands, `SKILL.md` frontmatter, subagent frontmatter, MCP, Agent SDK and Claude API.

On a real run it died with `Prompt is too long` about ten seconds after spawn, returning nothing. Five sibling `Explore` agents dispatched in the same batch all completed normally.

## Why

`claude-code-guide` runs on a small-context model — the spawn record shows `"model":"haiku"`, which is a 200k window, and no model was passed at the call site.

The prompt itself is not the problem. Ruled out by measurement:

- The prompt was ~200 words.
- The parent conversation was 76,754 tokens at spawn — comfortably under 200k, so inherited context does not explain it either.
- **Control:** a deliberately trivial prompt (`Reply with exactly the word: OK`) to the same agent type, in the same session, spawned when the parent conversation was **larger**, completed normally and returned `OK`.

Same agent, same model pin, same inherited context, opposite outcome — the only variable is how much the prompt makes it fetch. A request that broad makes the agent fan out a batch of documentation lookups in its first turn, and their combined results exceed the window on the very next request. The ~10s timing matches a first tool-call turn returning rather than any slow accumulation.

## The fix

- Cap the ask at **three areas per spawn**, and tell it to look things up rather than pull whole pages.
- Split the surface across parallel spawns, so losing one costs a slice instead of the entire freshness check.
- Record the fallback: the `claude-code/CHANGELOG.md` raw URL is already in `sources.json`, and reading the version range directly answers most freshness questions without an agent at all.
- Add the lesson to the skill's `## Gotchas`, including the diagnostic tell — the sibling agents succeed while this one dies, which points at the model rather than the batch.
