### PR TITLE
docs: document the remaining external tools (gh, ffmpeg, yt-dlp, fabric, jq) and add them to Doctor

### DIFF
--- a/LifeOS/GETTING-STARTED.md
+++ b/LifeOS/GETTING-STARTED.md
@@ -95,7 +95,7 @@ These are narrower — tied to one terminal, one platform, or one opt-in workflo
 
 | Tool | Powers | Install |
 |------|--------|---------|
-| `rtk` | Transparent command compression on the Bash pre-tool hook. Skips silently without it (also needs `jq`). | see the rtk project |
+| `rtk` | Transparent command compression on the Bash pre-tool hook — compresses what the model *watches* (git status, test and build runs), never what it *reads*. Skips silently without it (also needs `jq`). | [rtk-ai/rtk](https://github.com/rtk-ai/rtk) — `brew install rtk`, or take the release binary. **Do not run `rtk init -g`**: that installs rtk's own global hook alongside LifeOS's `ContextReduction.hook.sh` and you get two rewriters on the same command. rtk also keeps a local `history.db` of proxied commands, and its telemetry is opt-in — `rtk telemetry disable` makes that explicit. |
 | `kitten` | Terminal tab naming and the retro banner, on the kitty terminal only. | ships with [kitty](https://sw.kovidgoyal.net/kitty/) |
 | `cmux` | The CMUX agent cockpit skill. macOS only — on Linux use the TMUX skill instead. | see the cmux project |
 | `mkcert` | Local HTTPS certificates during Pulse setup. Pulse runs over HTTP without it. | `brew install mkcert` |

--- a/LifeOS/GETTING-STARTED.md
+++ b/LifeOS/GETTING-STARTED.md
@@ -29,6 +29,78 @@ Run it whenever anything feels off. Every ❌ line carries its own fix command. 
 - **Auth:** none.
 - **Verify:** `Doctor.ts` → interceptor ✅ (skill present + browser found).
 
+## ripgrep — fast filesystem search
+
+**Powers:** ContextSearch queries, the work sweep, and the model-drift scan. LifeOS treats the filesystem as its index instead of a vector store, so shipped tools shell out to `rg` directly.
+
+- **Install:** `brew install ripgrep` (Linux: `sudo apt-get install ripgrep`)
+- **Auth:** none.
+- **Verify:** `Doctor.ts` → ripgrep ✅
+- **Note:** the built-in `Grep` tool is already ripgrep-backed and works regardless; this is for the tools that spawn `rg` themselves.
+
+## ImageMagick — image inspection
+
+**Powers:** Interceptor's blank-frame guard, its measured zoom, and Art's composition steps.
+
+- **Install:** `brew install imagemagick` (Linux: `sudo apt-get install imagemagick`)
+- **Auth:** none.
+- **Verify:** `Doctor.ts` → imagemagick ✅
+- **Note:** without it, `Capture.sh` still returns a screenshot but prints `BLANK-FRAME GUARD SKIPPED` — the capture is then unchecked for a black or blank frame, so don't cite it as pixel-verified without looking at it yourself.
+
+## gh — the work system of record
+
+**Powers:** work capture, the work and commitment sweeps, `TASKLIST.md` regeneration, and the Pulse Work tab. The Work System keeps its system of record in a private GitHub repo, and every reader reaches it through `gh`.
+
+- **Install:** `brew install gh` (Linux: see [cli.github.com](https://cli.github.com))
+- **Auth:** `gh auth login`
+- **Verify:** `Doctor.ts` → gh ✅
+- **Note:** the tools that use it spawn `gh` with no fallback, so without it work capture fails rather than degrading. This is the one on this list most worth installing first.
+
+## ffmpeg — audio and video
+
+**Powers:** AudioEditor's cutting pipeline, transcript splitting for long recordings, Conveyor renders, and Interceptor's zoom fallback when ImageMagick is absent.
+
+- **Install:** `brew install ffmpeg` (Linux: `sudo apt-get install ffmpeg`)
+- **Auth:** none.
+- **Verify:** `Doctor.ts` → ffmpeg ✅
+
+## yt-dlp — YouTube ingestion
+
+**Powers:** the Feed system's YouTube source and the Upgrade skill's channel scan.
+
+- **Install:** `brew install yt-dlp` (Linux: `sudo apt-get install yt-dlp`)
+- **Auth:** none.
+- **Verify:** `Doctor.ts` → ytdlp ✅
+
+## fabric — prompt patterns
+
+**Powers:** the Fabric skill's pattern library and its YouTube transcript fetch.
+
+- **Install:** see [github.com/danielmiessler/fabric](https://github.com/danielmiessler/fabric)
+- **Auth:** per fabric's own setup.
+- **Verify:** `Doctor.ts` → fabric ✅
+
+## jq — JSON in shell hooks
+
+**Powers:** the shell hooks that parse JSON, including the command-compression rewrite.
+
+- **Install:** `brew install jq` (Linux: `sudo apt-get install jq`)
+- **Auth:** none.
+- **Verify:** `Doctor.ts` → jq ✅
+- **Note:** hooks that need it check first and skip silently when it's missing, so absence costs the feature, never the tool call.
+
+## Smaller optional tools
+
+These are narrower — tied to one terminal, one platform, or one opt-in workflow — so the Doctor doesn't check them. Each is skipped cleanly when absent.
+
+| Tool | Powers | Install |
+|------|--------|---------|
+| `rtk` | Transparent command compression on the Bash pre-tool hook. Skips silently without it (also needs `jq`). | see the rtk project |
+| `kitten` | Terminal tab naming and the retro banner, on the kitty terminal only. | ships with [kitty](https://sw.kovidgoyal.net/kitty/) |
+| `cmux` | The CMUX agent cockpit skill. macOS only — on Linux use the TMUX skill instead. | see the cmux project |
+| `mkcert` | Local HTTPS certificates during Pulse setup. Pulse runs over HTTP without it. | `brew install mkcert` |
+| `gws` | Pulse job-output email and the Conveyor YouTube OAuth client. | see the gws project |
+
 ## Cloudflare / wrangler — scheduled cloud flows
 
 **Powers:** the "runs while you sleep" layer (Arbol) and Worker deploys.

--- a/LifeOS/install/LIFEOS/TOOLS/Doctor.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/Doctor.ts
@@ -162,6 +162,90 @@ const CAPS: CapSpec[] = [
     fixCmd: 'install Google Chrome (or Brave), then re-run: bun LIFEOS/TOOLS/Doctor.ts',
   },
   {
+    id: 'ripgrep',
+    title: 'Fast filesystem search (ripgrep)',
+    powers: 'ContextSearch queries, work sweeps, and the model-drift scan',
+    ttlHours: 24 * 7,
+    configured: () => true, // shipped code shells out to `rg`; absence is broken, not unconfigured
+    probeOffline: async () =>
+      which('rg')
+        ? { ok: true, detail: 'rg on PATH' }
+        : { ok: false, detail: 'rg not on PATH — tools that shell out to it will fail' },
+    fixCmd: 'brew install ripgrep  (Linux: sudo apt-get install ripgrep)',
+  },
+  {
+    id: 'imagemagick',
+    title: 'Image inspection (ImageMagick)',
+    powers: "Interceptor's blank-frame guard, measured zoom, and Art composition",
+    ttlHours: 24 * 7,
+    configured: () => true, // the capture guard and Art both shell out to `magick`
+    probeOffline: async () =>
+      which('magick')
+        ? { ok: true, detail: 'magick on PATH' }
+        : { ok: false, detail: 'magick not on PATH — the blank-frame guard skips and captures go unchecked' },
+    fixCmd: 'brew install imagemagick  (Linux: sudo apt-get install imagemagick)',
+  },
+  {
+    id: 'gh',
+    title: 'Work system of record (GitHub CLI)',
+    powers: 'work capture, sweeps, commitments, and the Pulse Work tab',
+    ttlHours: 24 * 7,
+    configured: () => true, // WorkSweep/CommitmentSweep/Pulse spawn `gh` with no fallback
+    probeOffline: async () =>
+      which('gh')
+        ? { ok: true, detail: 'gh on PATH' }
+        : { ok: false, detail: 'gh not on PATH — work capture and sweeps cannot reach the work repo' },
+    fixCmd: 'brew install gh && gh auth login  (Linux: see cli.github.com)',
+  },
+  {
+    id: 'ffmpeg',
+    title: 'Audio/video processing (ffmpeg)',
+    powers: 'AudioEditor, transcript splitting, Conveyor renders, Interceptor zoom fallback',
+    ttlHours: 24 * 7,
+    configured: () => true, // SplitAndTranscribe and AudioEditor spawn `ffmpeg` directly
+    probeOffline: async () =>
+      which('ffmpeg')
+        ? { ok: true, detail: 'ffmpeg on PATH' }
+        : { ok: false, detail: 'ffmpeg not on PATH — audio/video tools will fail at spawn' },
+    fixCmd: 'brew install ffmpeg  (Linux: sudo apt-get install ffmpeg)',
+  },
+  {
+    id: 'ytdlp',
+    title: 'YouTube ingestion (yt-dlp)',
+    powers: "the Feed YouTube source and the Upgrade skill's channel scan",
+    ttlHours: 24 * 7,
+    configured: () => true,
+    probeOffline: async () =>
+      which('yt-dlp')
+        ? { ok: true, detail: 'yt-dlp on PATH' }
+        : { ok: false, detail: 'yt-dlp not on PATH — YouTube transcript and channel steps are skipped' },
+    fixCmd: 'brew install yt-dlp  (Linux: sudo apt-get install yt-dlp)',
+  },
+  {
+    id: 'fabric',
+    title: 'Prompt patterns (fabric)',
+    powers: "the Fabric skill's pattern library and YouTube transcript fetch",
+    ttlHours: 24 * 7,
+    configured: () => true,
+    probeOffline: async () =>
+      which('fabric')
+        ? { ok: true, detail: 'fabric on PATH' }
+        : { ok: false, detail: 'fabric not on PATH — pattern runs fall back to native prompting' },
+    fixCmd: 'see github.com/danielmiessler/fabric for install',
+  },
+  {
+    id: 'jq',
+    title: 'JSON in shell hooks (jq)',
+    powers: 'hook-side JSON parsing, including the command-compression rewrite',
+    ttlHours: 24 * 7,
+    configured: () => true,
+    probeOffline: async () =>
+      which('jq')
+        ? { ok: true, detail: 'jq on PATH' }
+        : { ok: false, detail: 'jq not on PATH — shell hooks that parse JSON skip silently' },
+    fixCmd: 'brew install jq  (Linux: sudo apt-get install jq)',
+  },
+  {
     id: 'cloudflare',
     title: 'Scheduled cloud flows (Cloudflare/wrangler)',
     powers: 'Arbol scheduled flows and Worker deploys',


### PR DESCRIPTION
Follow-on to #1660, applying the same logic to the rest of the tree.

## Method

Rather than grep for tool names, I enumerated what shipped code actually spawns:

- `Bun.spawn`/`spawnSync`/`execFile` array literals across `*.ts`
- command invocations in shipped `*.sh`
- every `command -v` / `Bun.which` guard — the strongest signal, since a guard means the code already knows the tool may be absent

That guard set came back as: `bash bun bunx claude codex fabric gws interceptor jq kitten magick rtk wrangler`. Four were documented, `bun` is in INSTALL.md, and `bash`/`claude` are foundational. The rest, plus the unguarded spawns, are what this PR covers.

## Load-bearing and undocumented — added to Doctor and the page

| Tool | Powers | Absence today |
|------|--------|---------------|
| `gh` | Work System's system of record | **fails outright** |
| `ffmpeg` | AudioEditor, transcript splitting, Conveyor | fails at spawn |
| `yt-dlp` | Feed YouTube source, Upgrade channel scan | step skipped |
| `fabric` | Fabric skill's pattern library | falls back to native prompting |
| `jq` | shell hooks that parse JSON | hook skips silently |

`gh` is the significant one. `WorkSweep`, `CommitmentSweep`, `CommitmentLog`, `RetagSweepTypes`, the Pulse work module and `ReminderRouter` all spawn it, **none with a fallback** — and `WorkSystem.md` states the GitHub repo *is* the system of record. So on a host without `gh`, work capture doesn't degrade, it fails, and nothing said so in advance. On the machine I audited from, `gh` is genuinely absent.

## Narrower ones — short table, no Doctor row

`rtk`, `kitten`, `cmux`, `mkcert`, `gws`. Each is tied to one terminal, one platform, or one opt-in workflow, and each skips cleanly when absent — a Doctor row would be a red ❌ on most hosts for something the user never wanted. They're listed so nothing is undocumented, without turning the check into noise.

## Deliberately excluded

`whisper` reads like a dependency — it appears in `ExtractTranscript.ts`, `SplitAndTranscribe.ts` and `Conveyor/Runner.ts`. It is the OpenAI `whisper-1` **API model**, not a local binary (`model: "whisper-1"` at `SplitAndTranscribe.ts:98`). That's an API-key concern, not an external tool, so documenting it here would have been wrong.

## Verified

- `Doctor.ts` runs clean with all 11 capabilities and exits 0, honouring its never-install-fatal contract.
- On this host it correctly reports `gh` **broken** with its fix command, while `ffmpeg`, `yt-dlp`, `fabric` and `jq` report live — so both branches are exercised by a real run, not just the happy path.
- Cross-check: every `id` in Doctor's registry has a corresponding mention in `GETTING-STARTED.md` — 11/11.
