### PR TITLE
feat(linux): add systemd --user backend to 4 scheduler installers

### DIFF
--- a/LifeOS/install/LIFEOS/DOCUMENTATION/Services/BackgroundServices.md
+++ b/LifeOS/install/LIFEOS/DOCUMENTATION/Services/BackgroundServices.md
@@ -60,7 +60,7 @@ bun ~/.claude/LIFEOS/TOOLS/Services.ts doc                 # regenerate the tabl
 
 ## Fresh install
 
-The LifeOS install skill (`skills/LifeOS/`, `DeployComponents.ts`) stands up the core set during Setup. `Services.ts install --all` is the complete-coverage path: point a fresh macOS install at it and every service comes up, opt-ins included. macOS-only — `launchd` services skip cleanly on Linux/Windows. **Integration status:** `DeployComponents.ts` currently covers ~9 components; wiring it to read `Services.ts`'s registry so a single Setup step covers all 16 is the tracked follow-up.
+The LifeOS install skill (`skills/LifeOS/`, `DeployComponents.ts`) stands up the core set during Setup. `Services.ts install --all` is the complete-coverage path: point a fresh macOS install at it and every service comes up, opt-ins included. Mostly macOS-only for now — `launchd` services skip cleanly on Linux/Windows, with the exception of work sweep, derived-file sync, commitment sweep, usage aggregator, and codex update (`com.lifeos.worksweep`/`derivedsync`/`commitmentsweep`/`usage-aggregator`/`codexupdate`), whose installers detect `process.platform` and materialize a systemd `--user` unit (service+timer, or service+path for the file-watch case) instead — same install command, same `--uninstall`/`--status` flags. **Integration status:** `DeployComponents.ts` currently covers ~9 components; wiring it to read `Services.ts`'s registry so a single Setup step covers all 16 is the tracked follow-up. `Services.ts status` itself still only inspects `launchd`, so it under-reports on Linux until it gains the same platform branch (tracked separately).
 
 ## Cross-references
 

--- a/LifeOS/install/LIFEOS/TOOLS/InstallCodexUpdate.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/InstallCodexUpdate.ts
@@ -10,6 +10,18 @@
  * ~/Library/LaunchAgents/com.lifeos.codexupdate.plist, and runs `launchctl bootstrap`.
  * Idempotent — re-running install bootouts the prior load first. Mirrors
  * InstallWorkSweep.ts exactly.
+ *
+ * Two backends, chosen by `process.platform` (same pattern as
+ * LIFEOS/PULSE/manage.sh and InstallWorkSweep.ts — macOS uses launchd,
+ * Linux uses systemd --user):
+ *
+ *  - darwin: materializes com.lifeos.codexupdate.plist.template into
+ *    ~/Library/LaunchAgents/ and bootstraps it with launchctl.
+ *  - linux: materializes com.lifeos.codexupdate.{service,timer}.template
+ *    into ~/.config/systemd/user/ and enables the timer with systemctl
+ *    --user. Requires `loginctl enable-linger $USER` for the timer to
+ *    survive logout (same requirement PULSE/manage.sh documents for
+ *    com.lifeos.pulse).
  */
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from "fs";
@@ -17,11 +29,22 @@ import { join } from "path";
 
 declare const Bun: { spawn: (cmd: string[], opts?: any) => any };
 
+const IS_LINUX = process.platform === "linux";
 const HOME = process.env.HOME || "";
+const LABEL = "com.lifeos.codexupdate";
+
+// ── darwin (launchd) paths ──
 const TEMPLATE_PATH = join(HOME, ".claude", "LIFEOS", "TOOLS", "com.lifeos.codexupdate.plist.template");
 const LAUNCH_AGENTS_DIR = join(HOME, "Library", "LaunchAgents");
 const TARGET_PLIST = join(LAUNCH_AGENTS_DIR, "com.lifeos.codexupdate.plist");
