### PR TITLE
fix(statusline): move the usage fetch off the render path

### DIFF
--- a/LifeOS/install/LIFEOS/LIFEOS_StatusLine.sh
+++ b/LifeOS/install/LIFEOS/LIFEOS_StatusLine.sh
@@ -888,45 +888,67 @@ if [ "$MODE" = "normal" ]; then
                 fi
             fi
             if mkdir "$USAGE_LOCK" 2>/dev/null; then
-                echo "$$" > "$USAGE_LOCK/pid" 2>/dev/null   # ownership token (verified on release)
-                # Extract OAuth token — macOS Keychain or Linux credentials file
-                if [ "$(uname -s)" = "Darwin" ]; then
-                    cred_json=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null)
-                else
-                    cred_json=$(cat "${HOME}/.claude/.credentials.json" 2>/dev/null)
-                fi
-                token=$(echo "$cred_json" | jq -r '.claudeAiOauth.accessToken // empty' 2>/dev/null)
+                # Fetch DETACHED, mirroring the location/weather refresh above.
+                # The keychain read and the 3s curl must not sit on the render
+                # path. Claude Code kills a statusline render that overruns its
+                # refreshInterval, and killing one mid-`security` can strand the
+                # terminal in the canonical/no-echo mode that call put it in.
+                # </dev/null severs stdin so the fetch can never read the TTY.
+                #
+                # $$ inside a subshell still names the PARENT on bash 3.2 (no
+                # BASHPID), and that parent exits in milliseconds, so writing $$
+                # as the ownership token would let the next render's liveness
+                # check reap a lock whose fetch is still running. sh -c 'echo
+                # $PPID' returns the subshell's own pid — verified equal to the
+                # parent's $! on bash 3.2.57 (macOS).
+                (
+                    _fetch_pid=$(sh -c 'echo $PPID')
+                    echo "$_fetch_pid" > "$USAGE_LOCK/pid" 2>/dev/null   # ownership token (verified on release)
+                    # Release on EXIT so a killed fetch cannot leak the mutex,
+                    # and ONLY if we still own it — never nuke another holder's.
+                    trap 'if [ "$(cat "$USAGE_LOCK/pid" 2>/dev/null)" = "$_fetch_pid" ]; then rm -f "$USAGE_LOCK/pid" 2>/dev/null; rmdir "$USAGE_LOCK" 2>/dev/null; fi' EXIT
 
-                if [ -n "$token" ]; then
-                    usage_json=$(curl -s --max-time 3 \
-                        -H "Authorization: Bearer $token" \
-                        -H "Content-Type: application/json" \
-                        -H "anthropic-beta: oauth-2025-04-20" \
-                        "https://api.anthropic.com/api/oauth/usage" 2>/dev/null)
-
-                    # Fail CLOSED: install a new cache ONLY when the body is real JSON
-                    # with a five_hour field. A 429/5xx/HTML body fails this probe, so
-                    # last-known-good is never atomically overwritten with garbage (P5).
-                    if [ -n "$usage_json" ] && echo "$usage_json" | jq -e '.five_hour' >/dev/null 2>&1; then
-                        # Atomic write (P4): temp in the SAME dir (same fs => rename is
-                        # atomic), 0600, and never mv onto a followed symlink (the path
-                        # is predictable in a world-writable dir). Stamp fetched_at (P6).
-                        # mv ONLY if the temp is non-empty (defends jq-exit-0-empty).
-                        _tmp_cache="${USAGE_CACHE}.tmp.$$"
-                        if echo "$usage_json" | jq --argjson now "$_usage_now" '. + {fetched_at:$now}' > "$_tmp_cache" 2>/dev/null && [ -s "$_tmp_cache" ]; then
-                            chmod 600 "$_tmp_cache" 2>/dev/null
-                            [ -L "$USAGE_CACHE" ] && rm -f "$USAGE_CACHE" 2>/dev/null
-                            mv -f "$_tmp_cache" "$USAGE_CACHE" 2>/dev/null && _data_age=0
-                        fi
-                        rm -f "$_tmp_cache" 2>/dev/null
+                    # Extract OAuth token — macOS Keychain or Linux credentials file
+                    if [ "$(uname -s)" = "Darwin" ]; then
+                        cred_json=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null)
+                    else
+                        cred_json=$(cat "${HOME}/.claude/.credentials.json" 2>/dev/null)
                     fi
