### PR TITLE
feat(knowledge): regenerate _schema.md on the doc-integrity pass (generator is currently dead code)

### DIFF
--- a/LifeOS/install/hooks/DocIntegrity.hook.ts
+++ b/LifeOS/install/hooks/DocIntegrity.hook.ts
@@ -19,6 +19,7 @@ import { readHookInput, parseTranscriptFromInput } from './lib/hook-io';
 import { handleDocCrossRefIntegrity } from './handlers/DocCrossRefIntegrity';
 import { handleRebuildArchSummary } from './handlers/RebuildArchSummary';
 import { handleMemoryDirIntegrity } from './handlers/MemoryDirIntegrity';
+import { handleRebuildKnowledgeSchema } from './handlers/RebuildKnowledgeSchema';
 
 async function main() {
   const input = await readHookInput();
@@ -57,6 +58,12 @@ async function main() {
     await handleMemoryDirIntegrity();
   } catch (err) {
     console.error('[DocIntegrity] Memory-dir handler failed:', err);
+  }
+
+  try {
+    await handleRebuildKnowledgeSchema();
+  } catch (err) {
+    console.error('[DocIntegrity] Knowledge-schema regen failed:', err);
   }
 
   process.exit(0);

--- a/LifeOS/install/hooks/handlers/RebuildKnowledgeSchema.ts
+++ b/LifeOS/install/hooks/handlers/RebuildKnowledgeSchema.ts
@@ -1,0 +1,21 @@
+/**
+ * RebuildKnowledgeSchema — regenerate `MEMORY/KNOWLEDGE/_schema.md` from
+ * `KnowledgeSchema.ts` (the pure-data source of truth) on the doc-integrity
+ * pass, so the schema doc never drifts from the schema and exists on every
+ * install. Fire-and-forget; a failure is non-fatal (logged by the caller).
+ *
+ * Runs the standalone generator as a subprocess rather than importing it,
+ * because `GenerateKnowledgeSchemaDoc.ts` executes `main()` on import.
+ */
+import { spawn } from "child_process";
+import { join } from "path";
+import { getLifeosDir } from "../lib/paths";
+
+export async function handleRebuildKnowledgeSchema(): Promise<void> {
+  const generator = join(getLifeosDir(), "TOOLS", "GenerateKnowledgeSchemaDoc.ts");
+  await new Promise<void>((resolve) => {
+    const child = spawn("bun", [generator], { stdio: "ignore" });
+    child.on("close", () => resolve());
+    child.on("error", () => resolve());
+  });
+}


### PR DESCRIPTION
`GenerateKnowledgeSchemaDoc.ts` is dead code — nothing in the tree invokes it. Two consequences follow:

1. **`_schema.md` does not exist on a fresh install.** The schema doc the archive is supposed to be governed by simply isn't there.
2. **Where it does exist, it drifts** from `KnowledgeSchema.ts`, which the doc itself names as the single source of truth.

## This is not theoretical

On the archive this was found on, `_schema.md` declared `kb-v3` canonical while describing **0.9%** of the notes it governed — 17 of 1,801. The gap went unnoticed for as long as it did precisely because nothing regenerated the doc, so there was no moment at which the declaration and the reality were compared.

The same class of drift bit again during the repair: a change to the validation rule in `validate()` would not have appeared in the generated doc, because the generator reads the `PER_TYPE_REQUIRED` data table. Caught only because the doc was regenerated by hand and read.

## The change

Wire the generator into `DocIntegrity`, which already runs a cross-reference pass, so `_schema.md` is rebuilt from `KnowledgeSchema.ts` every time integrity is checked.

- **Fire-and-forget, non-fatal.** A generator failure logs and does not break the doc-integrity pass.
- **Subprocess, not import.** `GenerateKnowledgeSchemaDoc.ts` executes `main()` at import time, so importing it would run the generator as a side effect of loading the handler.

Net effect: the schema doc exists on every install, and cannot silently disagree with the code that defines it.

Companion to #1684, which fixes a rule in the same schema. That PR changes behaviour in `validate()`; this one guarantees the generated doc reflects such changes.