-const LABEL = "com.lifeos.codexupdate";
+
+// ── linux (systemd --user) paths ──
+const SERVICE_TEMPLATE_PATH = join(HOME, ".claude", "LIFEOS", "TOOLS", "com.lifeos.codexupdate.service.template");
+const TIMER_TEMPLATE_PATH = join(HOME, ".claude", "LIFEOS", "TOOLS", "com.lifeos.codexupdate.timer.template");
+const SYSTEMD_USER_DIR = join(HOME, ".config", "systemd", "user");
+const TARGET_SERVICE = join(SYSTEMD_USER_DIR, `${LABEL}.service`);
+const TARGET_TIMER = join(SYSTEMD_USER_DIR, `${LABEL}.timer`);
+const TIMER_UNIT = `${LABEL}.timer`;
 
 async function uid(): Promise<string> {
   const proc = Bun.spawn(["id", "-u"], { stdout: "pipe", stderr: "ignore" });
@@ -30,8 +53,26 @@ async function uid(): Promise<string> {
   return out.trim();
 }
 
+async function username(): Promise<string> {
+  // Prefer `id -un` over process.env.USER — USER isn't guaranteed to be set
+  // in every invoking environment, and an empty string would make
+  // `loginctl enable-linger ""` fail silently.
+  const proc = Bun.spawn(["id", "-un"], { stdout: "pipe", stderr: "ignore" });
+  const out = await new Response(proc.stdout).text();
+  await proc.exited;
+  return out.trim();
+}
+
 async function launchctl(args: string[]): Promise<{ ok: boolean; out: string; err: string }> {
   const proc = Bun.spawn(["launchctl", ...args], { stdout: "pipe", stderr: "pipe" });
+  const out = await new Response(proc.stdout).text();
+  const err = await new Response(proc.stderr).text();
+  const exit = await proc.exited;
+  return { ok: exit === 0, out, err };
+}
+
+async function systemctl(args: string[]): Promise<{ ok: boolean; out: string; err: string }> {
+  const proc = Bun.spawn(["systemctl", "--user", ...args], { stdout: "pipe", stderr: "pipe" });
   const out = await new Response(proc.stdout).text();
   const err = await new Response(proc.stderr).text();
   const exit = await proc.exited;
@@ -47,7 +88,9 @@ async function detectBun(): Promise<string> {
   return path;
 }
 
-async function install(): Promise<void> {
+// ── darwin (launchd) ──
+
+async function installDarwin(): Promise<void> {
   if (!existsSync(TEMPLATE_PATH)) {
     console.error(`[InstallCodexUpdate] template missing at ${TEMPLATE_PATH}`);
     process.exit(1);
@@ -84,7 +127,7 @@ async function install(): Promise<void> {
   }
 }
 
-async function uninstall(): Promise<void> {
+async function uninstallDarwin(): Promise<void> {
   const u = await uid();
   if (existsSync(TARGET_PLIST)) {
     const r = await launchctl(["bootout", `gui/${u}`, TARGET_PLIST]);
@@ -95,7 +138,7 @@ async function uninstall(): Promise<void> {
   }
 }
 
-async function status(): Promise<void> {
+async function statusDarwin(): Promise<void> {
   const u = await uid();
   const r = await launchctl(["print", `gui/${u}/${LABEL}`]);
   if (!r.ok) {
@@ -105,11 +148,76 @@ async function status(): Promise<void> {
   console.log(r.out);
 }
 
+// ── linux (systemd --user) ──
+
+async function installLinux(): Promise<void> {
+  if (!existsSync(SERVICE_TEMPLATE_PATH) || !existsSync(TIMER_TEMPLATE_PATH)) {
+    console.error(`[InstallCodexUpdate] template missing — expected ${SERVICE_TEMPLATE_PATH} and ${TIMER_TEMPLATE_PATH}`);
+    process.exit(1);
+  }
+  const bunPath = await detectBun();
+  const bunDir = bunPath.replace(/\/bun$/, "");
+  console.log(`[InstallCodexUpdate] detected bun at ${bunPath}`);
+
+  const materialize = (templatePath: string) =>
+    readFileSync(templatePath, "utf-8")
+      .replace(/\{\{HOME\}\}/g, HOME)
+      .replace(/\{\{BUN\}\}/g, bunPath)
+      .replace(/\{\{BUN_DIR\}\}/g, bunDir);
+
+  if (!existsSync(SYSTEMD_USER_DIR)) mkdirSync(SYSTEMD_USER_DIR, { recursive: true });
+
+  // Idempotent teardown (ignore failures — first install has nothing to remove)
+  await systemctl(["disable", "--now", TIMER_UNIT]);
+
+  writeFileSync(TARGET_SERVICE, materialize(SERVICE_TEMPLATE_PATH));
+  writeFileSync(TARGET_TIMER, materialize(TIMER_TEMPLATE_PATH));
+  console.log(`[InstallCodexUpdate] wrote ${TARGET_SERVICE}`);
+  console.log(`[InstallCodexUpdate] wrote ${TARGET_TIMER}`);
+
+  await systemctl(["daemon-reload"]);
+
+  // Survive logout/reboot, same requirement PULSE/manage.sh documents for com.lifeos.pulse.
+  await Bun.spawn(["loginctl", "enable-linger", await username()], { stdout: "ignore", stderr: "ignore" }).exited;
+
+  const r = await systemctl(["enable", "--now", TIMER_UNIT]);
+  if (!r.ok) {
+    console.error(`[InstallCodexUpdate] enable --now failed: ${r.err.trim()}`);
+    process.exit(1);
+  }
+  console.log(`[InstallCodexUpdate] systemd timer enabled — ${TIMER_UNIT} active (daily 04:00)`);
+
+  const list = await systemctl(["list-timers", TIMER_UNIT, "--no-pager"]);
+  if (list.ok) console.log(list.out.trim());
+}
+
+async function uninstallLinux(): Promise<void> {
+  await systemctl(["disable", "--now", TIMER_UNIT]);
+  let removed = false;
+  for (const f of [TARGET_SERVICE, TARGET_TIMER]) {
+    if (existsSync(f)) {
+      try { unlinkSync(f); console.log(`[InstallCodexUpdate] removed ${f}`); removed = true; } catch {}
+    }
+  }
+  if (!removed) console.log(`[InstallCodexUpdate] no unit files found — nothing to do`);
+  await systemctl(["daemon-reload"]);
+}
+
+async function statusLinux(): Promise<void> {
+  const r = await systemctl(["status", TIMER_UNIT, "--no-pager"]);
+  console.log(r.out || r.err);
+  const list = await systemctl(["list-timers", TIMER_UNIT, "--no-pager"]);
+  if (list.ok) console.log(list.out.trim());
+  if (!r.ok) process.exit(1);
+}
+
+// ── dispatch ──
+
 async function main(): Promise<void> {
   const arg = process.argv[2];
-  if (arg === "--uninstall") return uninstall();
-  if (arg === "--status") return status();
-  return install();
+  if (arg === "--uninstall") return IS_LINUX ? uninstallLinux() : uninstallDarwin();
+  if (arg === "--status") return IS_LINUX ? statusLinux() : statusDarwin();
+  return IS_LINUX ? installLinux() : installDarwin();
 }
 
 if (import.meta.main) {

--- a/LifeOS/install/LIFEOS/TOOLS/InstallCommitmentSweep.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/InstallCommitmentSweep.ts
@@ -7,22 +7,56 @@
  *
  * Reads template, substitutes __HOME__ with $HOME, writes to ~/Library/LaunchAgents/,
  * bootstraps via launchctl bootstrap. Idempotent — re-runs cleanly replace existing.
+ *
+ * Two backends, chosen by `process.platform` (same pattern as
+ * LIFEOS/PULSE/manage.sh and InstallWorkSweep.ts — macOS uses launchd,
+ * Linux uses systemd --user):
+ *
+ *  - darwin: materializes com.lifeos.commitmentsweep.plist.template into
+ *    ~/Library/LaunchAgents/ and bootstraps it with launchctl.
+ *  - linux: materializes com.lifeos.commitmentsweep.{service,timer}.template
+ *    into ~/.config/systemd/user/ and enables the timer with systemctl
+ *    --user. Requires `loginctl enable-linger $USER` for the timer to
+ *    survive logout (same requirement PULSE/manage.sh documents for
+ *    com.lifeos.pulse). Unlike the darwin plist (which hardcodes
+ *    /opt/homebrew/bin/bun), the systemd service template uses a {{BUN}}
+ *    placeholder resolved via `which bun` at install time — the plist
+ *    itself is left untouched.
  */
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync } from "fs";
 import { join } from "path";
 import { spawnSync } from "child_process";
 
+const IS_LINUX = process.platform === "linux";
 const HOME = process.env.HOME || "";
+const LABEL = "com.lifeos.commitmentsweep";
+const STATE_DIR = join(HOME, ".claude", "LIFEOS", "MEMORY", "STATE");
+
+// ── darwin (launchd) paths ──
 const TEMPLATE = join(HOME, ".claude", "LIFEOS", "TOOLS", "com.lifeos.commitmentsweep.plist.template");
 const TARGET_DIR = join(HOME, "Library", "LaunchAgents");
 const TARGET = join(TARGET_DIR, "com.lifeos.commitmentsweep.plist");
-const STATE_DIR = join(HOME, ".claude", "LIFEOS", "MEMORY", "STATE");
-const LABEL = "com.lifeos.commitmentsweep";
+
+// ── linux (systemd --user) paths ──
+const SERVICE_TEMPLATE_PATH = join(HOME, ".claude", "LIFEOS", "TOOLS", "com.lifeos.commitmentsweep.service.template");
+const TIMER_TEMPLATE_PATH = join(HOME, ".claude", "LIFEOS", "TOOLS", "com.lifeos.commitmentsweep.timer.template");
+const SYSTEMD_USER_DIR = join(HOME, ".config", "systemd", "user");
+const TARGET_SERVICE = join(SYSTEMD_USER_DIR, `${LABEL}.service`);
+const TARGET_TIMER = join(SYSTEMD_USER_DIR, `${LABEL}.timer`);
+const TIMER_UNIT = `${LABEL}.timer`;
 
 function uid(): string {
   const r = spawnSync("id", ["-u"], { encoding: "utf8" });
   return (r.stdout || "501").trim();
+}
+
+function username(): string {
+  // Prefer `id -un` over process.env.USER — USER isn't guaranteed to be set
+  // in every invoking environment, and an empty string would make
+  // `loginctl enable-linger ""` fail silently.
+  const r = spawnSync("id", ["-un"], { encoding: "utf8" });
+  return (r.stdout || "").trim();
 }
 
 function launchctl(args: string[]): { code: number; out: string; err: string } {
@@ -30,7 +64,19 @@ function launchctl(args: string[]): { code: number; out: string; err: string } {
   return { code: r.status ?? 1, out: r.stdout || "", err: r.stderr || "" };
 }
 
-function uninstall(): void {
+function systemctl(args: string[]): { code: number; out: string; err: string } {
+  const r = spawnSync("systemctl", ["--user", ...args], { encoding: "utf8" });
+  return { code: r.status ?? 1, out: r.stdout || "", err: r.stderr || "" };
+}
+
+function detectBun(): string {
+  const r = spawnSync("which", ["bun"], { encoding: "utf8" });
+  const path = (r.stdout || "").trim();
+  if (!path) throw new Error("bun not found in PATH — install bun first");
+  return path;
+}
+
+function uninstallDarwin(): void {
   const u = uid();
   const r = launchctl(["bootout", `gui/${u}/${LABEL}`]);
   if (r.code === 0) console.log(`[InstallCommitmentSweep] booted out ${LABEL}`);
@@ -41,7 +87,7 @@ function uninstall(): void {
   }
 }
 
-function install(): void {
+function installDarwin(): void {
   if (!existsSync(TEMPLATE)) {
     console.error(`[InstallCommitmentSweep] template missing: ${TEMPLATE}`);
     process.exit(1);
@@ -75,13 +121,72 @@ function install(): void {
   }
 }
 
+// ── linux (systemd --user) ──
+
+function materializeLinux(templatePath: string, bunPath: string): string {
+  const bunDir = bunPath.replace(/\/bun$/, "");
+  return readFileSync(templatePath, "utf8")
+    .replace(/\{\{HOME\}\}/g, HOME)
+    .replace(/\{\{BUN\}\}/g, bunPath)
+    .replace(/\{\{BUN_DIR\}\}/g, bunDir);
+}
+
+function installLinux(): void {
+  if (!existsSync(SERVICE_TEMPLATE_PATH) || !existsSync(TIMER_TEMPLATE_PATH)) {
+    console.error(`[InstallCommitmentSweep] template missing — expected ${SERVICE_TEMPLATE_PATH} and ${TIMER_TEMPLATE_PATH}`);
+    process.exit(1);
+  }
+  const bunPath = detectBun();
+  console.log(`[InstallCommitmentSweep] detected bun at ${bunPath}`);
+  mkdirSync(SYSTEMD_USER_DIR, { recursive: true });
+  mkdirSync(STATE_DIR, { recursive: true });
+
+  // Idempotent teardown (ignore failures — first install has nothing to remove)
+  systemctl(["disable", "--now", TIMER_UNIT]);
+
+  writeFileSync(TARGET_SERVICE, materializeLinux(SERVICE_TEMPLATE_PATH, bunPath), { mode: 0o644 });
+  writeFileSync(TARGET_TIMER, materializeLinux(TIMER_TEMPLATE_PATH, bunPath), { mode: 0o644 });
+  console.log(`[InstallCommitmentSweep] wrote ${TARGET_SERVICE}`);
+  console.log(`[InstallCommitmentSweep] wrote ${TARGET_TIMER}`);
+
+  systemctl(["daemon-reload"]);
+
+  // Survive logout/reboot, same requirement PULSE/manage.sh documents for com.lifeos.pulse.
+  spawnSync("loginctl", ["enable-linger", username()]);
+
+  const r = systemctl(["enable", "--now", TIMER_UNIT]);
+  if (r.code === 0) {
+    console.log(`[InstallCommitmentSweep] systemd timer enabled — ${TIMER_UNIT} active (daily 07:00)`);
+  } else {
+    console.error(`[InstallCommitmentSweep] enable --now failed: ${r.err.trim() || r.code}`);
+    process.exit(2);
+  }
+
+  const list = systemctl(["list-timers", TIMER_UNIT, "--no-pager"]);
+  if (list.code === 0) console.log(list.out.trim());
+}
+
+function uninstallLinux(): void {
+  systemctl(["disable", "--now", TIMER_UNIT]);
+  let removed = false;
+  for (const f of [TARGET_SERVICE, TARGET_TIMER]) {
+    if (existsSync(f)) {
+      try { unlinkSync(f); console.log(`[InstallCommitmentSweep] removed ${f}`); removed = true; } catch {}
+    }
+  }
+  if (!removed) console.log(`[InstallCommitmentSweep] no unit files found — nothing to do`);
+  systemctl(["daemon-reload"]);
+}
+
+// ── dispatch ──
+
 function main() {
   const args = process.argv.slice(2);
   if (args.includes("--uninstall")) {
-    uninstall();
+    if (IS_LINUX) uninstallLinux(); else uninstallDarwin();
     process.exit(0);
   }
-  install();
+  if (IS_LINUX) installLinux(); else installDarwin();
 }
 
 if (import.meta.main) main();

--- a/LifeOS/install/LIFEOS/TOOLS/InstallDerivedSync.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/InstallDerivedSync.ts
@@ -5,10 +5,25 @@
  *   bun ~/.claude/LIFEOS/TOOLS/InstallDerivedSync.ts             # install
  *   bun ~/.claude/LIFEOS/TOOLS/InstallDerivedSync.ts --uninstall # remove
  *   bun ~/.claude/LIFEOS/TOOLS/InstallDerivedSync.ts --status    # check
+ *
+ * Two backends, chosen by `process.platform` (same pattern as
+ * LIFEOS/PULSE/manage.sh and InstallWorkSweep.ts — macOS uses launchd,
+ * Linux uses systemd --user):
+ *
+ *  - darwin: materializes com.lifeos.derivedsync.plist.template into
+ *    ~/Library/LaunchAgents/ and bootstraps it with launchctl.
+ *  - linux: materializes com.lifeos.derivedsync.{service,path}.template into
+ *    ~/.config/systemd/user/ and enables the .path unit with systemctl
+ *    --user. Requires `loginctl enable-linger $USER` for the unit to
+ *    survive logout (same requirement PULSE/manage.sh documents for
+ *    com.lifeos.pulse). The .path unit is started once at install time to
+ *    match the launchd plist's RunAtLoad true.
  */
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync, realpathSync } from "fs";
 import { join } from "path";
+
+const IS_LINUX = process.platform === "linux";
 
 type SpawnProcess = {
   stdout: ReadableStream<Uint8Array> | null;
@@ -34,11 +49,21 @@ type LaunchctlResult = {
 };
 
 const HOME = process.env.HOME || "";
+const LABEL = "com.lifeos.derivedsync";
+const COMMAND_TIMEOUT_MS = 30 * 1000;
+
+// ── darwin (launchd) paths ──
 const TEMPLATE_PATH = join(HOME, ".claude", "LIFEOS", "TOOLS", "com.lifeos.derivedsync.plist.template");
 const LAUNCH_AGENTS_DIR = join(HOME, "Library", "LaunchAgents");
 const TARGET_PLIST = join(LAUNCH_AGENTS_DIR, "com.lifeos.derivedsync.plist");
-const LABEL = "com.lifeos.derivedsync";
-const COMMAND_TIMEOUT_MS = 30 * 1000;
+
+// ── linux (systemd --user) paths ──
+const SERVICE_TEMPLATE_PATH = join(HOME, ".claude", "LIFEOS", "TOOLS", "com.lifeos.derivedsync.service.template");
+const PATH_TEMPLATE_PATH = join(HOME, ".claude", "LIFEOS", "TOOLS", "com.lifeos.derivedsync.path.template");
+const SYSTEMD_USER_DIR = join(HOME, ".config", "systemd", "user");
+const TARGET_SERVICE = join(SYSTEMD_USER_DIR, `${LABEL}.service`);
+const TARGET_PATH = join(SYSTEMD_USER_DIR, `${LABEL}.path`);
+const PATH_UNIT = `${LABEL}.path`;
 
 async function exitedWithTimeout(proc: SpawnProcess): Promise<CommandExit> {
   const started = Date.now();
@@ -69,6 +94,24 @@ async function launchctl(args: string[]): Promise<LaunchctlResult> {
   return { ok: result.exit === 0 && !result.timedOut, out, err, exit: result.exit, ms: result.ms };
 }
 
+async function systemctl(args: string[]): Promise<LaunchctlResult> {
+  const proc = Bun.spawn(["systemctl", "--user", ...args], { stdout: "pipe", stderr: "pipe" });
+  const out = await new Response(proc.stdout).text();
+  const err = await new Response(proc.stderr).text();
+  const result = await exitedWithTimeout(proc);
+  return { ok: result.exit === 0 && !result.timedOut, out, err, exit: result.exit, ms: result.ms };
+}
+
+async function username(): Promise<string> {
+  // Prefer `id -un` over process.env.USER — USER isn't guaranteed to be set
+  // in every invoking environment, and an empty string would make
+  // `loginctl enable-linger ""` fail silently.
+  const proc = Bun.spawn(["id", "-un"], { stdout: "pipe", stderr: "ignore" });
+  const out = await new Response(proc.stdout).text();
+  await exitedWithTimeout(proc);
+  return out.trim();
+}
+
 async function detectBun(): Promise<string> {
   const proc = Bun.spawn(["which", "bun"], { stdout: "pipe", stderr: "ignore" });
   const out = await new Response(proc.stdout).text();
@@ -80,7 +123,9 @@ async function detectBun(): Promise<string> {
   return path;
 }
 
-async function install(): Promise<void> {
+// ── darwin (launchd) ──
+
+async function installDarwin(): Promise<void> {
   if (!existsSync(TEMPLATE_PATH)) {
     console.error(`[InstallDerivedSync] template missing at ${TEMPLATE_PATH}`);
     process.exit(1);
@@ -121,7 +166,7 @@ async function install(): Promise<void> {
   }
 }
 
-async function uninstall(): Promise<void> {
+async function uninstallDarwin(): Promise<void> {
   const u = await uid();
   if (existsSync(TARGET_PLIST)) {
     const r = await launchctl(["bootout", `gui/${u}`, TARGET_PLIST]);
@@ -132,7 +177,7 @@ async function uninstall(): Promise<void> {
   }
 }
 
-async function status(): Promise<void> {
+async function statusDarwin(): Promise<void> {
   const u = await uid();
   const r = await launchctl(["print", `gui/${u}/${LABEL}`]);
   if (!r.ok) {
@@ -142,11 +187,79 @@ async function status(): Promise<void> {
   console.log(r.out);
 }
 
+// ── linux (systemd --user) ──
+
+async function installLinux(): Promise<void> {
+  if (!existsSync(SERVICE_TEMPLATE_PATH) || !existsSync(PATH_TEMPLATE_PATH)) {
+    console.error(`[InstallDerivedSync] template missing — expected ${SERVICE_TEMPLATE_PATH} and ${PATH_TEMPLATE_PATH}`);
+    process.exit(1);
+  }
+  const bunPath = await detectBun();
+  const bunDir = bunPath.replace(/\/bun$/, "");
+  const userDir = realpathSync(join(HOME, ".claude", "LIFEOS", "USER"));
+  console.log(`[InstallDerivedSync] detected bun at ${bunPath}`);
+
+  const materialize = (templatePath: string) =>
+    readFileSync(templatePath, "utf-8")
+      .replace(/\{\{HOME\}\}/g, HOME)
+      .replace(/\{\{BUN\}\}/g, bunPath)
+      .replace(/\{\{BUN_DIR\}\}/g, bunDir)
+      .replace(/\{\{USER_DIR\}\}/g, userDir);
+
+  if (!existsSync(SYSTEMD_USER_DIR)) mkdirSync(SYSTEMD_USER_DIR, { recursive: true });
+
+  // Idempotent teardown (ignore failures — first install has nothing to remove)
+  await systemctl(["disable", "--now", PATH_UNIT]);
+
+  writeFileSync(TARGET_SERVICE, materialize(SERVICE_TEMPLATE_PATH));
+  writeFileSync(TARGET_PATH, materialize(PATH_TEMPLATE_PATH));
+  console.log(`[InstallDerivedSync] wrote ${TARGET_SERVICE}`);
+  console.log(`[InstallDerivedSync] wrote ${TARGET_PATH}`);
+
+  await systemctl(["daemon-reload"]);
+
+  // Survive logout/reboot, same requirement PULSE/manage.sh documents for com.lifeos.pulse.
+  await Bun.spawn(["loginctl", "enable-linger", await username()], { stdout: "ignore", stderr: "ignore" }).exited;
+
+  const r = await systemctl(["enable", "--now", PATH_UNIT]);
+  if (!r.ok) {
+    console.error(`[InstallDerivedSync] enable --now failed: ${r.err.trim()}`);
+    process.exit(1);
+  }
+  console.log(`[InstallDerivedSync] systemd path unit enabled — ${PATH_UNIT} active`);
+
+  // RunAtLoad true equivalent — fire the service once immediately.
+  await systemctl(["start", `${LABEL}.service`]);
+
+  const list = await systemctl(["status", PATH_UNIT, "--no-pager"]);
+  if (list.ok || list.out) console.log(list.out.trim());
+}
+
+async function uninstallLinux(): Promise<void> {
+  await systemctl(["disable", "--now", PATH_UNIT]);
+  let removed = false;
+  for (const f of [TARGET_SERVICE, TARGET_PATH]) {
+    if (existsSync(f)) {
+      try { unlinkSync(f); console.log(`[InstallDerivedSync] removed ${f}`); removed = true; } catch {}
+    }
+  }
+  if (!removed) console.log(`[InstallDerivedSync] no unit files found — nothing to do`);
+  await systemctl(["daemon-reload"]);
+}
+
+async function statusLinux(): Promise<void> {
+  const r = await systemctl(["status", PATH_UNIT, "--no-pager"]);
+  console.log(r.out || r.err);
+  if (!r.ok) process.exit(1);
+}
+
+// ── dispatch ──
+
 async function main(): Promise<void> {
   const arg = process.argv[2];
-  if (arg === "--uninstall") return uninstall();
-  if (arg === "--status") return status();
-  return install();
+  if (arg === "--uninstall") return IS_LINUX ? uninstallLinux() : uninstallDarwin();
+  if (arg === "--status") return IS_LINUX ? statusLinux() : statusDarwin();
+  return IS_LINUX ? installLinux() : installDarwin();
 }
 
 main().catch((err) => { console.error(`[InstallDerivedSync] Fatal: ${err}`); process.exit(1); });

--- a/LifeOS/install/LIFEOS/TOOLS/InstallUsageAggregator.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/InstallUsageAggregator.ts
@@ -10,17 +10,40 @@
  * Reads $HOME, substitutes {{HOME}}/{{BUN}}/{{BUN_DIR}} in the template, writes
  * ~/Library/LaunchAgents/com.lifeos.usage-aggregator.plist, and runs launchctl
  * bootstrap. Idempotent: re-running bootouts the prior load before bootstrapping.
+ *
+ * Two backends, chosen by `process.platform` (same pattern as
+ * LIFEOS/PULSE/manage.sh and InstallWorkSweep.ts — macOS uses launchd,
+ * Linux uses systemd --user):
+ *
+ *  - darwin: materializes com.lifeos.usage-aggregator.plist.template into
+ *    ~/Library/LaunchAgents/ and bootstraps it with launchctl.
+ *  - linux: materializes com.lifeos.usage-aggregator.{service,timer}.template
+ *    into ~/.config/systemd/user/ and enables the timer with systemctl
+ *    --user. Requires `loginctl enable-linger $USER` for the timer to
+ *    survive logout (same requirement PULSE/manage.sh documents for
+ *    com.lifeos.pulse).
  */
 import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from "fs";
 import { join } from "path";
 
 declare const Bun: { spawn: (cmd: string[], opts?: any) => any };
 
+const IS_LINUX = process.platform === "linux";
 const HOME = process.env.HOME || "";
+const LABEL = "com.lifeos.usage-aggregator";
+
+// ── darwin (launchd) paths ──
 const TEMPLATE_PATH = join(HOME, ".claude", "LIFEOS", "TOOLS", "com.lifeos.usage-aggregator.plist.template");
 const LAUNCH_AGENTS_DIR = join(HOME, "Library", "LaunchAgents");
 const TARGET_PLIST = join(LAUNCH_AGENTS_DIR, "com.lifeos.usage-aggregator.plist");
-const LABEL = "com.lifeos.usage-aggregator";
+
+// ── linux (systemd --user) paths ──
+const SERVICE_TEMPLATE_PATH = join(HOME, ".claude", "LIFEOS", "TOOLS", "com.lifeos.usage-aggregator.service.template");
+const TIMER_TEMPLATE_PATH = join(HOME, ".claude", "LIFEOS", "TOOLS", "com.lifeos.usage-aggregator.timer.template");
+const SYSTEMD_USER_DIR = join(HOME, ".config", "systemd", "user");
+const TARGET_SERVICE = join(SYSTEMD_USER_DIR, `${LABEL}.service`);
+const TARGET_TIMER = join(SYSTEMD_USER_DIR, `${LABEL}.timer`);
+const TIMER_UNIT = `${LABEL}.timer`;
 
 async function uid(): Promise<string> {
   const proc = Bun.spawn(["id", "-u"], { stdout: "pipe", stderr: "ignore" });
@@ -29,8 +52,26 @@ async function uid(): Promise<string> {
   return out.trim();
 }
 
+async function username(): Promise<string> {
+  // Prefer `id -un` over process.env.USER — USER isn't guaranteed to be set
+  // in every invoking environment, and an empty string would make
+  // `loginctl enable-linger ""` fail silently.
+  const proc = Bun.spawn(["id", "-un"], { stdout: "pipe", stderr: "ignore" });
+  const out = await new Response(proc.stdout).text();
+  await proc.exited;
+  return out.trim();
+}
+
 async function launchctl(args: string[]): Promise<{ ok: boolean; out: string; err: string }> {
   const proc = Bun.spawn(["launchctl", ...args], { stdout: "pipe", stderr: "pipe" });
+  const out = await new Response(proc.stdout).text();
+  const err = await new Response(proc.stderr).text();
+  const exit = await proc.exited;
+  return { ok: exit === 0, out, err };
+}
+
+async function systemctl(args: string[]): Promise<{ ok: boolean; out: string; err: string }> {
+  const proc = Bun.spawn(["systemctl", "--user", ...args], { stdout: "pipe", stderr: "pipe" });
   const out = await new Response(proc.stdout).text();
   const err = await new Response(proc.stderr).text();
   const exit = await proc.exited;
@@ -46,7 +87,9 @@ async function detectBun(): Promise<string> {
   return path;
 }
 
-async function install(): Promise<void> {
+// ── darwin (launchd) ──
+
+async function installDarwin(): Promise<void> {
   if (!existsSync(TEMPLATE_PATH)) {
     console.error(`[InstallUsageAggregator] template missing at ${TEMPLATE_PATH}`);
     process.exit(1);
@@ -83,7 +126,7 @@ async function install(): Promise<void> {
   }
 }
 
-async function uninstall(): Promise<void> {
+async function uninstallDarwin(): Promise<void> {
   const u = await uid();
   if (existsSync(TARGET_PLIST)) {
     const r = await launchctl(["bootout", `gui/${u}`, TARGET_PLIST]);
@@ -94,7 +137,7 @@ async function uninstall(): Promise<void> {
   }
 }
 
-async function status(): Promise<void> {
+async function statusDarwin(): Promise<void> {
   const u = await uid();
   const r = await launchctl(["print", `gui/${u}/${LABEL}`]);
   if (!r.ok) {
@@ -104,11 +147,76 @@ async function status(): Promise<void> {
   console.log(r.out);
 }
 
+// ── linux (systemd --user) ──
+
+async function installLinux(): Promise<void> {
+  if (!existsSync(SERVICE_TEMPLATE_PATH) || !existsSync(TIMER_TEMPLATE_PATH)) {
+    console.error(`[InstallUsageAggregator] template missing — expected ${SERVICE_TEMPLATE_PATH} and ${TIMER_TEMPLATE_PATH}`);
+    process.exit(1);
+  }
+  const bunPath = await detectBun();
+  const bunDir = bunPath.replace(/\/bun$/, "");
+  console.log(`[InstallUsageAggregator] detected bun at ${bunPath}`);
+
+  const materialize = (templatePath: string) =>
+    readFileSync(templatePath, "utf-8")
+      .replace(/\{\{HOME\}\}/g, HOME)
+      .replace(/\{\{BUN\}\}/g, bunPath)
+      .replace(/\{\{BUN_DIR\}\}/g, bunDir);
+
+  if (!existsSync(SYSTEMD_USER_DIR)) mkdirSync(SYSTEMD_USER_DIR, { recursive: true });
+
+  // Idempotent teardown (ignore failures — first install has nothing to remove)
+  await systemctl(["disable", "--now", TIMER_UNIT]);
+
+  writeFileSync(TARGET_SERVICE, materialize(SERVICE_TEMPLATE_PATH));
+  writeFileSync(TARGET_TIMER, materialize(TIMER_TEMPLATE_PATH));
+  console.log(`[InstallUsageAggregator] wrote ${TARGET_SERVICE}`);
+  console.log(`[InstallUsageAggregator] wrote ${TARGET_TIMER}`);
+
+  await systemctl(["daemon-reload"]);
+
+  // Survive logout/reboot, same requirement PULSE/manage.sh documents for com.lifeos.pulse.
+  await Bun.spawn(["loginctl", "enable-linger", await username()], { stdout: "ignore", stderr: "ignore" }).exited;
+
+  const r = await systemctl(["enable", "--now", TIMER_UNIT]);
+  if (!r.ok) {
+    console.error(`[InstallUsageAggregator] enable --now failed: ${r.err.trim()}`);
+    process.exit(1);
+  }
+  console.log(`[InstallUsageAggregator] systemd timer enabled — ${TIMER_UNIT} active (nightly 03:30, + boot run)`);
+
+  const list = await systemctl(["list-timers", TIMER_UNIT, "--no-pager"]);
+  if (list.ok) console.log(list.out.trim());
+}
+
+async function uninstallLinux(): Promise<void> {
+  await systemctl(["disable", "--now", TIMER_UNIT]);
+  let removed = false;
+  for (const f of [TARGET_SERVICE, TARGET_TIMER]) {
+    if (existsSync(f)) {
+      try { unlinkSync(f); console.log(`[InstallUsageAggregator] removed ${f}`); removed = true; } catch {}
+    }
+  }
+  if (!removed) console.log(`[InstallUsageAggregator] no unit files found — nothing to do`);
+  await systemctl(["daemon-reload"]);
+}
+
+async function statusLinux(): Promise<void> {
+  const r = await systemctl(["status", TIMER_UNIT, "--no-pager"]);
+  console.log(r.out || r.err);
+  const list = await systemctl(["list-timers", TIMER_UNIT, "--no-pager"]);
+  if (list.ok) console.log(list.out.trim());
+  if (!r.ok) process.exit(1);
+}
+
+// ── dispatch ──
+
 async function main(): Promise<void> {
   const arg = process.argv[2];
-  if (arg === "--uninstall") return uninstall();
-  if (arg === "--status") return status();
-  return install();
+  if (arg === "--uninstall") return IS_LINUX ? uninstallLinux() : uninstallDarwin();
+  if (arg === "--status") return IS_LINUX ? statusLinux() : statusDarwin();
+  return IS_LINUX ? installLinux() : installDarwin();
 }
 
 if (import.meta.main) {

--- a/LifeOS/install/LIFEOS/TOOLS/com.lifeos.codexupdate.service.template
+++ b/LifeOS/install/LIFEOS/TOOLS/com.lifeos.codexupdate.service.template
@@ -1,0 +1,32 @@
+# com.lifeos.codexupdate.service.template — Source template (Linux/systemd --user).
+# Install via:
+#   bun ~/.claude/LIFEOS/TOOLS/InstallCodexUpdate.ts
+#
+# The installer reads $HOME at install time, substitutes {{HOME}}/{{BUN}}/{{BUN_DIR}}
+# placeholders, writes the materialized units to ~/.config/systemd/user/, and
+# enables the timer via systemctl --user. This template stays clean of
+# principal-specific paths so it ships in the public LifeOS release,
+# mirroring the macOS com.lifeos.codexupdate.plist.template (same daily
+# 04:00 cadence, no boot-time run, same log target family).
+#
+# Behavior: one-shot run of CodexUpdate.ts, triggered by the paired .timer
+# unit (com.lifeos.codexupdate.timer — daily at 04:00 local). No boot-time
+# run — avoids reinstalling the codex global on every login, same reason
+# the launchd plist omits RunAtLoad. StartLimitIntervalSec/StartLimitBurst
+# are the systemd analog of the launchd plist's ThrottleInterval 60.
+# stdout/stderr captured to MEMORY/STATE/com.lifeos.codexupdate.log, same
+# as the launchd StandardOutPath/StandardErrorPath.
+
+[Unit]
+Description=LifeOS Codex update — keeps the Codex mirror / update state current
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+[Service]
+Type=oneshot
+ExecStart={{BUN}} {{HOME}}/.claude/LIFEOS/TOOLS/CodexUpdate.ts
+WorkingDirectory={{HOME}}/.claude
+Environment=HOME={{HOME}}
+Environment=PATH={{BUN_DIR}}:/usr/local/bin:/usr/bin:/bin
+StandardOutput=append:{{HOME}}/.claude/LIFEOS/MEMORY/STATE/com.lifeos.codexupdate.log
+StandardError=append:{{HOME}}/.claude/LIFEOS/MEMORY/STATE/com.lifeos.codexupdate.log

--- a/LifeOS/install/LIFEOS/TOOLS/com.lifeos.codexupdate.timer.template
+++ b/LifeOS/install/LIFEOS/TOOLS/com.lifeos.codexupdate.timer.template
@@ -1,0 +1,14 @@
+# com.lifeos.codexupdate.timer.template — pairs with com.lifeos.codexupdate.service.template.
+# Equivalent to the launchd plist's StartCalendarInterval Hour=4 Minute=0
+# with no RunAtLoad: fires once daily at 04:00 local time, no boot-time run.
+
+[Unit]
+Description=LifeOS Codex update timer — daily 04:00
+
+[Timer]
+OnCalendar=*-*-* 04:00:00
+Persistent=true
+Unit=com.lifeos.codexupdate.service
+
+[Install]
+WantedBy=timers.target

--- a/LifeOS/install/LIFEOS/TOOLS/com.lifeos.commitmentsweep.service.template
+++ b/LifeOS/install/LIFEOS/TOOLS/com.lifeos.commitmentsweep.service.template
@@ -1,0 +1,31 @@
+# com.lifeos.commitmentsweep.service.template — Source template (Linux/systemd --user).
+# Install via:
+#   bun ~/.claude/LIFEOS/TOOLS/InstallCommitmentSweep.ts
+#
+# The installer reads $HOME at install time, substitutes {{HOME}}/{{BUN}}/{{BUN_DIR}}
+# placeholders, writes the materialized units to ~/.config/systemd/user/, and
+# enables the timer via systemctl --user. This template stays clean of
+# principal-specific paths so it ships in the public LifeOS release,
+# mirroring the macOS com.lifeos.commitmentsweep.plist.template (same daily
+# 7am cadence, same log target family).
+#
+# Behavior: one-shot run of CommitmentSweep.ts, triggered by the paired
+# .timer unit (com.lifeos.commitmentsweep.timer — daily at 07:00 local).
+# StartLimitIntervalSec/StartLimitBurst are the systemd analog of the
+# launchd plist's ThrottleInterval 60. stdout/stderr captured to
+# MEMORY/STATE/com.lifeos.commitmentsweep.log, same as the launchd
+# StandardOutPath/StandardErrorPath.
+
+[Unit]
+Description=LifeOS Commitment sweep — daily commitments/reminders cadence
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+[Service]
+Type=oneshot
+ExecStart={{BUN}} {{HOME}}/.claude/LIFEOS/TOOLS/CommitmentSweep.ts
+WorkingDirectory={{HOME}}/.claude
+Environment=HOME={{HOME}}
+Environment=PATH={{BUN_DIR}}:/usr/local/bin:/usr/bin:/bin
+StandardOutput=append:{{HOME}}/.claude/LIFEOS/MEMORY/STATE/com.lifeos.commitmentsweep.log
+StandardError=append:{{HOME}}/.claude/LIFEOS/MEMORY/STATE/com.lifeos.commitmentsweep.log

--- a/LifeOS/install/LIFEOS/TOOLS/com.lifeos.commitmentsweep.timer.template
+++ b/LifeOS/install/LIFEOS/TOOLS/com.lifeos.commitmentsweep.timer.template
@@ -1,0 +1,15 @@
+# com.lifeos.commitmentsweep.timer.template — pairs with com.lifeos.commitmentsweep.service.template.
+# Equivalent to the launchd plist's StartCalendarInterval Hour=7 Minute=0
+# with RunAtLoad false: fires once daily at 07:00 local time, no boot-time
+# catch-up run.
+
+[Unit]
+Description=LifeOS Commitment sweep timer — daily 07:00
+
+[Timer]
+OnCalendar=*-*-* 07:00:00
+Persistent=true
+Unit=com.lifeos.commitmentsweep.service
+
+[Install]
+WantedBy=timers.target

--- a/LifeOS/install/LIFEOS/TOOLS/com.lifeos.derivedsync.path.template
+++ b/LifeOS/install/LIFEOS/TOOLS/com.lifeos.derivedsync.path.template
@@ -1,0 +1,21 @@
+# com.lifeos.derivedsync.path.template — pairs with com.lifeos.derivedsync.service.template.
+# Equivalent to the launchd plist's WatchPaths (7 USER subdirectories) +
+# RunAtLoad true: PathModified fires the paired .service on any change under
+# these paths, and the installer starts the service once at install time to
+# match RunAtLoad's "fire once immediately" behavior.
+
+[Unit]
+Description=LifeOS Derived-file sync watcher — USER source directories
+
+[Path]
+PathModified={{USER_DIR}}
+PathModified={{USER_DIR}}/TELOS
+PathModified={{USER_DIR}}/TELOS/IDEAL_STATE
+PathModified={{USER_DIR}}/TELOS/CURRENT_STATE
+PathModified={{USER_DIR}}/PRINCIPAL
+PathModified={{USER_DIR}}/DIGITAL_ASSISTANT
+PathModified={{USER_DIR}}/CONFIG
+Unit=com.lifeos.derivedsync.service
+
+[Install]
+WantedBy=default.target

--- a/LifeOS/install/LIFEOS/TOOLS/com.lifeos.derivedsync.service.template
+++ b/LifeOS/install/LIFEOS/TOOLS/com.lifeos.derivedsync.service.template
@@ -1,0 +1,36 @@
+# com.lifeos.derivedsync.service.template — Source template (Linux/systemd --user).
+# Install via:
+#   bun ~/.claude/LIFEOS/TOOLS/InstallDerivedSync.ts
+#
+# The installer reads $HOME at install time, resolves LIFEOS/USER to the real
+# USER directory, substitutes {{HOME}}/{{BUN}}/{{BUN_DIR}}/{{USER_DIR}}
+# placeholders, writes the materialized units to ~/.config/systemd/user/, and
+# enables them via systemctl --user. This template stays clean of
+# principal-specific paths so it ships in the public LifeOS release,
+# mirroring the macOS com.lifeos.derivedsync.plist.template (same trigger
+# paths, same log target family).
+#
+# Behavior: one-shot run of DerivedSync.ts, triggered by the paired .path
+# unit (com.lifeos.derivedsync.path — fires on any USER source change).
+# StartLimitIntervalSec/StartLimitBurst below are the systemd analog of the
+# launchd plist's ThrottleInterval 30 (crash-loop rate limiting; DerivedSync
+# itself is a silent no-op on unchanged file hashes, so this rarely matters
+# in practice). stdout/stderr captured to
+# MEMORY/OBSERVABILITY/derived-sync-systemd.log — a separate log file from
+# the launchd side's derived-sync-launchd.log (DerivedSync.ts's own
+# structured log at MEMORY/OBSERVABILITY/derived-sync.jsonl is shared by
+# both backends).
+
+[Unit]
+Description=LifeOS Derived-file sync — regenerates PRINCIPAL_TELOS, LIFEOS_STATE, Data-Plane on USER hand-edits
+StartLimitIntervalSec=30
+StartLimitBurst=5
+
+[Service]
+Type=oneshot
+ExecStart={{BUN}} {{HOME}}/.claude/LIFEOS/TOOLS/DerivedSync.ts
+WorkingDirectory={{HOME}}/.claude
+Environment=HOME={{HOME}}
+Environment=PATH={{BUN_DIR}}:{{HOME}}/.local/bin:/usr/local/bin:/usr/bin:/bin
+StandardOutput=append:{{HOME}}/.claude/LIFEOS/MEMORY/OBSERVABILITY/derived-sync-systemd.log
+StandardError=append:{{HOME}}/.claude/LIFEOS/MEMORY/OBSERVABILITY/derived-sync-systemd.log

--- a/LifeOS/install/LIFEOS/TOOLS/com.lifeos.usage-aggregator.service.template
+++ b/LifeOS/install/LIFEOS/TOOLS/com.lifeos.usage-aggregator.service.template
@@ -1,0 +1,33 @@
+# com.lifeos.usage-aggregator.service.template — Source template (Linux/systemd --user).
+# Install via:
+#   bun ~/.claude/LIFEOS/TOOLS/InstallUsageAggregator.ts
+#
+# The installer reads $HOME at install time, substitutes {{HOME}}/{{BUN}}/{{BUN_DIR}}
+# placeholders, writes the materialized units to ~/.config/systemd/user/, and
+# enables the timer via systemctl --user. This template stays clean of
+# principal-specific paths so it ships in the public LifeOS release,
+# mirroring the macOS com.lifeos.usage-aggregator.plist.template (same
+# nightly 03:30 cadence + boot-time run, same log target family).
+#
+# Behavior: one-shot run of UsageAggregator.ts, triggered by the paired
+# .timer unit (com.lifeos.usage-aggregator.timer — nightly at 03:30 local,
+# plus once ~2min after boot to populate the durable store immediately,
+# same intent as the launchd plist's RunAtLoad true). StartLimitIntervalSec/
+# StartLimitBurst are the systemd analog of the launchd plist's
+# ThrottleInterval 60. stdout/stderr captured to
+# MEMORY/STATE/com.lifeos.usage-aggregator.log, same as the launchd
+# StandardOutPath/StandardErrorPath.
+
+[Unit]
+Description=LifeOS Usage aggregator — nightly usage/cost telemetry rollup
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+[Service]
+Type=oneshot
+ExecStart={{BUN}} {{HOME}}/.claude/LIFEOS/TOOLS/UsageAggregator.ts
+WorkingDirectory={{HOME}}/.claude
+Environment=HOME={{HOME}}
+Environment=PATH={{BUN_DIR}}:/usr/local/bin:/usr/bin:/bin
+StandardOutput=append:{{HOME}}/.claude/LIFEOS/MEMORY/STATE/com.lifeos.usage-aggregator.log
+StandardError=append:{{HOME}}/.claude/LIFEOS/MEMORY/STATE/com.lifeos.usage-aggregator.log

--- a/LifeOS/install/LIFEOS/TOOLS/com.lifeos.usage-aggregator.timer.template
+++ b/LifeOS/install/LIFEOS/TOOLS/com.lifeos.usage-aggregator.timer.template
@@ -1,0 +1,17 @@
+# com.lifeos.usage-aggregator.timer.template — pairs with com.lifeos.usage-aggregator.service.template.
+# Equivalent to the launchd plist's StartCalendarInterval Hour=3 Minute=30
+# plus RunAtLoad true: OnCalendar fires nightly at 03:30, and OnBootSec
+# fires once ~2min after boot so the durable store is populated
+# immediately, same as RunAtLoad's "fire once when loaded" behavior.
+
+[Unit]
+Description=LifeOS Usage aggregator timer — nightly 03:30
+
+[Timer]
+OnBootSec=2min
+OnCalendar=*-*-* 03:30:00
+Persistent=true
+Unit=com.lifeos.usage-aggregator.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## What's broken

`DerivedSync.ts` / `CommitmentSweep.ts` / `UsageAggregator.ts` / `CodexUpdate.ts` have no macOS dependency in their service bodies (they're plain bun scripts), but their installers only know how to write a launchd plist — so none of the 4 can be scheduled on Linux.

`DerivedSync` in particular has real user-visible impact: it's what keeps `PRINCIPAL_TELOS.md` (imported by `CLAUDE.md`) and `LIFEOS_STATE.json` (read by the statusline rings) in sync with hand-edited TELOS files. Without it, those two files silently go stale after every TELOS edit.

## Fix

Follows the `process.platform` dispatch pattern `InstallWorkSweep.ts` established (#1692, closed/ported): darwin path untouched, linux path materializes a systemd `--user` unit pair instead of a plist.

- **derivedsync**: `WatchPaths` (7 dirs) + `RunAtLoad` → `.path` unit (`PathModified` x7) + `.service` (oneshot); the service is started once at install time to match `RunAtLoad`'s "fire once when loaded" behavior
- **commitmentsweep**: `StartCalendarInterval` 07:00 → `.timer` (`OnCalendar`, `Persistent=true`) + `.service`
- **usage-aggregator**: `StartCalendarInterval` 03:30 + `RunAtLoad` → `.timer` (`OnCalendar` + `OnBootSec=2min`) + `.service`
- **codexupdate**: `StartCalendarInterval` 04:00, no `RunAtLoad` → `.timer` (`OnCalendar` only) + `.service`

`ThrottleInterval` becomes `StartLimitIntervalSec`/`StartLimitBurst` on the `.service` (not on derivedsync's `.path` — `TriggerLimitIntervalSec` needs systemd 255+, unavailable on e.g. Debian 12's 252).

`InstallCommitmentSweep.ts`'s darwin plist hardcodes `/opt/homebrew/bin/bun` (no `detectBun()`) — left untouched. Only the new linux path calls a newly-added `detectBun()` to resolve `{{BUN}}` in the systemd templates.

Also fixes `BackgroundServices.md`'s now-inaccurate "macOS-only" claim in the Fresh Install section.

## Why this doesn't change macOS behavior

Every deletion in this diff is either a `const` moved a few lines up (`LABEL`, `STATE_DIR`, `COMMAND_TIMEOUT_MS` — same value, same file, just relocated next to the other platform-specific paths) or a dispatch line that now ternaries into the same original function, renamed `*Darwin` with its body byte-for-byte unchanged. No darwin behavior is touched.

## Verification

Tested end-to-end on Ubuntu 24.04 / systemd 255:

- `systemd-analyze --user verify` passes clean on all 8 new units
- **DerivedSync**: install → `.path` unit active → touching `TELOS.md` fired a targeted re-run (confirmed via the tool's own `derived-sync.jsonl` log — only the actions tied to the changed file ran) → `PRINCIPAL_TELOS.md` regenerated. Re-running install is idempotent. `--uninstall` removes both units cleanly.
- **UsageAggregator**: install → the boot-equivalent run fired immediately, exited 0, wrote `usage-daily.jsonl`. Timer correctly queued for the next 03:30.
- **CommitmentSweep**: install → timer correctly queued for the next 07:00; service not run (matches `RunAtLoad false`).
- **CodexUpdate**: timer registered for 04:00; service deliberately left un-started in this test (it has global-install side effects) — `systemctl --user is-active` confirms `inactive`.

Unrelated pre-existing bug found during verification, not fixed here (out of scope — it's in `DerivedSync.ts`'s own logic, not the installer/scheduler): `DeriveDenyHashes.ts` fails with `ENOENT` because `~/.claude/skills/_LIFEOS/` doesn't exist on this host. Would fail identically under launchd.

Related: #1692 (WorkSweep systemd backend, same pattern, ported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)