### PR TITLE
fix(pulse): fmtHero renders negative amounts as unabridged digits

### DIFF
--- a/LifeOS/install/LIFEOS/PULSE/Observability/src/app/finances/page.tsx
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/src/app/finances/page.tsx
@@ -185,13 +185,20 @@ interface FinancesDataV2 {
 
 function fmtHero(dollars: number | null | undefined): string {
   const n = Number(dollars) || 0;
-  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 10_000) return `$${Math.round(n / 1000)}K`;
-  if (n >= 1_000) {
-    const k = n / 1000;
-    return k % 1 === 0 ? `$${k.toFixed(0)}K` : `$${k.toFixed(1)}K`;
+  // Threshold on magnitude, not the signed value — a negative net (a real,
+  // common case: this card renders red ink when spending exceeds income)
+  // otherwise misses every `>=` check above and falls through to the last
+  // branch's unabridged digit string (e.g. "$-2,120,000" next to a sibling
+  // KPI reading "$2.1M").
+  const sign = n < 0 ? "-" : "";
+  const abs = Math.abs(n);
+  if (abs >= 1_000_000) return `${sign}$${(abs / 1_000_000).toFixed(1)}M`;
+  if (abs >= 10_000) return `${sign}$${Math.round(abs / 1000)}K`;
+  if (abs >= 1_000) {
+    const k = abs / 1000;
+    return k % 1 === 0 ? `${sign}$${k.toFixed(0)}K` : `${sign}$${k.toFixed(1)}K`;
   }
-  return `$${Math.round(n).toLocaleString()}`;
+  return `${sign}$${Math.round(abs).toLocaleString()}`;
 }
 
 function fmtExact(dollars: number | null | undefined): string {


### PR DESCRIPTION
`fmtHero()`'s magnitude thresholds (`>= 1_000_000`, `>= 10_000`, `>= 1_000`) are checked against the signed value, so any negative number fails every branch and falls through to the last one, which was written assuming `n` was already known-small. Net (Overall tab) commonly goes negative when spending exceeds income, so a K/M-abbreviated sibling KPI like "$2.1M" ends up next to "$-2,120,000" instead of "-$2.1M".

## Fix

Threshold on `Math.abs(n)` instead and prepend the sign once, before the currency symbol.

## Non-destructive

Positive inputs are byte-identical (sign is the empty string); this only changes output for values that were already rendering as long unformatted digit strings.

## Verification

Standalone checks: `fmtHero(2120000)` → `$2.1M` (unchanged), `fmtHero(-2120000)` → `-$2.1M` (was `$-2,120,000`), plus the K/thousands/zero boundary cases, all matching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)