-                fi
-                # Release ONLY if we still own the lock — never nuke another holder's.
-                if [ "$(cat "$USAGE_LOCK/pid" 2>/dev/null)" = "$$" ]; then
-                    rm -f "$USAGE_LOCK/pid" 2>/dev/null; rmdir "$USAGE_LOCK" 2>/dev/null
-                fi
+                    token=$(echo "$cred_json" | jq -r '.claudeAiOauth.accessToken // empty' 2>/dev/null)
+
+                    if [ -n "$token" ]; then
+                        usage_json=$(curl -s --max-time 3 \
+                            -H "Authorization: Bearer $token" \
+                            -H "Content-Type: application/json" \
+                            -H "anthropic-beta: oauth-2025-04-20" \
+                            "https://api.anthropic.com/api/oauth/usage" 2>/dev/null)
+
+                        # Fail CLOSED: install a new cache ONLY when the body is real JSON
+                        # with a five_hour field. A 429/5xx/HTML body fails this probe, so
+                        # last-known-good is never atomically overwritten with garbage (P5).
+                        if [ -n "$usage_json" ] && echo "$usage_json" | jq -e '.five_hour' >/dev/null 2>&1; then
+                            # Atomic write (P4): temp in the SAME dir (same fs => rename is
+                            # atomic), 0600, and never mv onto a followed symlink (the path
+                            # is predictable in a world-writable dir). Stamp fetched_at (P6).
+                            # mv ONLY if the temp is non-empty (defends jq-exit-0-empty).
+                            _tmp_cache="${USAGE_CACHE}.tmp.${_fetch_pid}"
+                            if echo "$usage_json" | jq --argjson now "$_usage_now" '. + {fetched_at:$now}' > "$_tmp_cache" 2>/dev/null && [ -s "$_tmp_cache" ]; then
+                                chmod 600 "$_tmp_cache" 2>/dev/null
+                                [ -L "$USAGE_CACHE" ] && rm -f "$USAGE_CACHE" 2>/dev/null
+                                mv -f "$_tmp_cache" "$USAGE_CACHE" 2>/dev/null
+                            fi
+                            rm -f "$_tmp_cache" 2>/dev/null
+                        fi
+                    fi
+                ) </dev/null >/dev/null 2>&1 &
+                disown 2>/dev/null || true
             fi
             # Losers (mkdir failed): no fetch, no wait — fall through to last-known-good.
+            # The winner no longer waits either: _data_age keeps its pre-fetch
+            # value, so this render shows last-known-good with an honest age and
+            # the fresh data lands on the next tick. The forced-refetch
+            # bookkeeping below therefore restores _orig_age, which is correct —
+            # from this render's point of view the attempt has not landed yet.
         fi
         # Forced-refetch bookkeeping: a failed forced attempt restores the true
         # data age (a success already set _data_age=0), so staleness reporting


### PR DESCRIPTION
## What

Location and weather already refresh in detached background subshells. The comment above them says why:

> This replaces the original synchronous design that did `curl --max-time 3` on the render path during cache expiry — that's what killed the perf and got the feature ripped out on 2026-05-08.

The usage fetch is the last one still inline. Every 900s the mutex winner runs `security find-generic-password` and a `curl --max-time 3` while the bar renders. If that endpoint is slow, the render sits there waiting.

Measured against a blackholed endpoint so the curl burns its full timeout: **3.36–3.49s per render**, against a shipped `refreshInterval` of 1.

### The part that bites on macOS

