### PR TITLE
docs: document ripgrep and ImageMagick as external tools; add both to Doctor

### DIFF
--- a/LifeOS/GETTING-STARTED.md
+++ b/LifeOS/GETTING-STARTED.md
@@ -29,6 +29,24 @@ Run it whenever anything feels off. Every ❌ line carries its own fix command. 
 - **Auth:** none.
 - **Verify:** `Doctor.ts` → interceptor ✅ (skill present + browser found).
 
+## ripgrep — fast filesystem search
+
+**Powers:** ContextSearch queries, the work sweep, and the model-drift scan. LifeOS treats the filesystem as its index instead of a vector store, so shipped tools shell out to `rg` directly.
+
+- **Install:** `brew install ripgrep` (Linux: `sudo apt-get install ripgrep`)
+- **Auth:** none.
+- **Verify:** `Doctor.ts` → ripgrep ✅
+- **Note:** the built-in `Grep` tool is already ripgrep-backed and works regardless; this is for the tools that spawn `rg` themselves.
+
+## ImageMagick — image inspection
+
+**Powers:** Interceptor's blank-frame guard, its measured zoom, and Art's composition steps.
+
+- **Install:** `brew install imagemagick` (Linux: `sudo apt-get install imagemagick`)
+- **Auth:** none.
+- **Verify:** `Doctor.ts` → imagemagick ✅
+- **Note:** without it, `Capture.sh` still returns a screenshot but prints `BLANK-FRAME GUARD SKIPPED` — the capture is then unchecked for a black or blank frame, so don't cite it as pixel-verified without looking at it yourself.
+
 ## Cloudflare / wrangler — scheduled cloud flows
 
 **Powers:** the "runs while you sleep" layer (Arbol) and Worker deploys.

--- a/LifeOS/install/LIFEOS/TOOLS/Doctor.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/Doctor.ts
@@ -162,6 +162,30 @@ const CAPS: CapSpec[] = [
     fixCmd: 'install Google Chrome (or Brave), then re-run: bun LIFEOS/TOOLS/Doctor.ts',
   },
   {
+    id: 'ripgrep',
+    title: 'Fast filesystem search (ripgrep)',
+    powers: 'ContextSearch queries, work sweeps, and the model-drift scan',
+    ttlHours: 24 * 7,
+    configured: () => true, // shipped code shells out to `rg`; absence is broken, not unconfigured
+    probeOffline: async () =>
+      which('rg')
+        ? { ok: true, detail: 'rg on PATH' }
+        : { ok: false, detail: 'rg not on PATH — tools that shell out to it will fail' },
+    fixCmd: 'brew install ripgrep  (Linux: sudo apt-get install ripgrep)',
+  },
+  {
+    id: 'imagemagick',
+    title: 'Image inspection (ImageMagick)',
+    powers: "Interceptor's blank-frame guard, measured zoom, and Art composition",
+    ttlHours: 24 * 7,
+    configured: () => true, // the capture guard and Art both shell out to `magick`
+    probeOffline: async () =>
+      which('magick')
+        ? { ok: true, detail: 'magick on PATH' }
+        : { ok: false, detail: 'magick not on PATH — the blank-frame guard skips and captures go unchecked' },
+    fixCmd: 'brew install imagemagick  (Linux: sudo apt-get install imagemagick)',
+  },
+  {
     id: 'cloudflare',
     title: 'Scheduled cloud flows (Cloudflare/wrangler)',
     powers: 'Arbol scheduled flows and Worker deploys',


### PR DESCRIPTION
`GETTING-STARTED.md` is the page that lists the external tools doctrine uses, and it opens with a promise: *"None are required — every one degrades honestly when absent."* Two tools that shipped code shells out to were missing from it, and from Doctor's registry.

## ripgrep

`ContextSearch/Tools/ContextSearch.ts` spawns `rg` directly, as do the work sweep and `UpdateModels.ts`'s drift scan. LifeOS indexes through the filesystem instead of a vector store, so this is load-bearing rather than a style preference — the architecture doc says as much ("fast search such as with Ripgrep can give us everything people usually want from a RAG system").

Worth separating: the built-in `Grep` tool is independently ripgrep-backed and unaffected. This is only about the tools that spawn `rg` themselves.

## ImageMagick

Interceptor's blank-frame guard and Art's composition steps both spawn `magick`.

`Capture.sh` already handles absence well — it returns the screenshot but prints `BLANK-FRAME GUARD SKIPPED (imagemagick-absent) — do not treat it as pixel-verified without looking`, with an install hint. That is exactly the honest degradation the page promises. The gap was that nothing told you beforehand, so the first signal was a warning mid-verification.

## Changes

- Both added to Doctor's capability registry, so they surface as ✅/❌ with a fix command like every other tool, and can be `decline`d.
- Both documented in `GETTING-STARTED.md` in the same shape as the existing entries, with the ImageMagick note recording what actually happens when it is absent.

## Verified

`Doctor.ts` run with both binaries present → both report ✅ live. The same `which()` logic run against a PATH with `rg` and `magick` stripped → both report broken and surface their fix command. Doctor's existing capabilities are unchanged in both runs.
