### PR TITLE
fix(pulse/observability): sample-entry regex, fd leak, unbounded caches, gendered string

### DIFF
--- a/LifeOS/install/LIFEOS/PULSE/Observability/observability.ts
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/observability.ts
@@ -143,10 +143,14 @@ function readJsonlByteTail(filePath: string, maxBytes: number): any[] {
     const size = statSync(filePath).size
     const start = Math.max(0, size - maxBytes)
     const fd = openSync(filePath, "r")
-    const buf = Buffer.alloc(size - start)
-    readSync(fd, buf, 0, buf.length, start)
-    closeSync(fd)
-    let text = buf.toString("utf-8")
+    let text: string
+    try {
+      const buf = Buffer.alloc(size - start)
+      readSync(fd, buf, 0, buf.length, start)
+      text = buf.toString("utf-8")
+    } finally {
+      closeSync(fd)
+    }
     if (start > 0) {
       const nl = text.indexOf("\n")
       text = nl === -1 ? "" : text.slice(nl + 1)

--- a/LifeOS/install/LIFEOS/PULSE/Observability/observability.ts
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/observability.ts
@@ -3959,7 +3959,7 @@ function buildTeamFromUserFiles(appIds: string[]): OverviewTeam[] | null {
   if (principal) {
     team.push({
       id: "T0", name: principal, role: "Principal", kind: "human", owns: [],
-      avatar: principal.charAt(0), note: "Sets direction. Everything here serves his TELOS.",
+      avatar: principal.charAt(0), note: "Sets direction. Everything here serves the principal's TELOS.",
     })
   }
   const da = nameFrom(readMd(join(USER_DIR, "DIGITAL_ASSISTANT", "DA_IDENTITY.md")))

--- a/LifeOS/install/LIFEOS/PULSE/Observability/observability.ts
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/observability.ts
@@ -4234,7 +4234,10 @@ function handleLifeCardApi(): Response {
 // arm on a fresh install: the "run /interview" onboarding banner never rendered,
 // and Pulse presented the fabricated sample mission and goals to the new user as
 // if they were their own. Placeholder entries do not count as personalization.
-const SAMPLE_ENTRY_RE = /^\**\s*\(sample\)/i
+// \b not literal ")": the scaffold also writes "(sample — …)" variants (e.g.
+// MISSION.md M2), which a literal match let through. Same fix as the sibling
+// filter in LIFEOS/TOOLS/GenerateTelosSummary.ts.
+const SAMPLE_ENTRY_RE = /^\**\s*\(sample\b/i
 
 function telosPersonalized(): boolean {
   try {

--- a/LifeOS/install/LIFEOS/PULSE/Observability/observability.ts
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/observability.ts
@@ -285,6 +285,21 @@ function foldClimbLine(map: Map<string, ClimbPoint[]>, line: string): void {
   map.set(ev.slug, points)
 }
 
+// Key-count eviction. The per-key series are ring-buffered (200 points / 600
+// ticks), but the number of KEYS was unbounded: every slug and every session_id
+// the daemon ever folded stayed resident for its lifetime. Nothing downstream
+// reads a series whose newest point is older than the stalest run window
+// (RUN_ACTIVITY.nativeStaleMs, 4h), so a day of retention is generous. Called
+// on the fold path only — an unchanged log returns early and grows nothing.
+const CACHE_RETENTION_MS = 24 * 60 * 60 * 1000
+
+function evictStaleSeries<T extends { ts: number }>(map: Map<string, T[]>, now: number): void {
+  for (const [key, series] of map) {
+    const last = series[series.length - 1]
+    if (!last || now - last.ts > CACHE_RETENTION_MS) map.delete(key)
+  }
+}
+
 export function getClimbData(): Map<string, ClimbPoint[]> {
   try {
     if (!existsSync(WORK_EVENTS_PATH)) return new Map()
@@ -314,6 +329,7 @@ export function getClimbData(): Map<string, ClimbPoint[]> {
     climbCache.offset += Buffer.byteLength(complete, "utf-8") + 1
 
     for (const line of complete.split("\n")) foldClimbLine(climbCache.data, line)
+    evictStaleSeries(climbCache.data, Date.now())
     return climbCache.data
   } catch {
     return climbCache.data
@@ -444,6 +460,7 @@ export function getActivityData(): Map<string, ToolTick[]> {
     const remainder = chunk.slice(lastNewline + 1)
     activityCache.offset = st.size - Buffer.byteLength(remainder, "utf-8")
     for (const line of chunk.slice(0, lastNewline).split("\n")) foldActivityLine(line)
+    evictStaleSeries(activityCache.bySession, Date.now())
     return activityCache.bySession
   } catch {
     return activityCache.bySession


### PR DESCRIPTION
<!-- commit-map -->
**4 commits, one per fix**, so each can be cherry-picked independently. Each was verified to apply cleanly onto `47df8ee` by itself.

| Commit | Fix |
|---|---|
| `f2f01fd` | close the fd when readJsonlByteTail throws |
| `6ef670c` | evict stale series keys from the activity and climb caches |
| `6eb8d90` | drop the gendered pronoun from a shipped API response |
| `5d71e64` | match the shipped "(sample — …)" entries in SAMPLE_ENTRY_RE |

---

Four defects in `LIFEOS/PULSE/Observability/observability.ts`, all in code added or changed by 7.28.3.

- **`SAMPLE_ENTRY_RE` (~4216)** — `/^\**\s*\(sample\)/i` requires a literal `)`, so it misses the shipped `(sample — …)` entries. `MISSION.md:M2` alone made `realEntries(mission) > 0`, so `telosPersonalized()` returned true on a fresh install, template mode never armed, and Pulse showed the sample mission and goals to a new user as their own. Now `\(sample\b`, matching the sibling filter in `LIFEOS/TOOLS/GenerateTelosSummary.ts:164`.
- **`readJsonlByteTail` (~147)** — no `try/finally` around the fd, so a throw between open and close leaks it. Both sibling readers added in the same change already have the guard; this matches them.
- **`activityCache` / `climbCache` (~405)** — each series is capped, but the number of KEYS was unbounded: every slug and session_id ever folded stayed resident for the daemon's life. Adds key eviction on the fold path only.
- **`buildTeamFromUserFiles` (~3941)** — a hardcoded gendered pronoun in a shipped API response, in a function whose own comment says names never live in this file. Now phrased without one.

Verified: a scratch harness against the real shipped `USER/TELOS` scaffold — 28 sample bullets, 0 missed by the new regex, real entries still pass, eviction keeps live keys and drops stale.

One thing for the porter: the cache eviction is a real behaviour change for `climbCache`, not only memory. `buildIscDeltas` computes all-time totals from a slug's points, so an ISA quiet for >24h then resuming re-seeds from `prevDone = 0` and shows a one-off spike. 24h was chosen as 6x the widest consumer window (`RUN_ACTIVITY.nativeStaleMs`, 4h). Bounding key count instead of age is the alternative if all-time totals are meant to be durable.

---

**Testing.** Commands and output are in the per-file notes above. I did **not** do a fresh-system install verification (contributing step 3) — these are targeted fixes verified per-file, not an install run.

