### PR TITLE
fix: match .tsx and .mjs/.cjs in two extension checks that omit them

### DIFF
--- a/LifeOS/install/hooks/handlers/DocCrossRefIntegrity.ts
+++ b/LifeOS/install/hooks/handlers/DocCrossRefIntegrity.ts
@@ -193,7 +193,7 @@ function isSystemFileModified(modifiedFiles: Set<string>): boolean {
       if (CLAUDE_EXCLUDED.some(ex => relPath.includes(ex))) continue;
 
       if (relPath.startsWith('hooks/') && (relPath.endsWith('.ts') || relPath.endsWith('.sh'))) return true;
-      if (relPath.startsWith('skills/') && (relPath.endsWith('.md') || relPath.endsWith('.ts') || relPath.endsWith('.yaml') || relPath.endsWith('.yml'))) return true;
+      if (relPath.startsWith('skills/') && (relPath.endsWith('.md') || relPath.endsWith('.ts') || relPath.endsWith('.tsx') || relPath.endsWith('.yaml') || relPath.endsWith('.yml'))) return true;
       if (relPath === 'settings.json') return true;
       if (relPath === 'CLAUDE.md') return true;
       if (relPath.startsWith('agents/') && relPath.endsWith('.md')) return true;
@@ -207,7 +207,7 @@ function isSystemFileModified(modifiedFiles: Set<string>): boolean {
       const relPath = filePath.slice(LIFEOS_DIR.length + 1);
       if (LIFEOS_EXCLUDED.some(ex => relPath.includes(ex))) continue;
 
-      if ((relPath.startsWith('PAI/') || relPath.includes('skills/')) && (relPath.endsWith('.md') || relPath.endsWith('.ts') || relPath.endsWith('.yaml') || relPath.endsWith('.yml'))) return true;
+      if ((relPath.startsWith('PAI/') || relPath.includes('skills/')) && (relPath.endsWith('.md') || relPath.endsWith('.ts') || relPath.endsWith('.tsx') || relPath.endsWith('.yaml') || relPath.endsWith('.yml'))) return true;
       if (relPath.includes('/Tools/') && relPath.endsWith('.ts')) return true;
       if (relPath.includes('/Workflows/') && relPath.endsWith('.md')) return true;
       continue;

--- a/LifeOS/install/skills/Evals/Graders/CodeBased/BinaryTests.ts
+++ b/LifeOS/install/skills/Evals/Graders/CodeBased/BinaryTests.ts
@@ -67,7 +67,7 @@ export class BinaryTestsGrader extends BaseGrader {
   private detectTestCommand(file: string): string {
     if (file.endsWith('.py')) return 'python -m pytest';
     if (file.endsWith('.ts')) return 'bun test';
-    if (file.endsWith('.js')) return 'node --test';
+    if (file.endsWith('.js') || file.endsWith('.mjs') || file.endsWith('.cjs')) return 'node --test';
     if (file.endsWith('.go')) return 'go test';
     if (file.endsWith('.rs')) return 'cargo test --';
     return 'bun test';  // Default


### PR DESCRIPTION
<!-- commit-map -->
**2 commits, one per fix**, so each can be cherry-picked independently.

| Commit | Fix |
|---|---|
| `a1836dd` | let a .tsx edit under skills/ trigger the doc-integrity pass |
| `67031e7` | route .mjs and .cjs test files to node --test |

---

Two extension checks that omit a sibling type that actually exists in the tree. Same shape as #1741, different extensions.

- **`a1836dd` — `hooks/handlers/DocCrossRefIntegrity.ts:196,210`.** This is the relevance gate deciding whether the Stop-hook cross-reference check runs at all. It accepted `.ts` but not `.tsx`, so editing any of the 24 `.tsx` files under `skills/` (all in `skills/Telos/DashboardTemplate`) skipped the pass entirely. The failure mode is a silent no-run that is indistinguishable from a clean result. Both scope checks are updated together so the `~/.claude` and `LIFEOS` branches stay in step.

- **`67031e7` — `skills/Evals/Graders/CodeBased/BinaryTests.ts:70`.** `detectTestCommand` matched `.js` only, so `.mjs` and `.cjs` fell through to the `bun test` default and ran under a different runner than the explicit `.js` branch intends.

**One thing deliberately not changed.** `.tsx` also falls through `detectTestCommand` to the default, but `bun test` is the right command for it, so adding it would change nothing. Listing it would have made the diff look more thorough while doing nothing, which is worse than leaving it.

**Two sites checked and left alone**, noted so the omission reads as deliberate:

- `hooks/handlers/RebuildArchSummary.ts:59` omits `.tsx`, but its five tracked directories (`hooks`, `ALGORITHM`, `TOOLS`, `USER/CONFIG`, `USER/SECURITY`) contain **zero** `.tsx` files. It is correctly scoped, not deficient.
- `.md` vs `.markdown` is handled in `PULSE/lib/provenance-watcher.ts:35`, and there are **no** `.markdown` files anywhere in the repo, so nothing is missing there either.

---

**Testing.** Both files transpile clean under `bun build --no-bundle`. These are branch-condition changes in a relevance gate and a command selector, so the meaningful check is the extension census behind them: `git ls-files` reports 122 `.tsx` in the payload (24 under `skills/`), 5 `.mjs`, and 0 `.markdown`.
