### PR TITLE
Fix Books.md template: restore 'Daniel Kahneman' as the book author

### DIFF
--- a/LifeOS/install/LIFEOS/USER_TEMPLATES/Books.md
+++ b/LifeOS/install/LIFEOS/USER_TEMPLATES/Books.md
@@ -14,5 +14,5 @@ What you're reading and what landed. Drop new entries on top.
 - **Meditations** — Marcus Aurelius · ★10 · stoic operating system
 - **Antifragile** — Nassim Taleb · ★9 · systems that gain from disorder
 - **Deep Work** — Cal Newport · ★8 · attention as the productivity asset
-- **Thinking, Fast and Slow** — {{PRINCIPAL_NAME}} Kahneman
+- **Thinking, Fast and Slow** — Daniel Kahneman
 - **The Selfish Gene** — Richard Dawkins · ★9


### PR DESCRIPTION
The `{{PRINCIPAL_NAME}}` placeholder substitution caught the author's first name in the Books starter template, so every install renders line 17 as `<principal name> Kahneman` (e.g. "Alice Kahneman") in the suggested-reading list.

**Before:** `- **Thinking, Fast and Slow** — {{PRINCIPAL_NAME}} Kahneman`
**After:** `- **Thinking, Fast and Slow** — Daniel Kahneman`

This is the only content-level placeholder hit in the payload — `grep -rP '\{\{PRINCIPAL_NAME\}\} [A-Z][a-z]+' LifeOS/install` returns just this line ({{DA_NAME}} has no equivalent hits).