### PR TITLE
fix: match .yml as well as .yaml in the four sites that discover YAML files

### DIFF
--- a/LifeOS/install/LIFEOS/PULSE/modules/tab-freshness.ts
+++ b/LifeOS/install/LIFEOS/PULSE/modules/tab-freshness.ts
@@ -168,7 +168,7 @@ function resolveSpec(spec: SourceSpec): ResolvedSource[] {
     const out: ResolvedSource[] = []
     let entries: string[] = []
     try {
-      entries = readdirSync(spec.path).filter((e) => e.endsWith(".md") || e.endsWith(".json") || e.endsWith(".yaml"))
+      entries = readdirSync(spec.path).filter((e) => e.endsWith(".md") || e.endsWith(".json") || e.endsWith(".yaml") || e.endsWith(".yml"))
     } catch {
       // unreadable dir — record as missing
       return [{ name: spec.name, path: spec.path, exists: false, mtime: null }]

--- a/LifeOS/install/LIFEOS/TOOLS/DocCheck.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/DocCheck.ts
@@ -164,7 +164,7 @@ function findDocs(): string[] {
   const secDir = join(LIFEOS_DIR, 'USER', 'SECURITY');
   try {
     for (const f of readdirSync(secDir)) {
-      if (f.endsWith('.md') || f.endsWith('.yaml')) docs.push(join(secDir, f));
+      if (f.endsWith('.md') || f.endsWith('.yaml') || f.endsWith('.yml')) docs.push(join(secDir, f));
     }
   } catch { /* */ }
 

--- a/LifeOS/install/skills/Evals/Tools/EvalRunner.ts
+++ b/LifeOS/install/skills/Evals/Tools/EvalRunner.ts
@@ -82,8 +82,11 @@ export function buildLiveSystemPrompt(): string {
 
 function resolveSuite(name: string): string | null {
   for (const dir of [USER_SUITES, SKILL_SUITES]) {
-    for (const p of [join(dir, `${name}.yaml`), join(dir, 'Regression', `${name}.yaml`), join(dir, 'Capability', `${name}.yaml`)]) {
-      if (existsSync(p)) return p;
+    // .yaml first, so an existing .yaml keeps winning if both somehow exist.
+    for (const ext of ['yaml', 'yml']) {
+      for (const p of [join(dir, `${name}.${ext}`), join(dir, 'Regression', `${name}.${ext}`), join(dir, 'Capability', `${name}.${ext}`)]) {
+        if (existsSync(p)) return p;
+      }
     }
   }
   return null;

--- a/LifeOS/install/skills/Evals/Tools/SuiteManager.ts
+++ b/LifeOS/install/skills/Evals/Tools/SuiteManager.ts
@@ -91,7 +91,7 @@ export function listSuites(type?: EvalType): EvalSuite[] {
     if (!existsSync(dirPath)) continue;
 
     for (const file of readdirSync(dirPath)) {
-      if (file.endsWith('.yaml')) {
+      if (file.endsWith('.yaml') || file.endsWith('.yml')) {
         const suite = parseYaml(readFileSync(join(dirPath, file), 'utf-8')) as EvalSuite;
         suites.push(suite);
       }


### PR DESCRIPTION
<!-- commit-map -->
**4 commits, one per fix**, so each can be cherry-picked independently. Each was verified to apply cleanly onto `47df8ee` by itself.

| Commit | Fix |
|---|---|
| `343bfca` | list .yml suites, not just .yaml |
| `05d8658` | resolve a suite saved as .yml |
| `53fdad9` | include .yml when scanning USER/SECURITY for docs |
| `2fef266` | count .yml files toward tab freshness |

---

Four places that discover YAML files matched only `.yaml`, so a file written as `.yml` was skipped in silence. Nothing is broken in the shipped tree — every writer in the codebase emits `.yaml` — so this only affects **hand-authored** files, which is where a silent skip is least expected and hardest to diagnose.

The two Evals sites are the ones that matter. Both search the user's own suites directory, and both fail quietly:

- **`343bfca` — `skills/Evals/Tools/SuiteManager.ts:94`.** `listSuites()` walks `Suites/{Capability,Regression}/`. A `.yml` suite simply never appeared, with no error.
- **`05d8658` — `skills/Evals/Tools/EvalRunner.ts:85`.** `resolveSuite()` searched `USER_SUITES` and `SKILL_SUITES` for `.yaml` only, returned `null`, and `runSuite` turns that into a soft `"Suite not found"` result rather than a throw — so the run reported a missing suite for a file sitting right there. `.yaml` is still tried first, so precedence is unchanged if both ever exist.

The other two are lower risk but the same shape:

- **`53fdad9` — `LIFEOS/TOOLS/DocCheck.ts:167`.** Already accepted `.yaml` in `USER/SECURITY/`; a `.yml` policy file dropped out of the doc check, which reads as "checked and clean" rather than "never looked at".
- **`2fef266` — `PULSE/modules/tab-freshness.ts:171`.** The expanded specs include user-authored data directories (`HEALTH/`, `FINANCES/`, `BUSINESS/`, `LOCAL/`), so a `.yml` there was invisible to freshness and a tab could report stale while the newest file in it was the one just edited.

Five sibling sites already handle both and were left alone: `DocCrossRefIntegrity.ts:196,210`, `RebuildArchSummary.ts:59`, `InstallEngine.ts:339`, `ReferenceCheck.ts:301`, `CrossVendorAudit.ts:183`. This change brings the remaining four in line with them rather than introducing a new convention.

---

**Testing.** Both Evals fixes were verified with a real before/after, by dropping a `ymltest.yml` suite into `Suites/Regression/` in each tree and running the actual functions:

```
resolveSuite  before: "Suite not found: ymltest"   after: resolves and runs
listSuites    before: [core-behaviors]             after: [ymltest, core-behaviors]
```

The probe files were removed afterwards; the diff is the four one-line changes only. All four touched files transpile clean under `bun build --no-bundle`.

**Note on overlap.** #1739 also touches `EvalRunner.ts`, in `runSuite` around lines 113 and 146. This change is in `resolveSuite` at line 85, so the two do not collide, but they are worth porting in either order rather than concurrently.
