### PR TITLE
fix(observability): five React defects incl. Memory Graph crash on fresh installs

### DIFF
--- a/LifeOS/install/LIFEOS/PULSE/Observability/src/app/algorithm/page.tsx
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/src/app/algorithm/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Workflow,
   ArrowRight,
@@ -148,6 +148,10 @@ export default function AlgorithmPage() {
   const [docNote, setDocNote] = useState("");
 
   const [regenerating, setRegenerating] = useState(false);
+  // The regenerate poll starts in a click handler, not an effect — hold its id
+  // so unmount can clear it (it otherwise runs for up to 15 minutes).
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  useEffect(() => () => { if (pollRef.current) clearInterval(pollRef.current); }, []);
 
   const load = useCallback(() => {
     fetch("/api/algorithm-tab")
@@ -278,10 +282,12 @@ export default function AlgorithmPage() {
           setData(d);
           if (!d.generating || Date.now() - startedAt > 15 * 60_000) {
             clearInterval(poll);
+            pollRef.current = null;
             setRegenerating(false);
           }
         } catch { /* keep polling */ }
       }, 5000);
+      pollRef.current = poll;
     } catch (e: any) {
       setError(String(e?.message ?? e));
       setRegenerating(false);

--- a/LifeOS/install/LIFEOS/PULSE/Observability/src/app/ledger/page.tsx
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/src/app/ledger/page.tsx
@@ -86,7 +86,7 @@ export default function LedgerPage() {
     const load = () =>
       fetch("/api/ledger")
         .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
-        .then((j) => alive && setData(j))
+        .then((j) => { if (alive) { setData(j); setError(null); } })
         .catch((e) => alive && setError(String(e)));
     load();
     const t = setInterval(load, 60_000);

--- a/LifeOS/install/LIFEOS/PULSE/Observability/src/app/memory/graph/page.tsx
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/src/app/memory/graph/page.tsx
@@ -15,7 +15,8 @@ import { Network, Search, ArrowLeft, CornerDownRight, ExternalLink, Tag, X } fro
 interface MemNode { id: string; title: string; category: string; backlinkCount: number; silo: string; type: string; tags: string[]; pagerank: number }
 interface MemEdge { source: string; target: string; kind: string }
 interface Theme { tag: string; count: number }
-interface MemGraph { nodes: MemNode[]; edges: MemEdge[]; themes: Theme[]; built: string | null; nodeCount?: number; edgeCount?: number }
+// themes is optional: the no-graph fallback answers 200 with nodes/edges only.
+interface MemGraph { nodes: MemNode[]; edges: MemEdge[]; themes?: Theme[]; built: string | null; nodeCount?: number; edgeCount?: number }
 
 // Every silo's nodes are wiki-indexed, so a focused node can open as a note.
 function noteUrl(node: MemNode): string | null {
@@ -254,7 +255,7 @@ export default function MemoryGraphPage() {
                 A theme is a tag running through your notes. Click one to see its members and how they connect.
               </div>
               <div className="flex flex-wrap gap-1.5">
-                {data.themes.map((t) => (
+                {(data.themes ?? []).map((t) => (
                   <button key={t.tag} onClick={() => { setTheme(theme === t.tag ? null : t.tag); setFocus(null); setTrail([]); }}
                     className={"px-2 py-0.5 rounded-full border text-[11px] transition-colors " + (theme === t.tag ? "border-sky-500/50 bg-sky-500/10 text-sky-300" : "border-line-2 bg-surface-2 text-ink-2 hover:border-line-3 hover:text-ink-1")}
                     style={font}>

--- a/LifeOS/install/LIFEOS/PULSE/Observability/src/components/activity/CapabilityStrip.tsx
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/src/components/activity/CapabilityStrip.tsx
@@ -150,21 +150,25 @@ export default function CapabilityStrip() {
   const [data, setData] = useState<CapabilitiesData | null>(null);
   const [windowMin, setWindowMin] = useState(60);
 
-  const fetchData = useCallback(async () => {
+  const fetchData = useCallback(async (signal?: AbortSignal) => {
     try {
       const d = await localOnlyApiCall<CapabilitiesData>(
         `/api/capabilities?window=${windowMin}`,
+        { signal },
       );
-      setData(d);
+      if (!signal?.aborted) setData(d);
     } catch {
       // strip stays hidden until data arrives
     }
   }, [windowMin]);
 
   useEffect(() => {
-    fetchData();
-    const interval = setInterval(fetchData, 10000);
-    return () => clearInterval(interval);
+    // Aborted on window switch, so a slower response for the old window can
+    // never land on top of the newer one.
+    const ac = new AbortController();
+    fetchData(ac.signal);
+    const interval = setInterval(() => fetchData(ac.signal), 10000);
+    return () => { ac.abort(); clearInterval(interval); };
   }, [fetchData]);
 
   const { active, quiet } = useMemo(() => {

--- a/LifeOS/install/LIFEOS/PULSE/Observability/src/components/activity/WorkBoard.tsx
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/src/components/activity/WorkBoard.tsx
@@ -947,8 +947,8 @@ export default function WorkBoard() {
               <BoardRow
                 key={s.sessionId}
                 s={s}
-                expanded={false}
-                onToggle={() => {}}
+                expanded={expandedId === s.sessionId}
+                onToggle={() => setExpandedId(expandedId === s.sessionId ? null : s.sessionId)}
               />
             ))}
           </div>


### PR DESCRIPTION
<!-- commit-map -->
**5 commits, one per fix**, so each can be cherry-picked independently. Each was verified to apply cleanly onto `47df8ee` by itself.

| Commit | Fix |
|---|---|
| `bbe709a` | stop the Memory Graph route crashing on fresh installs |
| `52552da` | clear the Ledger error on a successful poll |
| `d730b30` | clear the Algorithm regenerate interval on unmount |
| `9e04106` | make Live-sessions rows actually expand |
| `524028c` | abort in-flight CapabilityStrip fetches on window switch |

---

Five React defects under `LIFEOS/PULSE/Observability/src/`.

- **`app/memory/graph/page.tsx:257`** — `data.themes.map` crashes the whole Memory Graph route on a fresh install. `handleMemoryGraphApi` returns a default **200** carrying `communities` and no `themes` when the graph file is absent, and the only guard is `!data`, which a truthy themeless object passes. `themes` is now optional on the interface and the call site defaults it.
- **`app/ledger/page.tsx:90`** — the success path never cleared `error`, and `if (error)` replaces the whole page, so one transient fetch failure pinned the Ledger to its error state permanently.
- **`app/algorithm/page.tsx:275`** — `setInterval` created inside a click handler rather than an effect, leaking up to 15 minutes of `setState` on an unmounted component. Adds a ref plus an unmount effect, matching the file's existing idiom.
- **`components/activity/WorkBoard.tsx:950`** — the Live-sessions section hard-coded `expanded={false}` and a no-op `onToggle` while `BoardRow` still rendered the chevron, `cursor-pointer` and hover background, so the row advertised itself as clickable and did nothing. Wired to `expandedId`/`setExpandedId` exactly as the sibling sections are.
- **`components/activity/CapabilityStrip.tsx:153`** — no AbortController or generation guard, so after a window switch the slower 24h response overwrote the newer 1h one.

Verified: `tsc --noEmit` output is byte-identical to the clean tree (confirmed by stashing and re-running) — the one remaining error is pre-existing in `app/telos/_v7/app.tsx`, untouched here. `next build` was deliberately not run: `generateBuildId` uses a timestamp and `distDir` is the tracked `out/`, so it would rewrite committed artifacts, and `typescript.ignoreBuildErrors` is set so it adds no checking.

---

**Testing.** Commands and output are in the per-file notes above. I did **not** do a fresh-system install verification (contributing step 3) — these are targeted fixes verified per-file, not an install run.

