### PR TITLE
fix(evals): derive judge model levels from the registry (claude-opus-5 was silently demoted to medium)

### DIFF
--- a/LifeOS/install/skills/Evals/Graders/ModelBased/LLMRubric.ts
+++ b/LifeOS/install/skills/Evals/Graders/ModelBased/LLMRubric.ts
@@ -6,6 +6,7 @@
 import { BaseGrader, registerGrader, type GraderContext } from '../Base.ts';
 import type { GraderConfig, GraderResult, LLMRubricParams } from '../../Types/index.ts';
 import { inference, type InferenceLevel } from '../../../../LIFEOS/TOOLS/Inference.ts';
+import { CURRENT, EFFORT_MODEL } from '../../../../LIFEOS/TOOLS/models.ts';
 import { readFileSync, existsSync } from 'fs';
 
 export class LLMRubricGrader extends BaseGrader {
@@ -24,14 +25,22 @@ export class LLMRubricGrader extends BaseGrader {
 
     const scale = params.scale ?? '1-5';
     // Map model preference to inference level (default to medium/Sonnet)
-    const levelMap: Record<string, InferenceLevel> = {
-      'claude-haiku-4-5-20251001': 'low',
+    // Superseded judge IDs, kept so existing eval configs keep resolving.
+    const legacyLevels: Record<string, InferenceLevel> = {
       'claude-sonnet-4-6': 'medium',
       'claude-opus-4-8': 'high',
       'claude-opus-4-6': 'high',
       'claude-sonnet-4-20250514': 'medium',
       'claude-opus-4-20250514': 'high',
-      'claude-fable-5': 'max',
+    };
+    // Current lineup is DERIVED from the model registry rather than restated:
+    // models.ts is the single edit point on a release, so a bump cannot strand
+    // a current model here and silently demote its judge to the default.
+    const levelMap: Record<string, InferenceLevel> = {
+      ...legacyLevels,
+      ...Object.fromEntries(
+        Object.entries(EFFORT_MODEL).map(([level, tier]) => [CURRENT[tier], level as InferenceLevel]),
+      ),
     };
     const level: InferenceLevel = levelMap[params.judge_model ?? ''] ?? 'medium';
 

--- a/LifeOS/install/skills/Evals/Graders/ModelBased/NaturalLanguageAssert.ts
+++ b/LifeOS/install/skills/Evals/Graders/ModelBased/NaturalLanguageAssert.ts
@@ -6,6 +6,7 @@
 import { BaseGrader, registerGrader, type GraderContext } from '../Base.ts';
 import type { GraderConfig, GraderResult, NaturalLanguageAssertParams } from '../../Types/index.ts';
 import { inference, type InferenceLevel } from '../../../../LIFEOS/TOOLS/Inference.ts';
+import { CURRENT, EFFORT_MODEL } from '../../../../LIFEOS/TOOLS/models.ts';
 
 export class NaturalLanguageAssertGrader extends BaseGrader {
   type = 'natural_language_assert' as const;
@@ -22,14 +23,22 @@ export class NaturalLanguageAssertGrader extends BaseGrader {
     }
 
     // Map model preference to inference level (default to medium/Sonnet)
-    const levelMap: Record<string, InferenceLevel> = {
-      'claude-haiku-4-5-20251001': 'low',
+    // Superseded judge IDs, kept so existing eval configs keep resolving.
+    const legacyLevels: Record<string, InferenceLevel> = {
       'claude-sonnet-4-6': 'medium',
       'claude-opus-4-8': 'high',
       'claude-opus-4-6': 'high',
       'claude-sonnet-4-20250514': 'medium',
       'claude-opus-4-20250514': 'high',
-      'claude-fable-5': 'max',
+    };
+    // Current lineup is DERIVED from the model registry rather than restated:
+    // models.ts is the single edit point on a release, so a bump cannot strand
+    // a current model here and silently demote its judge to the default.
+    const levelMap: Record<string, InferenceLevel> = {
+      ...legacyLevels,
+      ...Object.fromEntries(
+        Object.entries(EFFORT_MODEL).map(([level, tier]) => [CURRENT[tier], level as InferenceLevel]),
+      ),
     };
     const level: InferenceLevel = levelMap[params.judge_model ?? ''] ?? 'medium';
     const requireAll = params.require_all ?? true;

--- a/LifeOS/install/skills/Evals/Graders/ModelBased/PairwiseComparison.ts
+++ b/LifeOS/install/skills/Evals/Graders/ModelBased/PairwiseComparison.ts
@@ -6,6 +6,7 @@
 import { BaseGrader, registerGrader, type GraderContext } from '../Base.ts';
 import type { GraderConfig, GraderResult, PairwiseComparisonParams } from '../../Types/index.ts';
 import { inference, type InferenceLevel } from '../../../../LIFEOS/TOOLS/Inference.ts';
+import { CURRENT, EFFORT_MODEL } from '../../../../LIFEOS/TOOLS/models.ts';
 import { readFileSync, existsSync } from 'fs';
 
 export class PairwiseComparisonGrader extends BaseGrader {
@@ -29,14 +30,22 @@ export class PairwiseComparisonGrader extends BaseGrader {
     }
 
     // Map model preference to inference level (default to medium/Sonnet)
-    const levelMap: Record<string, InferenceLevel> = {
-      'claude-haiku-4-5-20251001': 'low',
+    // Superseded judge IDs, kept so existing eval configs keep resolving.
+    const legacyLevels: Record<string, InferenceLevel> = {
       'claude-sonnet-4-6': 'medium',
       'claude-opus-4-8': 'high',
       'claude-opus-4-6': 'high',
       'claude-sonnet-4-20250514': 'medium',
       'claude-opus-4-20250514': 'high',
-      'claude-fable-5': 'max',
+    };
+    // Current lineup is DERIVED from the model registry rather than restated:
+    // models.ts is the single edit point on a release, so a bump cannot strand
+    // a current model here and silently demote its judge to the default.
+    const levelMap: Record<string, InferenceLevel> = {
+      ...legacyLevels,
+      ...Object.fromEntries(
+        Object.entries(EFFORT_MODEL).map(([level, tier]) => [CURRENT[tier], level as InferenceLevel]),
+      ),
     };
     const level: InferenceLevel = levelMap[params.judge_model ?? ''] ?? 'medium';
     const positionSwap = params.position_swap ?? true;


### PR DESCRIPTION
The three model-based graders each hardcoded a judge-model → inference-level map. The lineup moved and the maps didn't, so both current top-tier IDs fell through to the `?? 'medium'` default:

| judge_model | resolved to | should be |
|---|---|---|
| `claude-opus-5` | `medium` | **`high`** |
| `claude-sonnet-5` | `medium` | `medium` (right only by accident) |

The opus case is the damaging one: an eval configured with the strongest judge silently ran on Sonnet-tier inference, and nothing surfaced the demotion — the grader still returned scores, just from a weaker model than asked for.

## The fix

Derive the current lineup from `EFFORT_MODEL`/`CURRENT` in `models.ts` rather than restating it. That file already describes itself as the single edit point on a model release, and its header cites exactly this failure (`ContextAudit` checking for `claude-opus-4-7` long after `claude-opus-4-8` shipped) as the reason it exists.

```ts
const levelMap: Record<string, InferenceLevel> = {
  ...legacyLevels,
  ...Object.fromEntries(
    Object.entries(EFFORT_MODEL).map(([level, tier]) => [CURRENT[tier], level as InferenceLevel]),
  ),
};
```

Superseded IDs (`claude-opus-4-8`, `claude-opus-4-6`, `claude-sonnet-4-6`, and the two dated 2025 IDs) stay in a small `legacyLevels` table so existing eval configs keep resolving. `claude-fable-5` and `claude-haiku-4-5-20251001` came out of the hardcoded list because they're now produced by the derivation with identical values.

A future model bump flows through automatically instead of stranding a judge here.

## Verified

Resolution asserted against the shipped expression:

- `claude-opus-5` → `high`, `claude-sonnet-5` → `medium`, `claude-fable-5` → `max`, `claude-haiku-4-5-20251001` → `low`
- all five legacy IDs unchanged
- unknown model and empty string still fall back to `medium`

All three graders transpile clean.

Companion to #1656, which bumped `CURRENT.opus` to `claude-opus-5` — that bump is what made the stale maps observable.
