### PR TITLE
fix(knowledge): waive source_* requirements for source_kind: internal (and teach the doc generator about it)

### DIFF
--- a/LifeOS/install/LIFEOS/TOOLS/GenerateKnowledgeSchemaDoc.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/GenerateKnowledgeSchemaDoc.ts
@@ -69,6 +69,8 @@ function render(): string {
     L.push(`| \`${t}\` | ${extra.length ? extra.map((k) => `\`${k}\``).join(", ") : "— (envelope only)"} |`);
   }
   L.push("");
+  L.push("**Waived for internal notes.** A note with `source_kind: internal` has no external origin — it *is* the primary artifact (an own-prose capture, a design decision, a corpus this system built). Demanding a `source_url` of it asks for a URL that cannot exist, so `source_*` requirements above are skipped when `source_kind` is `internal`. Externally-sourced notes still must carry their provenance.");
+  L.push("");
   L.push("A note missing an optional per-type source field (e.g. a research note with no `source_url`) is **envelope-conformant but incomplete** — Lint reports it as an enrichment gap, not a schema failure.");
   L.push("");
 

--- a/LifeOS/install/LIFEOS/TOOLS/KnowledgeSchema.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/KnowledgeSchema.ts
@@ -488,7 +488,14 @@ export function validate(parsed: ParsedNote, _slug: string, dirType: CanonicalTy
 
   // per-type required (present AND non-empty)
   const effType = ((CANONICAL_TYPES as readonly string[]).includes(t ?? "") ? t : dirType) as CanonicalType;
+  // `source_kind: internal` means the note has no external origin — it IS the
+  // primary artifact (a LifeOS corpus, a design decision, an own-prose capture).
+  // Demanding a source_url of it asks for a URL that cannot exist, so the
+  // source_* requirements are waived for internal notes. Externally-sourced
+  // notes still must carry their provenance.
+  const isInternal = deq(get("source_kind")) === "internal";
   for (const key of PER_TYPE_REQUIRED[effType] ?? []) {
+    if (isInternal && key.startsWith("source_")) continue;
     if (missingOrEmpty(key)) v.push({ key, problem: `required for type ${effType}` });
   }
 


### PR DESCRIPTION
`PER_TYPE_REQUIRED` demands `source_url` on every `research` note. That is wrong for notes carrying `source_kind: internal` — those have no external origin. They *are* the primary artifact: an own-prose capture, a design decision, a corpus the system itself built. The rule asks for a URL that cannot exist.

## Found on a real archive

Migrating a 1,801-note archive onto kb-v3 left exactly two violation classes. The second was 10 research notes failing this rule with **nothing to backfill** — I checked every one, and none contained a single URL anywhere in its body. Three were LifeOS's own artifacts; seven were OCR captures whose source URL was lost upstream.

Editing ten notes to satisfy a rule that shouldn't apply to them is the wrong direction. Fixing the rule took one condition.

## The change

```ts
const isInternal = deq(get("source_kind")) === "internal";
for (const key of PER_TYPE_REQUIRED[effType] ?? []) {
  if (isInternal && key.startsWith("source_")) continue;
  if (missingOrEmpty(key)) v.push({ key, problem: `required for type ${effType}` });
}
```

Externally-sourced notes are unaffected and still must carry their provenance.

## Second half: the generator

`GenerateKnowledgeSchemaDoc` reads `PER_TYPE_REQUIRED` — a data table — while the new rule lives in `validate()`. Left alone, the generated `_schema.md` would state a requirement the linter does not enforce.

That is the exact failure this schema exists to prevent, so the generator now emits the waiver alongside the table.

## Verified

On the archive this was found on:

| | Before | After |
|---|---|---|
| Envelope-conformant | 1791 / 1801 (99.4%) | **1801 / 1801 (100%)** |
| Fully conformant | 1781 (98.9%) | **1801 (100%)** |
| Completeness gaps | 10 | **0** |

`_schema.md` regenerated and carries the waiver text. One caveat worth stating: my first attempt at this used `field()`, which returns an `FmField` object rather than a string — `KnowledgeLint` threw a TypeError immediately rather than silently mis-validating, which is the behaviour you want from a linter. The committed version uses `deq(get(...))`, matching the surrounding code.