Those seconds are a kill window — Claude Code terminates a render that overruns its interval (#1767 covers what the killed renders leave behind).

`security` is the bad one to get killed inside of. It prompts through `readpassphrase()`, which opens `/dev/tty` directly and flips the terminal to canonical no-echo mode. Kill the render mid-call and the terminal can stay that way. What you get is a session where arrow keys spray escape sequences, backspace stops echoing, and what you type goes into a password buffer instead of the prompt — so hitting enter answers a keychain challenge you can't see.

Worth noting: the `2>/dev/null` on that line can't prevent any of it, because the prompt goes to `/dev/tty`, not stderr.

`</dev/null` on the detached subshell removes the path entirely. The fetch can't read the terminal because it no longer has one.

## Change

Wrap the fetch in the same `) </dev/null >/dev/null 2>&1 &` + `disown` shape the weather block already uses. Two things had to change to keep @lmbagley's mutex from #1349 intact.

**Ownership token.** Bash 3.2 has no `BASHPID`, and `$$` inside a subshell still names the parent — which exits in milliseconds. Writing `$$` would let the next render's liveness check reap a lock whose fetch is still running. `sh -c 'echo $PPID'` returns the subshell's own pid:

```
parent_shell_pid=61010
parent_sees_bang=61011
  inside_subshell: dollar_dollar=61010  sh_c_PPID=61011  BASHPID=UNSET
```

`sh_c_PPID` matches the parent's `$!`. That's the value that goes in the pid file, so `kill -0` still reads a live process.

**Release.** Moved to an `EXIT` trap so a killed fetch can't leak the mutex. It still verifies ownership before removing anything, same as before.

## Why it's safe

`_data_age` never reaches 0 on this render now, so the winner takes the same path the mutex losers already take: last-known-good with an honest age, fresh data on the next tick. That path is already there and already exercised.

The forced-refetch bookkeeping restores `_orig_age`, which is correct — from this render's point of view the attempt hasn't landed yet, and the comment there already says a non-landed attempt should restore the true age.

Everything else is untouched: the fail-closed `.five_hour` probe, the atomic `fetched_at`-stamped write, the symlink guard, the dead-owner reap, the 900s TTL and the scoped fast lane. `_tmp_cache` now keys off the fetch pid instead of `$$`, which is strictly more unique.

## Verification

macOS 15 (Apple Silicon), bash 3.2.57. Both arms get test-only cache and lock paths plus a blackholed endpoint, so nothing touches live state and the curl always burns its full 3s.

| | Render 1 | Render 2 |
|---|---|---|
| stock | 3.49s | 3.36s |
| patched | 0.29s | 0.27s |

Lock behavior on the patched build:

```
t+0.0s  lock HELD by detached fetch, pid=81648
        owner alive? YES
t+5.0s  lock RELEASED cleanly
```

`bash -n` exits 0.

**Portability of the ownership token.** The token has to equal the parent's `$!` or the liveness reap can kill a live fetch, so I checked it on both shells LifeOS runs on, with both common `/bin/sh` implementations:

| shell | `/bin/sh` | token | parent `$!` | match |
|---|---|---|---|---|
| bash 3.2.57 | sh | 14313 | 14313 | yes |
| bash 5.3.15 | sh | 14322 | 14322 | yes |
| bash 5.3.15 | dash | 14331 | 14331 | yes |
| bash 3.2.57 | dash | 14340 | 14340 | yes |

`BASHPID` resolves to the same value on 5.3.15, so one code path is correct on both and there's no need for a platform branch. dash sets `$PPID` correctly, which matters because it's `/bin/sh` on Debian and Ubuntu. Everything else in the diff is POSIX apart from `disown`, which the weather block above already uses with the same `2>/dev/null || true` guard.

Linux gets a smaller version of the same win. It takes the `.credentials.json` branch, so there's no `security` call and no terminal to strand — but the `curl` is still on the render path, and #1767's report came from a headless Ubuntu box where killed renders were the problem.

**Control for that last line.** "Released cleanly" is a pass-by-absence, so I checked it can fail: strip the `EXIT` trap, leave everything else, re-run. Mutation counted (trap lines 1 → 0), sabotaged script still parses, and the lock leaks. The check isn't blind.

The stock arm is its own control for the latency number — same harness, same endpoint, 12x the wall time.

## Scope

Left alone on purpose:

- **`DeployComponents.ts` and the `refreshInterval` default.** That's #1772. This PR stands on its own — a render that doesn't block is worth having at any interval.
- **The `/tmp/pai-parallel` scratch dirs.** #1767 owns that. No overlap: different function, different region of the file.
- **The `2>/dev/null` on the keychain read.** Inside a detached subshell everything already goes to `/dev/null`, so changing it would be noise.
- **`USAGE_CACHE_TTL` and the scoped fast lane.** Not my call to retune, and detaching doesn't depend on it.

One thing I noticed but didn't act on: the comment at L859 says "the 5s tick rate must never hammer it," so the script was written expecting a 5s tick while the installer ships 1. That mismatch is what #1772 is about.
