### PR TITLE
fix(atlas): write the Pulse snapshot atomically

### DIFF
--- a/LifeOS/install/LIFEOS/ATLAS/Atlas.ts
+++ b/LifeOS/install/LIFEOS/ATLAS/Atlas.ts
@@ -17,7 +17,8 @@
  * the authority; `atlas owns` runs alongside it, never instead of it (Algorithm claim 16).
  */
 
-import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, renameSync } from "node:fs";
+import { atomicWriteText } from "../PULSE/lib/atomic-write";
 import { EVENTS_PATH, SNAPSHOT_PATH, Store, type Collector } from "./Store";
 import { cloudflare } from "./collectors/Cloudflare";
 import { github } from "./collectors/Github";
@@ -57,7 +58,7 @@ async function runSync(names: string[], scope: string): Promise<number> {
         console.error(`✗ ${name}: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
-    writeFileSync(SNAPSHOT_PATH, JSON.stringify(store.exportSnapshot()));
+    atomicWriteText(SNAPSHOT_PATH, JSON.stringify(store.exportSnapshot()));
   } finally {
     store.close();
   }
@@ -174,7 +175,7 @@ switch (cmd) {
   }
   case "export": {
     const store = new Store();
-    writeFileSync(SNAPSHOT_PATH, JSON.stringify(store.exportSnapshot()));
+    atomicWriteText(SNAPSHOT_PATH, JSON.stringify(store.exportSnapshot()));
     console.log(`snapshot → ${SNAPSHOT_PATH}`);
     store.close();
     break;


### PR DESCRIPTION
<!-- commit-map -->
**One commit, one fix** — `2df5e0c`, applies cleanly onto `47df8ee` on its own.

`LIFEOS/ATLAS/Atlas.ts` writes the Pulse snapshot with `writeFileSync` at two call sites (`runSync` and `case "export"`). That is truncate-then-write, and there is a documented concurrent reader: `PULSE/modules/atlas.ts:160` does `JSON.parse(readFileSync(SNAPSHOT_PATH))` on every `GET /api/atlas`, and `ATLAS/Store.ts:5` states "Pulse reads a redacted snapshot, never the live DB". A reader landing mid-write sees a truncated prefix and throws.

Both sites now use the existing `atomicWriteText` helper (temp file + rename), so a reader sees either the whole previous snapshot or the whole new one.

- `atomicWriteText`, not `atomicWriteJSON` — the latter reformats to `JSON.stringify(data, null, 2)`, which would change the snapshot's bytes. This keeps the compact output identical.
- Import path `../PULSE/lib/atomic-write` follows the convention already used by `LIFEOS/TOOLS/MergeSettings.ts:16` and `SettingsBackport.ts:45`.
- `writeFileSync` dropped from the `node:fs` import; it had no other use in the file.

Verified by bundling: `bun build --target=bun LIFEOS/ATLAS/Atlas.ts` resolves 10 modules and the helper's `renameSync(tmp, filePath)` is inlined in the output.

Out of scope but same class: `PULSE/modules/atlas.ts` writes its own `INSIGHTS_CACHE` with `writeFileSync`. Left alone here.

---

**Testing.** Commands and output are in the per-file notes above. I did **not** do a fresh-system install verification (contributing step 3) — these are targeted fixes verified per-file, not an install run.

