### PR TITLE
feat(knowledge): report note conformance on the doc-integrity pass (KnowledgeLint is invoked by nothing)

### DIFF
--- a/LifeOS/install/hooks/DocIntegrity.hook.ts
+++ b/LifeOS/install/hooks/DocIntegrity.hook.ts
@@ -20,6 +20,7 @@ import { handleDocCrossRefIntegrity } from './handlers/DocCrossRefIntegrity';
 import { handleRebuildArchSummary } from './handlers/RebuildArchSummary';
 import { handleMemoryDirIntegrity } from './handlers/MemoryDirIntegrity';
 import { handleRebuildKnowledgeSchema } from './handlers/RebuildKnowledgeSchema';
+import { handleKnowledgeConformance } from './handlers/KnowledgeConformance';
 
 async function main() {
   const input = await readHookInput();
@@ -64,6 +65,12 @@ async function main() {
     await handleRebuildKnowledgeSchema();
   } catch (err) {
     console.error('[DocIntegrity] Knowledge-schema regen failed:', err);
+  }
+
+  try {
+    await handleKnowledgeConformance();
+  } catch (err) {
+    console.error('[DocIntegrity] Knowledge-conformance check failed:', err);
   }
 
   process.exit(0);

--- a/LifeOS/install/hooks/DocIntegrity.hook.ts
+++ b/LifeOS/install/hooks/DocIntegrity.hook.ts
@@ -19,6 +19,7 @@ import { readHookInput, parseTranscriptFromInput } from './lib/hook-io';
 import { handleDocCrossRefIntegrity } from './handlers/DocCrossRefIntegrity';
 import { handleRebuildArchSummary } from './handlers/RebuildArchSummary';
 import { handleMemoryDirIntegrity } from './handlers/MemoryDirIntegrity';
+import { handleRebuildKnowledgeSchema } from './handlers/RebuildKnowledgeSchema';
 
 async function main() {
   const input = await readHookInput();
@@ -57,6 +58,12 @@ async function main() {
     await handleMemoryDirIntegrity();
   } catch (err) {
     console.error('[DocIntegrity] Memory-dir handler failed:', err);
+  }
+
+  try {
+    await handleRebuildKnowledgeSchema();
+  } catch (err) {
+    console.error('[DocIntegrity] Knowledge-schema regen failed:', err);
   }
 
   process.exit(0);

--- a/LifeOS/install/hooks/handlers/KnowledgeConformance.ts
+++ b/LifeOS/install/hooks/handlers/KnowledgeConformance.ts
@@ -1,0 +1,119 @@
+#!/usr/bin/env bun
+/**
+ * KnowledgeConformance.ts — Knowledge Archive schema conformance checker
+ *
+ * PURPOSE:
+ * RebuildKnowledgeSchema keeps `_schema.md` honest against `KnowledgeSchema.ts`,
+ * so the DOC can no longer drift from the CODE. Nothing, however, checks whether
+ * the NOTES conform to either. That gap is how an archive reached 0.9%
+ * conformance without a single warning: a bulk import wrote 1,744 notes off
+ * schema, later writers copied their frontmatter, and the only tool that could
+ * have said so (KnowledgeLint) was never invoked by anything.
+ *
+ * This closes the detection half. It reports; it never edits or blocks.
+ *
+ * TRIGGER: Stop hook (called from DocIntegrity.hook.ts)
+ *
+ * READS:
+ *   MEMORY/KNOWLEDGE/{People,Companies,Ideas,Research,Blogs,Books}/*.md
+ *
+ * WRITES:
+ *   stderr (audit log with [KnowledgeConformance] tag)
+ *   STATE/events.jsonl (typed event: doc.integrity.knowledge_conformance)
+ *
+ * SIDE EFFECTS:
+ *   None — read-only check. Non-conformance is a soft warning. Never blocks.
+ */
+
+import { readdirSync, readFileSync, existsSync, appendFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { getLifeosDir } from '../lib/paths';
+import { parseNote, validate, slugFromPath, DIR_TO_TYPE, type CanonicalType } from '../../LIFEOS/TOOLS/KnowledgeSchema';
+
+const TAG = '[KnowledgeConformance]';
+const LIFEOS_DIR = getLifeosDir();
+const MEMORY_DIR = join(LIFEOS_DIR, 'MEMORY');
+const KNOWLEDGE_DIR = join(MEMORY_DIR, 'KNOWLEDGE');
+const EVENTS_FILE = join(MEMORY_DIR, 'STATE', 'events.jsonl');
+const DIRS = ['People', 'Companies', 'Ideas', 'Research', 'Blogs', 'Books'] as const;
+
+function emitEvent(payload: Record<string, unknown>): void {
+  try {
+    mkdirSync(join(MEMORY_DIR, 'STATE'), { recursive: true });
+    appendFileSync(EVENTS_FILE, JSON.stringify({ timestamp: new Date().toISOString(), ...payload }) + '\n', 'utf-8');
+  } catch {
+    /* non-fatal */
+  }
+}
+
+export async function handleKnowledgeConformance(): Promise<void> {
+  const startTime = Date.now();
+  if (!existsSync(KNOWLEDGE_DIR)) return;
+
+  let total = 0;
+  let conformant = 0;
+  const byDir: Record<string, { n: number; ok: number }> = {};
+  const violationCounts: Record<string, number> = {};
+
+  for (const dir of DIRS) {
+    const dirPath = join(KNOWLEDGE_DIR, dir);
+    if (!existsSync(dirPath)) continue;
+    const dirType = DIR_TO_TYPE[dir] as CanonicalType;
+    byDir[dir] = { n: 0, ok: 0 };
+
+    for (const file of readdirSync(dirPath)) {
+      if (!file.endsWith('.md') || file.startsWith('_')) continue;
+      const path = join(dirPath, file);
+      total++;
+      byDir[dir].n++;
+      try {
+        const violations = validate(parseNote(readFileSync(path, 'utf-8')), slugFromPath(path), dirType);
+        if (violations.length === 0) {
+          conformant++;
+          byDir[dir].ok++;
+        } else {
+          for (const v of violations) {
+            const key = `${v.key} — ${v.problem}`;
+            violationCounts[key] = (violationCounts[key] || 0) + 1;
+          }
+        }
+      } catch {
+        violationCounts['unparseable frontmatter'] = (violationCounts['unparseable frontmatter'] || 0) + 1;
+      }
+    }
+  }
+
+  const nonConformant = total - conformant;
+  const pct = total > 0 ? ((conformant / total) * 100).toFixed(1) : '0.0';
+
+  emitEvent({
+    event: 'doc.integrity.knowledge_conformance',
+    total,
+    conformant,
+    non_conformant: nonConformant,
+    conformance_pct: Number(pct),
+    per_dir: byDir,
+    top_violations: Object.entries(violationCounts)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([problem, count]) => ({ problem, count })),
+    ok: nonConformant === 0,
+  });
+
+  const elapsed = Date.now() - startTime;
+  if (nonConformant > 0) {
+    console.error(`${TAG} ${nonConformant}/${total} notes off-schema (${pct}% conformant). Repair: bun LIFEOS/TOOLS/MigrateKnowledge.ts`);
+    for (const [problem, count] of Object.entries(violationCounts).sort((a, b) => b[1] - a[1]).slice(0, 3)) {
+      console.error(`${TAG}   ${count}× ${problem}`);
+    }
+  }
+  console.error(`${TAG} === Check complete (${elapsed}ms, ${pct}% conformant) ===`);
+}
+
+// Allow running standalone for verification.
+if (import.meta.main) {
+  handleKnowledgeConformance().catch((err) => {
+    console.error(`${TAG} Fatal:`, err);
+    process.exit(1);
+  });
+}

--- a/LifeOS/install/hooks/handlers/RebuildKnowledgeSchema.ts
+++ b/LifeOS/install/hooks/handlers/RebuildKnowledgeSchema.ts
@@ -1,0 +1,21 @@
+/**
+ * RebuildKnowledgeSchema — regenerate `MEMORY/KNOWLEDGE/_schema.md` from
+ * `KnowledgeSchema.ts` (the pure-data source of truth) on the doc-integrity
+ * pass, so the schema doc never drifts from the schema and exists on every
+ * install. Fire-and-forget; a failure is non-fatal (logged by the caller).
+ *
+ * Runs the standalone generator as a subprocess rather than importing it,
+ * because `GenerateKnowledgeSchemaDoc.ts` executes `main()` on import.
+ */
+import { spawn } from "child_process";
+import { join } from "path";
+import { getLifeosDir } from "../lib/paths";
+
+export async function handleRebuildKnowledgeSchema(): Promise<void> {
+  const generator = join(getLifeosDir(), "TOOLS", "GenerateKnowledgeSchemaDoc.ts");
+  await new Promise<void>((resolve) => {
+    const child = spawn("bun", [generator], { stdio: "ignore" });
+    child.on("close", () => resolve());
+    child.on("error", () => resolve());
+  });
+}


### PR DESCRIPTION
**Stacks on #1685.** That PR keeps `_schema.md` honest against `KnowledgeSchema.ts`, so the *doc* can no longer drift from the *code*. Nothing checks whether the **notes** conform to either.

## The gap this closes

`KnowledgeLint.ts` exists and works. It is invoked by **nothing in the tree** — every reference to it is prose, telling a human to run it. So note-level conformance is only ever measured when someone remembers to type the command.

That is how an archive reached **0.9% conformance** without a single warning:

1. A bulk import wrote 1,744 notes bypassing `MemorySystem.renderInitialNote`.
2. Later writers read a neighbouring note and copied its frontmatter, spreading the legacy dialect.
3. Nothing ever compared the notes to the schema, so none of it surfaced.

#1685 makes step 3's *documentation* half impossible. This makes the *data* half visible.

## The change

A read-only handler alongside the regen, in the pass that already runs.

- Calls `validate()` / `parseNote()` from `KnowledgeSchema` **directly** rather than shelling out to the CLI — one pass, no subprocess.
- Reports conformance percentage, per-directory breakdown, and the top violation classes.
- Names the repair command (`MigrateKnowledge.ts`) in the warning, so the next step is obvious.
- Emits `doc.integrity.knowledge_conformance` to `STATE/events.jsonl` for Pulse.
- **Reports only.** Never edits, never blocks. Non-conformance is a soft warning, matching `MemoryDirIntegrity`'s contract.

## Verified

On a 1,801-note archive:

```
[KnowledgeConformance] === Check complete (451ms, 100.0% conformant) ===
```

And with one note deliberately downgraded to `convention: kb-v2`:

```
[KnowledgeConformance] 1/1801 notes off-schema (99.9% conformant). Repair: bun LIFEOS/TOOLS/MigrateKnowledge.ts
[KnowledgeConformance]   1× convention — not kb-v3 (dialect not migrated)
```

Positive and negative both exercised. 451ms over 1,801 notes, so it is not a meaningful cost on the Stop path.
