### PR TITLE
feat(pulse): hide nav tabs whose module is switched off

### DIFF
--- a/LifeOS/install/LIFEOS/PULSE/Observability/src/components/AppHeader.tsx
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/src/components/AppHeader.tsx
@@ -13,11 +13,17 @@ import { TabFreshnessPill } from "@/components/TabFreshnessPill";
 // meta view of the system working on itself, never part of the scrolling row.
 // SYSTEM is the mode-switch into the machine plane (lands on systemHome).
 import { tier1Nav, systemNav, metaNav, systemHome } from "@/lib/palette/nav-manifest";
+import { useEnabledModules } from "@/lib/use-enabled-modules";
 
 const systemPaths = [...systemNav.map((i) => i.href), "/system"];
 
 export default function AppHeader() {
   const pathname = usePathname();
+  // A tab whose module is switched off in PULSE.toml would open a page with no
+  // backend answering it, so drop it from both rows and the mobile menu.
+  const isEnabled = useEnabledModules();
+  const tier1 = tier1Nav.filter(isEnabled);
+  const system = systemNav.filter(isEnabled);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const mobileMenuRef = useRef<HTMLDivElement>(null);
   const { observerMode, toggleObserverMode } = useObserverMode();
@@ -81,7 +87,7 @@ export default function AppHeader() {
             <nav
               className="hidden md:flex flex-wrap flex-1 items-center justify-start xl:justify-center gap-1 gap-y-1 min-w-0"
             >
-              {tier1Nav.map((item) => {
+              {tier1.map((item) => {
                 const active = isActive(item.href);
                 const Icon = item.icon;
                 return (
@@ -174,7 +180,7 @@ export default function AppHeader() {
                 System
               </span>
               <nav className="flex flex-wrap flex-1 items-center justify-start gap-1 gap-y-1.5 min-w-0">
-                {systemNav.map((item) => {
+                {system.map((item) => {
                   const active = isActive(item.href);
                   const Icon = item.icon;
                   return (
@@ -204,7 +210,7 @@ export default function AppHeader() {
         <div ref={mobileMenuRef} className="md:hidden border-b border-line-1 backdrop-blur-md" style={{ background: "rgba(6, 11, 26, 0.95)" }}>
           <nav className="flex flex-col px-4 py-3 gap-1">
             <div className="text-xs uppercase tracking-wider text-ink-3 px-3 py-1">Sections</div>
-            {tier1Nav.map((item) => {
+            {tier1.map((item) => {
               const active = isActive(item.href);
               const Icon = item.icon;
               return (
@@ -230,7 +236,7 @@ export default function AppHeader() {
               );
             })}
             <div className="text-xs uppercase tracking-wider text-ink-3 px-3 py-1 mt-2">System</div>
-            {systemNav.map((item) => {
+            {system.map((item) => {
               const active = isActive(item.href);
               const Icon = item.icon;
               return (

--- a/LifeOS/install/LIFEOS/PULSE/Observability/src/components/palette/CommandPalette.tsx
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/src/components/palette/CommandPalette.tsx
@@ -23,6 +23,7 @@ import {
 } from "lucide-react";
 import { wikiPageUrl } from "@/lib/wiki-links";
 import { paletteEntries, type NavItem } from "@/lib/palette/nav-manifest";
+import { useEnabledModules } from "@/lib/use-enabled-modules";
 import { fuzzyScore } from "@/lib/palette/fuzzy";
 import { recordSelection, frecencyBoost, topRecents, loadStore } from "@/lib/palette/frecency";
 import { PALETTE_OPEN_EVENT, type PaletteScope } from "@/lib/palette/events";
@@ -155,6 +156,11 @@ export default function CommandPalette() {
     };
   }, [open, query, scope]);
 
+  // Jumping to a page whose module is switched off lands on an empty view, so
+  // the palette searches the same filtered set the nav renders.
+  const isEnabled = useEnabledModules();
+  const entries = useMemo(() => paletteEntries.filter(isEnabled), [isEnabled]);
+
   // Local lane + merge.
   const rows: Row[] = useMemo(() => {
     const out: Row[] = [];
@@ -162,15 +168,15 @@ export default function CommandPalette() {
     if (scope !== "wiki") {
       if (!q) {
         const recents = topRecents(6)
-          .map((id) => paletteEntries.find((e) => e.href === id))
+          .map((id) => entries.find((e) => e.href === id))
           .filter((e): e is NavItem => Boolean(e));
         recents.forEach((entry) => out.push({ kind: "page", entry, recent: true }));
-        paletteEntries
+        entries
           .filter((e) => !recents.includes(e))
           .forEach((entry) => out.push({ kind: "page", entry }));
       } else {
         const store = loadStore();
-        paletteEntries
+        entries
           .map((entry) => ({
             entry,
             score: fuzzyScore(q, entry.label, entry.keywords) + frecencyBoost(entry.href, store),
@@ -185,7 +191,7 @@ export default function CommandPalette() {
       wikiResults.forEach((result) => out.push({ kind: "wiki", result }));
     }
     return out;
-  }, [query, scope, wikiResults]);
+  }, [query, scope, wikiResults, entries]);
 
   useEffect(() => {
     setSelectedIndex(0);

--- a/LifeOS/install/LIFEOS/PULSE/Observability/src/lib/palette/nav-manifest.ts
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/src/lib/palette/nav-manifest.ts
@@ -38,23 +38,30 @@ export interface NavItem {
   icon: LucideIcon;
   /** Palette-only match aliases; the nav bar ignores this field. */
   keywords?: string[];
+  /**
+   * PULSE.toml [modules] key backing this page. When that module is switched
+   * off its tab disappears from the nav and the palette instead of opening a
+   * page with no data behind it. Entries with no key are always shown — either
+   * they are infrastructure, or Pulse cannot serve the dashboard without them.
+   */
+  module?: string;
 }
 
 // ── Tier 1 — the persistent global nav (Life sections + System home).
 // This is the ONLY always-visible menu. Everything else is contextual.
 export const tier1Nav: NavItem[] = [
-  { href: "/telos", label: "TELOS", icon: Target, keywords: ["goals", "mission", "problems"] },
-  { href: "/work", label: "WORK", icon: FolderKanban, keywords: ["kanban", "sessions", "tasks", "projects", "repos", "sites"] },
-  { href: "/content", label: "CONTENT", icon: Clapperboard, keywords: ["videos", "pipeline", "conveyor"] },
-  { href: "/health", label: "HEALTH", icon: Activity, keywords: ["sleep", "fitness"] },
-  { href: "/finances", label: "FINANCES", icon: DollarSign, keywords: ["money", "burn", "expenses", "revenue"] },
-  { href: "/business", label: "BUSINESS", icon: Briefcase, keywords: ["company", "newsletter"] },
-  { href: "/growth", label: "GROWTH", icon: TrendingUp, keywords: ["metrics", "subscribers", "audience"] },
-  { href: "/local", label: "LOCAL", icon: MapPin, keywords: ["civic", "crime", "city"] },
-  { href: "/gear", label: "GEAR", icon: Boxes, keywords: ["assets", "inventory", "own", "stuff"] },
-  { href: "/atlas", label: "ATLAS", icon: Waypoints, keywords: ["graph", "assets", "estate", "infrastructure", "blast radius", "domains", "workers", "current state"] },
-  { href: "/memory", label: "CORTEX", icon: Brain, keywords: ["memory", "knowledge", "wiki", "notes", "archive", "graph"] },
-  { href: "/synapse", label: "SYNAPSE", icon: Share2, keywords: ["ideas", "capture", "router", "amber"] },
+  { href: "/telos", label: "TELOS", icon: Target, keywords: ["goals", "mission", "problems"], module: "telos" },
+  { href: "/work", label: "WORK", icon: FolderKanban, keywords: ["kanban", "sessions", "tasks", "projects", "repos", "sites"], module: "work" },
+  { href: "/content", label: "CONTENT", icon: Clapperboard, keywords: ["videos", "pipeline", "conveyor"], module: "content" },
+  { href: "/health", label: "HEALTH", icon: Activity, keywords: ["sleep", "fitness"], module: "health" },
+  { href: "/finances", label: "FINANCES", icon: DollarSign, keywords: ["money", "burn", "expenses", "revenue"], module: "finances" },
+  { href: "/business", label: "BUSINESS", icon: Briefcase, keywords: ["company", "newsletter"], module: "business" },
+  { href: "/growth", label: "GROWTH", icon: TrendingUp, keywords: ["metrics", "subscribers", "audience"], module: "growth" },
+  { href: "/local", label: "LOCAL", icon: MapPin, keywords: ["civic", "crime", "city"], module: "local" },
+  { href: "/gear", label: "GEAR", icon: Boxes, keywords: ["assets", "inventory", "own", "stuff"], module: "gear" },
+  { href: "/atlas", label: "ATLAS", icon: Waypoints, keywords: ["graph", "assets", "estate", "infrastructure", "blast radius", "domains", "workers", "current state"], module: "atlas" },
+  { href: "/memory", label: "CORTEX", icon: Brain, keywords: ["memory", "knowledge", "wiki", "notes", "archive", "graph"], module: "memory" },
+  { href: "/synapse", label: "SYNAPSE", icon: Share2, keywords: ["ideas", "capture", "router", "amber"], module: "synapse" },
 ];
 
 // ── Meta — pinned in the header's right cluster on EVERY page, outside both
@@ -70,19 +77,19 @@ export const systemHome = "/assistant";
 // ── Tier 2 — contextual. These machine pages render as a second row ONLY when
 // you are inside System. They used to be a permanent second global menu.
 export const systemNav: NavItem[] = [
-  { href: "/assistant", label: "Assistant", icon: Bot, keywords: ["chat", "ask"] },
-  { href: "/bunker", label: "Bunker", icon: Container, keywords: ["apps", "chassis"] },
-  { href: "/algorithm", label: "Algorithm", icon: Workflow, keywords: ["thinking", "doctrine", "rules", "loop"] },
+  { href: "/assistant", label: "Assistant", icon: Bot, keywords: ["chat", "ask"], module: "da" },
+  { href: "/bunker", label: "Bunker", icon: Container, keywords: ["apps", "chassis"], module: "bunker" },
+  { href: "/algorithm", label: "Algorithm", icon: Workflow, keywords: ["thinking", "doctrine", "rules", "loop"], module: "algorithm" },
   { href: "/skills", label: "Skills", icon: Zap },
   { href: "/hooks", label: "Hooks", icon: Webhook },
-  { href: "/conduit", label: "Conduit", icon: Radar, keywords: ["sensors"] },
-  { href: "/upgrades", label: "Upgrades", icon: Sparkles, keywords: ["hypotheses", "recommendations", "improvements", "directives", "proposals"] },
+  { href: "/conduit", label: "Conduit", icon: Radar, keywords: ["sensors"], module: "conduit" },
+  { href: "/upgrades", label: "Upgrades", icon: Sparkles, keywords: ["hypotheses", "recommendations", "improvements", "directives", "proposals"], module: "upgrades" },
   { href: "/arbol", label: "Arbol", icon: TreePine, keywords: ["workers", "pipeline"] },
   { href: "/security", label: "Security", icon: ShieldCheck, keywords: ["monitoring"] },
-  { href: "/ledger", label: "Ledger", icon: ScrollText, keywords: ["versions", "updates", "deploys", "drift", "integrity", "registry", "changelog"] },
-  { href: "/performance", label: "Perf", icon: BarChart3, keywords: ["performance", "latency"] },
-  { href: "/usage", label: "Usage", icon: Gauge, keywords: ["tokens", "cost"] },
-  { href: "/docs", label: "Docs", icon: BookOpen, keywords: ["documentation", "wiki"] },
+  { href: "/ledger", label: "Ledger", icon: ScrollText, keywords: ["versions", "updates", "deploys", "drift", "integrity", "registry", "changelog"], module: "ledger" },
+  { href: "/performance", label: "Perf", icon: BarChart3, keywords: ["performance", "latency"], module: "performance" },
+  { href: "/usage", label: "Usage", icon: Gauge, keywords: ["tokens", "cost"], module: "usage" },
+  { href: "/docs", label: "Docs", icon: BookOpen, keywords: ["documentation", "wiki"], module: "docs" },
 ];
 
 const homeEntry: NavItem = { href: "/", label: "Home", icon: Home, keywords: ["dashboard", "pulse"] };

--- a/LifeOS/install/LIFEOS/PULSE/Observability/src/lib/use-enabled-modules.ts
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/src/lib/use-enabled-modules.ts
@@ -1,0 +1,38 @@
+"use client";
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * Reads the resolved PULSE.toml [modules] map from the daemon and returns a
+ * predicate for filtering nav entries.
+ *
+ * Fails open on purpose. Until the fetch lands — and permanently if it errors,
+ * or if the daemon predates /api/config/modules — every entry stays visible.
+ * A dashboard briefly showing a tab it will hide a moment later is a much
+ * smaller problem than a nav that empties itself because one request failed.
+ */
+export function useEnabledModules(): (item: { module?: string }) => boolean {
+  const [modules, setModules] = useState<Record<string, boolean> | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/config/modules")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (!cancelled && data?.modules) setModules(data.modules);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Stable identity while `modules` is unchanged, so callers can memoise the
+  // filtered list on this predicate instead of rebuilding it every render.
+  return useCallback(
+    (item: { module?: string }) => {
+      if (!modules || !item.module) return true;
+      return modules[item.module] !== false;
+    },
+    [modules],
+  );
+}

--- a/LifeOS/install/LIFEOS/PULSE/PULSE.toml
+++ b/LifeOS/install/LIFEOS/PULSE/PULSE.toml
@@ -10,6 +10,54 @@
 
 # ── Module Configuration ──
 
+# [modules] is the one place to switch a Pulse surface off. Every key defaults
+# to the value shown; delete a line and you get that default back. Disabling a
+# module stops it loading, stops its API routes answering, and (via
+# /api/config/modules) hides its tab in the dashboard instead of leaving a nav
+# entry that opens an empty page.
+#
+# Infrastructure Pulse needs to serve anything at all — observability, hooks,
+# tab-freshness, menubar, siri, doctor — is deliberately not listed: those are
+# how Pulse runs, not modules you use.
+#
+# The older `[section].enabled` flags below still work and still win over these
+# defaults, so an existing config needs no changes.
+[modules]
+# Life surfaces (the top nav)
+telos = true
+work = true
+content = true
+health = true
+finances = true
+business = true
+growth = true       # audience metrics; needs USER/CUSTOMIZATIONS/TOOLS/Growth.ts
+local = true        # LocalIntelligence civic digest; needs a Hometown set
+gear = true
+atlas = true
+memory = true
+synapse = true
+projects = true
+books = true
+# System surfaces
+algorithm = true
+bunker = true
+conduit = true
+upgrades = true
+hypotheses = true
+ledger = true
+usage = true
+performance = true
+evals = true
+threatmodel = true
+hermes = true
+docs = true
+da = true
+# Opt-in surfaces (off unless you turn them on)
+voice = true
+imessage = false
+syslog = false
+
+
 [voice]
 enabled = true
 

--- a/LifeOS/install/LIFEOS/PULSE/lib.ts
+++ b/LifeOS/install/LIFEOS/PULSE/lib.ts
@@ -582,3 +582,4 @@ export async function spawnClaude(prompt: string, opts: { model: string; timeout
 
   return output.trim()
 }
+export { MODULE_DEFAULTS, resolveModules } from "./lib/modules"

--- a/LifeOS/install/LIFEOS/PULSE/lib/modules.ts
+++ b/LifeOS/install/LIFEOS/PULSE/lib/modules.ts
@@ -1,0 +1,47 @@
+// ── Module registry ──
+// Every Pulse surface a human can switch off, and the default they ship with.
+// Infrastructure the daemon needs in order to serve anything at all —
+// observability (the dashboard itself), hooks, tab-freshness, menubar, siri,
+// doctor — is deliberately absent: those are not modules you use, they are how
+// Pulse runs, and a "disabled" one would leave a dashboard that cannot render.
+//
+// Keys are the tab/module name. `resolveModules()` layers three sources so
+// existing installs keep working untouched: these defaults, then the legacy
+// per-section `[x].enabled` flags, then the `[modules]` table (which wins).
+export const MODULE_DEFAULTS: Record<string, boolean> = {
+  telos: true, work: true, content: true, health: true, finances: true,
+  business: true, growth: true, local: true, gear: true, atlas: true,
+  memory: true, synapse: true, books: true, conduit: true, projects: true,
+  ledger: true, upgrades: true, hypotheses: true, usage: true,
+  performance: true, bunker: true, algorithm: true, evals: true,
+  threatmodel: true, hermes: true, docs: true,
+  voice: true, imessage: false, syslog: false, da: true,
+}
+
+// Legacy `[section].enabled` flags that predate the `[modules]` table, mapped to
+// their module key. Honouring these is what keeps a pre-existing PULSE.toml
+// working after an upgrade — notably `[local_intelligence]`, whose flag was
+// read by loadModules() but never plumbed through loadPulseConfig(), so setting
+// it to false silently did nothing.
+const LEGACY_SECTION_KEYS: Record<string, string> = {
+  local_intelligence: "local", hypotheses: "hypotheses", upgrades: "upgrades",
+  telos: "telos", work: "work", content: "content", bunker: "bunker",
+  performance: "performance", syslog: "syslog", voice: "voice",
+  imessage: "imessage", da: "da",
+}
+
+/** Merge defaults ← legacy section flags ← `[modules]` table into one map. */
+export function resolveModules(parsed: Record<string, unknown>): Record<string, boolean> {
+  const modules = { ...MODULE_DEFAULTS }
+  for (const [section, key] of Object.entries(LEGACY_SECTION_KEYS)) {
+    const enabled = (parsed[section] as { enabled?: boolean } | undefined)?.enabled
+    if (typeof enabled === "boolean") modules[key] = enabled
+  }
+  const table = parsed.modules as Record<string, unknown> | undefined
+  if (table) {
+    for (const [key, value] of Object.entries(table)) {
+      if (typeof value === "boolean") modules[key] = value
+    }
+  }
+  return modules
+}

--- a/LifeOS/install/LIFEOS/PULSE/pulse.ts
+++ b/LifeOS/install/LIFEOS/PULSE/pulse.ts
@@ -67,6 +67,7 @@ import {
   spawnScript,
   spawnClaude,
   parseConfigToml,
+  resolveModules,
 } from "./lib"
 
 import { startHooks, handleHooksRequestAsync, hooksHealth } from "./modules/hooks"
@@ -105,7 +106,7 @@ let evalsModule: any = null
 let hermesModule: any = null
 
 async function loadModules(config: PulseConfig) {
-  if (config.voice?.enabled !== false) {
+  if (config.modules.voice) {
     try {
       voiceModule = await import("./VoiceServer/voice")
     } catch (err) {
@@ -120,12 +121,14 @@ async function loadModules(config: PulseConfig) {
     }
   }
   // Wiki module — always load (no config gate)
-  try {
-    wikiModule = await import("./modules/wiki")
-  } catch (err) {
-    log("warn", "Wiki module not available", { error: String(err) })
+  if (config.modules.docs) {
+    try {
+      wikiModule = await import("./modules/wiki")
+    } catch (err) {
+      log("warn", "Wiki module not available", { error: String(err) })
+    }
   }
-  if (config.imessage?.enabled) {
+  if (config.modules.imessage) {
     try {
       imessageModule = await import("./modules/imessage")
     } catch (err) {
@@ -141,49 +144,49 @@ async function loadModules(config: PulseConfig) {
   // Assistant (DA subsystem) is a private module stripped from the public
   // release payload. Existence-check before importing so a fresh public install
   // boots cleanly and simply omits the /assistant routes. #1419.
-  if (config.da?.enabled && existsSync(join(PULSE_DIR, "Assistant", "module.ts"))) {
+  if (config.modules.da && existsSync(join(PULSE_DIR, "Assistant", "module.ts"))) {
     try {
       assistantModule = await import("./Assistant/module")
     } catch (err) {
       log("warn", "Assistant module not available", { error: String(err) })
     }
   }
-  if (config.performance?.enabled !== false) {
+  if (config.modules.performance) {
     try {
       performanceModule = await import("./Performance/module")
     } catch (err) {
       log("warn", "Performance module not available", { error: String(err) })
     }
   }
-  if (config.syslog?.enabled) {
+  if (config.modules.syslog) {
     try {
       syslogModule = await import("./modules/syslog")
     } catch (err) {
       log("warn", "Syslog module not available", { error: String(err) })
     }
   }
-  if (config.work?.enabled !== false) {
+  if (config.modules.work) {
     try {
       workModule = await import("./modules/work")
     } catch (err) {
       log("warn", "Work module not available", { error: String(err) })
     }
   }
-  if (config.content?.enabled !== false) {
+  if (config.modules.content) {
     try {
       contentModule = await import("./modules/content")
     } catch (err) {
       log("warn", "Content module not available", { error: String(err) })
     }
   }
-  if (config.local_intelligence?.enabled !== false) {
+  if (config.modules.local) {
     try {
       localIntelligenceModule = await import("./modules/local-intelligence")
     } catch (err) {
       log("warn", "LocalIntelligence module not available", { error: String(err) })
     }
   }
-  if (config.telos?.enabled !== false) {
+  if (config.modules.telos) {
     try {
       telosModule = await import("./modules/telos")
       // Without this, state.running stays false and /api/telos/health reports
@@ -194,7 +197,7 @@ async function loadModules(config: PulseConfig) {
       log("warn", "Telos freshness module not available", { error: String(err) })
     }
   }
-  if (config.hypotheses?.enabled !== false) {
+  if (config.modules.hypotheses) {
     try {
       hypothesesModule = await import("./modules/hypotheses")
       if (hypothesesModule.start) hypothesesModule.start()
@@ -202,7 +205,7 @@ async function loadModules(config: PulseConfig) {
       log("warn", "Hypotheses module not available", { error: String(err) })
     }
   }
-  if (config.upgrades?.enabled !== false) {
+  if (config.modules.upgrades) {
     try {
       upgradesModule = await import("./modules/upgrades")
       if (upgradesModule.start) upgradesModule.start()
@@ -217,18 +220,22 @@ async function loadModules(config: PulseConfig) {
     log("warn", "Tab freshness module not available", { error: String(err) })
   }
   // Memory — autonomic-memory subsystem state surface (always loaded).
-  try {
-    memoryModule = await import("./modules/memory")
-    if (memoryModule.start) memoryModule.start()
-  } catch (err) {
-    log("warn", "Memory module not available", { error: String(err) })
+  if (config.modules.memory) {
+    try {
+      memoryModule = await import("./modules/memory")
+      if (memoryModule.start) memoryModule.start()
+    } catch (err) {
+      log("warn", "Memory module not available", { error: String(err) })
+    }
   }
   // Conduit — sensory layer daily-record surface (read-only; capture is launchd).
-  try {
-    conduitModule = await import("./modules/conduit")
-    if (conduitModule.start) conduitModule.start()
-  } catch (err) {
-    log("warn", "Conduit module not available", { error: String(err) })
+  if (config.modules.conduit) {
+    try {
+      conduitModule = await import("./modules/conduit")
+      if (conduitModule.start) conduitModule.start()
+    } catch (err) {
+      log("warn", "Conduit module not available", { error: String(err) })
+    }
   }
   // Menu bar — cross-subsystem aggregator behind the rich native menu bar dropdown.
   try {
@@ -238,64 +245,80 @@ async function loadModules(config: PulseConfig) {
     log("warn", "Menubar module not available", { error: String(err) })
   }
   // Books — favorite-books surface over USER/BOOKS.md.
-  try {
-    booksModule = await import("./modules/books")
-    if (booksModule.start) booksModule.start()
-  } catch (err) {
-    log("warn", "Books module not available", { error: String(err) })
+  if (config.modules.books) {
+    try {
+      booksModule = await import("./modules/books")
+      if (booksModule.start) booksModule.start()
+    } catch (err) {
+      log("warn", "Books module not available", { error: String(err) })
+    }
   }
   // Synapse — input routing & capture surface (ledger, knowledge, bookmarks, flows).
-  try {
-    synapseModule = await import("./modules/synapse")
-    if (synapseModule.start) synapseModule.start()
-  } catch (err) {
-    log("warn", "Synapse module not available", { error: String(err) })
+  if (config.modules.synapse) {
+    try {
+      synapseModule = await import("./modules/synapse")
+      if (synapseModule.start) synapseModule.start()
+    } catch (err) {
+      log("warn", "Synapse module not available", { error: String(err) })
+    }
   }
   // Ledger — change-tracking surface (versions, update registry, deploys, integrity, drift).
-  try {
-    ledgerModule = await import("./modules/ledger")
-    if (ledgerModule.start) ledgerModule.start()
-  } catch (err) {
-    log("warn", "Ledger module not available", { error: String(err) })
+  if (config.modules.ledger) {
+    try {
+      ledgerModule = await import("./modules/ledger")
+      if (ledgerModule.start) ledgerModule.start()
+    } catch (err) {
+      log("warn", "Ledger module not available", { error: String(err) })
+    }
   }
   // Projects — project routing-table surface over USER/PROJECTS.md.
-  try {
-    projectsModule = await import("./modules/projects")
-    if (projectsModule.start) await projectsModule.start()
-  } catch (err) {
-    log("warn", "Projects module not available", { error: String(err) })
+  if (config.modules.projects) {
+    try {
+      projectsModule = await import("./modules/projects")
+      if (projectsModule.start) await projectsModule.start()
+    } catch (err) {
+      log("warn", "Projects module not available", { error: String(err) })
+    }
   }
   // Assets — unified read-only inventory over USER/GEAR.md + network topology.
-  try {
-    assetsModule = await import("./modules/assets")
-    if (assetsModule.start) await assetsModule.start()
-  } catch (err) {
-    log("warn", "Assets module not available", { error: String(err) })
+  if (config.modules.gear) {
+    try {
+      assetsModule = await import("./modules/assets")
+      if (assetsModule.start) await assetsModule.start()
+    } catch (err) {
+      log("warn", "Assets module not available", { error: String(err) })
+    }
   }
   // Atlas — read-only surface over the asset-graph snapshot (LIFEOS/ATLAS).
-  try {
-    atlasModule = await import("./modules/atlas")
-    if (atlasModule.start) atlasModule.start()
-  } catch (err) {
-    log("warn", "Atlas module not available", { error: String(err) })
+  if (config.modules.atlas) {
+    try {
+      atlasModule = await import("./modules/atlas")
+      if (atlasModule.start) atlasModule.start()
+    } catch (err) {
+      log("warn", "Atlas module not available", { error: String(err) })
+    }
   }
   // ThreatModel — read-only surface over the private risk register
   // (skills/ThreatModel; data in LIFEOS/USER/SECURITY/THREATMODEL).
-  try {
-    threatModelModule = await import("./modules/threatmodel")
-    if (threatModelModule.start) threatModelModule.start()
-  } catch (err) {
-    log("warn", "ThreatModel module not available", { error: String(err) })
+  if (config.modules.threatmodel) {
+    try {
+      threatModelModule = await import("./modules/threatmodel")
+      if (threatModelModule.start) threatModelModule.start()
+    } catch (err) {
+      log("warn", "ThreatModel module not available", { error: String(err) })
+    }
   }
   // Usage — Anthropic subscription + durable token/cost/model usage surface.
-  try {
-    usageModule = await import("./modules/usage")
-    if (usageModule.start) await usageModule.start()
-  } catch (err) {
-    log("warn", "Usage module not available", { error: String(err) })
+  if (config.modules.usage) {
+    try {
+      usageModule = await import("./modules/usage")
+      if (usageModule.start) await usageModule.start()
+    } catch (err) {
+      log("warn", "Usage module not available", { error: String(err) })
+    }
   }
   // Bunker — application-harness registry surface (reads ~/.claude/LIFEOS/PULSE/Bunker via its CLI).
-  if (config.bunker?.enabled !== false) {
+  if (config.modules.bunker) {
     try {
       bunkerModule = await import("./modules/bunker")
     } catch (err) {
@@ -312,25 +335,31 @@ async function loadModules(config: PulseConfig) {
   }
   // Hermes — the sidecar's core files: SOUL, config, guard policy, and the code
   // that generates them. Read/edit surface behind the Assistant tab.
-  try {
-    hermesModule = await import("./modules/hermes")
-    if (hermesModule.start) hermesModule.start()
-  } catch (err) {
-    log("warn", "Hermes module not available", { error: String(err) })
+  if (config.modules.hermes) {
+    try {
+      hermesModule = await import("./modules/hermes")
+      if (hermesModule.start) hermesModule.start()
+    } catch (err) {
+      log("warn", "Hermes module not available", { error: String(err) })
+    }
   }
   // Algorithm — the thinking chain surface: doctrine (versioned edits), rules
   // files, AI-generated workflow summary for the /algorithm tab.
-  try {
-    algorithmTabModule = await import("./modules/algorithm-tab")
-    if (algorithmTabModule.start) algorithmTabModule.start()
-  } catch (err) {
-    log("warn", "AlgorithmTab module not available", { error: String(err) })
+  if (config.modules.algorithm) {
+    try {
+      algorithmTabModule = await import("./modules/algorithm-tab")
+      if (algorithmTabModule.start) algorithmTabModule.start()
+    } catch (err) {
+      log("warn", "AlgorithmTab module not available", { error: String(err) })
+    }
   }
   // Evals — standing eval-suite status (pass^k, regressions) for the /algorithm tab.
-  try {
-    evalsModule = await import("./modules/evals")
-  } catch (err) {
-    log("warn", "Evals module not available", { error: String(err) })
+  if (config.modules.evals) {
+    try {
+      evalsModule = await import("./modules/evals")
+    } catch (err) {
+      log("warn", "Evals module not available", { error: String(err) })
+    }
   }
 }
 
@@ -338,6 +367,8 @@ async function loadModules(config: PulseConfig) {
 
 interface PulseConfig {
   port: number
+  /** Resolved on/off state for every switchable surface. See MODULE_DEFAULTS. */
+  modules: Record<string, boolean>
   tls?: { enabled: boolean; cert: string; key: string } // unused — TLS removed
   voice?: { enabled: boolean; [key: string]: unknown }
   imessage?: { enabled: boolean; [key: string]: unknown }
@@ -389,6 +420,7 @@ async function loadPulseConfig(): Promise<PulseConfig> {
 
   return {
     port: (parsed.port as number) ?? parseInt(process.env.PULSE_PORT || "31337", 10),
+    modules: resolveModules(parsed),
     tls: (parsed.tls as PulseConfig["tls"]) ?? undefined,
     voice: (parsed.voice as PulseConfig["voice"]) ?? { enabled: true },
     imessage: (parsed.imessage as PulseConfig["imessage"]) ?? { enabled: false },
@@ -740,6 +772,13 @@ async function main() {
         return buildHealthResponse(state, config)
       }
 
+      // Which surfaces are switched on. The dashboard reads this to avoid
+      // rendering a tab whose backend was never loaded — without it, disabling a
+      // module leaves a nav entry that opens an empty page.
+      if (req.method === "GET" && pathname === "/api/config/modules") {
+        return Response.json({ modules: config.modules })
+      }
+
       // Voice routes: /notify, /notify/personality, /voice, /voice/health
       // (/voice/health is implemented and advertised by the module but was never
       // forwarded, so it 404'd — public PR #1621, @elhoim)
@@ -923,6 +962,20 @@ async function main() {
       if (algorithmTabModule && pathname.startsWith("/api/algorithm-tab")) {
         const resp = await algorithmTabModule.handleRequest(req, pathname)
         if (resp) return resp
+      }
+
+      // The HEALTH / FINANCES / BUSINESS / GROWTH surfaces have no module of
+      // their own — observability.ts serves them directly — so switching them
+      // off has to happen here, at the route, rather than at module load.
+      const LIFE_ROUTE_MODULES: Record<string, string> = {
+        "/api/life/health": "health",
+        "/api/life/finances": "finances",
+        "/api/life/business": "business",
+        "/api/life/growth": "growth",
+      }
+      const lifeModule = LIFE_ROUTE_MODULES[pathname]
+      if (lifeModule && !config.modules[lifeModule]) {
+        return Response.json({ error: "module disabled", module: lifeModule }, { status: 404 })
       }
 
       // Observability routes: /api/*, /dashboard/*


### PR DESCRIPTION
> **Stacked on #1748.** This branch contains that commit as its parent; the diff below is the second commit only. Merge or port #1748 first — without `/api/config/modules` the hook fetch 404s and every tab stays visible (which is the designed fallback, so nothing breaks, but nothing hides either).

## Problem

Switching a module off stops its backend but leaves its tab in both nav rows, the mobile menu and the command palette. Clicking one opens a page with nothing answering it — an empty view rather than an honest absence.

GROWTH shows this without any config at all: it's backed by an optional USER customization that isn't shipped, so on a fresh install the tab is always there and always empty.

## Change

- **`nav-manifest.ts`** — `NavItem.module?: string`, set on 21 entries. Entries without one (Home, Agents, Skills, Hooks, Arbol, Security) are infrastructure and always render.
- **`lib/use-enabled-modules.ts`** (new) — fetches `/api/config/modules` once, returns a `useCallback`-stable predicate so callers can memoise on it.
- **`AppHeader.tsx`** — filters `tier1Nav` and `systemNav` at all four render sites (desktop tier-1, desktop system row, mobile sections, mobile system).
- **`CommandPalette.tsx`** — searches the filtered set, so `Cmd-K` can't jump to a page the nav is hiding.

## Fails open, deliberately

Until the fetch lands — and permanently if it errors, or the daemon predates the endpoint — every entry stays visible. A dashboard briefly showing a tab it then hides is a much smaller problem than a nav that empties itself because one request failed.

## Verification

Ported to my own install, built (`next build`, 40 static routes), restarted Pulse with `local = false`.

**Backend:** `/api/config/modules` reports `local` off; `/api/local-intelligence/latest` → 404; `LocalIntelligence module loaded` absent from the current boot's journal.

**Rendered nav** — the real `AppHeader` at 1440px, read out of the live DOM:

```
/memory/graph /telos /work /content /projects /health /finances
/business /growth /assets /knowledge /amber /agents /assistant
```

14 links. `/local` sits between `/growth` and `/assets` in the manifest and is absent from the render; the sequence jumps straight from `/growth` to `/assets`. Every other entry is untouched.

**Visually** — captured the desktop header in a real Chrome and zoomed in on the nav strip. Row 1 reads `TELOS WORK CONTENT PROJECTS HEALTH FINANCES BUSINESS`, row 2 reads `GROWTH ASSETS KNOWLEDGE AMBER`. No LOCAL.

`tsc --noEmit`: 26 pre-existing errors in unrelated files, none in the four files this touches.

Not run: a fresh-system install verification (step 3 of the contributing process).
