### PR TITLE
fix(healthsync): resolve the operator's timezone instead of hardcoding America/Los_Angeles

### DIFF
--- a/LifeOS/install/LIFEOS/TOOLS/healthsync/eightsleep.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/healthsync/eightsleep.ts
@@ -16,6 +16,7 @@ import {
   isoNowLA,
   loadState,
   loadTokens,
+  resolveTimeZone,
   saveTokens,
   timedFetch,
   writeDayFile,
@@ -195,9 +196,11 @@ export async function pull(ctx: Ctx): Promise<SourceResult> {
 
   const to = dayKeyLA(ctx.now.getTime());
   const from = dayKeyLA(ctx.now.getTime() - WINDOW_DAYS * 24 * 60 * 60 * 1000);
+  // Ask Eight Sleep to bucket by the same zone the day keys use, or the window
+  // boundaries and the files they land in disagree for non-LA users.
   const url =
     `${CLIENT_API}/users/${auth.userId}/trends` +
-    `?tz=America/Los_Angeles&from=${from}&to=${to}` +
+    `?tz=${encodeURIComponent(resolveTimeZone())}&from=${from}&to=${to}` +
     `&include-main=false&include-all-sessions=true&model-version=v2`;
 
   let response: Response;

--- a/LifeOS/install/LIFEOS/TOOLS/healthsync/store.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/healthsync/store.ts
@@ -36,13 +36,58 @@ function stripQuotes(value: string): string {
   return trimmed;
 }
 
-export function dayKeyLA(epochMs: number): string {
+/** Last-resort zone, kept so behaviour is unchanged when nothing else resolves. */
+const FALLBACK_TIME_ZONE = "America/Los_Angeles";
+
+let cachedTimeZone: string | null = null;
+
+function isUsableTimeZone(tz: string | undefined | null): tz is string {
+  if (typeof tz !== "string" || tz.trim() === "") return false;
+  try {
+    new Intl.DateTimeFormat("en-CA", { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The IANA zone every health day-boundary is computed in.
+ *
+ * Resolution order, first usable wins:
+ *   1. `LIFEOS_HEALTH_TZ` — explicit override for this subsystem
+ *   2. `TZ`               — POSIX standard, what launchd/cron users already set
+ *   3. the host's own zone via Intl
+ *   4. `America/Los_Angeles` — previous hardcoded behaviour
+ *
+ * Why this matters: the day key decides which file a reading is filed under, so a
+ * wrong zone silently misfiles anything recorded near local midnight. Verified on a
+ * UTC-5 host: 01:13 local landed in the previous day's file because the zone was
+ * pinned to UTC-7.
+ */
+export function resolveTimeZone(): string {
+  if (cachedTimeZone !== null) return cachedTimeZone;
+  const candidates = [
+    process.env.LIFEOS_HEALTH_TZ,
+    process.env.TZ,
+    Intl.DateTimeFormat().resolvedOptions().timeZone,
+  ];
+  cachedTimeZone = candidates.find(isUsableTimeZone) ?? FALLBACK_TIME_ZONE;
+  return cachedTimeZone;
+}
+
+/** Test seam: drop the memoised zone so a changed env var takes effect. */
+export function resetTimeZoneCache(): void {
+  cachedTimeZone = null;
+}
+
+export function dayKey(epochMs: number): string {
   if (!Number.isFinite(epochMs)) {
     throw new Error("epochMs must be finite");
   }
 
   const parts = new Intl.DateTimeFormat("en-CA", {
-    timeZone: "America/Los_Angeles",
+    timeZone: resolveTimeZone(),
     year: "numeric",
     month: "2-digit",
     day: "2-digit",
@@ -54,17 +99,20 @@ export function dayKeyLA(epochMs: number): string {
   const key = `${year}-${month}-${day}`;
 
   if (!/^\d{4}-\d{2}-\d{2}$/.test(key)) {
-    throw new Error("failed to build LA day key");
+    throw new Error(`failed to build day key in ${resolveTimeZone()}`);
   }
 
   return key;
 }
 
-export function isoNowLA(d: Date): string {
-  // Convert the LA wall-clock parts, then compare them with UTC to derive the
+/** @deprecated Zone is no longer pinned to LA — use `dayKey`. Kept so callers don't break. */
+export const dayKeyLA = dayKey;
+
+export function isoNow(d: Date): string {
+  // Convert the local wall-clock parts, then compare them with UTC to derive the
   // correct DST-aware offset for that instant.
   const parts = new Intl.DateTimeFormat("en-CA", {
-    timeZone: "America/Los_Angeles",
+    timeZone: resolveTimeZone(),
     year: "numeric",
     month: "2-digit",
     day: "2-digit",
@@ -77,7 +125,7 @@ export function isoNowLA(d: Date): string {
   const getPart = (type: string): string => {
     const value = parts.find((part) => part.type === type)?.value;
     if (value === undefined) {
-      throw new Error(`missing ${type} while formatting LA timestamp`);
+      throw new Error(`missing ${type} while formatting timestamp in ${resolveTimeZone()}`);
     }
     return value;
   };
@@ -104,6 +152,9 @@ export function isoNowLA(d: Date): string {
 
   return `${year}-${month}-${day}T${hour}:${minute}:${second}${sign}${offsetHour}:${offsetMinute}`;
 }
+
+/** @deprecated Zone is no longer pinned to LA — use `isoNow`. Kept so callers don't break. */
+export const isoNowLA = isoNow;
 
 export function parseEnv(text: string): Record<string, string> {
   const env: Record<string, string> = {};


### PR DESCRIPTION
## Problem

`LIFEOS/TOOLS/healthsync/` pins every day-boundary calculation to `America/Los_Angeles` in three places:

| File | Line | What it pins |
|---|---|---|
| `store.ts` | 45 | `dayKeyLA()`: decides which day-file a reading lands in |
| `store.ts` | 67 | `isoNowLA()`: the `fetched_at` / `lastSuccess` stamp |
| `eightsleep.ts` | 200 | the `tz=` query param sent to Eight Sleep's trends API |

For any operator outside Pacific time the day key is wrong near local midnight, so readings are silently filed under the previous or next day. Nothing errors; the data is just in the wrong bucket, and `HealthSync.ts:253` then builds trend windows off those mis-keyed files.

Reproduced on a UTC-5 host on 2026-07-21: an export at **01:13 local** was written to `DATA/apple/2026-07-20.json`, because 01:13 UTC-5 is 23:13 the previous day in Los Angeles. Two hours of every day land in the wrong file; for UTC+ operators the window is larger.

`eightsleep.ts:200` compounds it: the provider is asked to bucket by LA while the files are keyed by LA too, so the two agree only for LA users, and the `from`/`to` window silently covers the wrong span for everyone else.

## Fix

Add `resolveTimeZone()` to `store.ts`, resolving in order and taking the first usable IANA zone:

1. `LIFEOS_HEALTH_TZ`: explicit override for this subsystem
2. `TZ`: the POSIX standard, which launchd/cron operators already set
3. the host zone via `Intl.DateTimeFormat().resolvedOptions().timeZone`
4. `America/Los_Angeles`: the previous hardcoded value, so behaviour is unchanged when nothing else resolves

Candidates are validated by constructing an `Intl.DateTimeFormat` and falling through on throw, so a typo'd `TZ` degrades instead of crashing the sync. The result is memoised with a `resetTimeZoneCache()` test seam.

The three hardcodes now call it. Error strings that said "LA day key" now name the resolved zone, which makes the next timezone bug self-describing.

## Compatibility

`dayKeyLA` and `isoNowLA` are kept as `@deprecated` aliases of the renamed `dayKey` / `isoNow`, so **no call site changes**. There are 12 call sites across `HealthSync.ts`, `apple.ts`, `oura.ts`, `function.ts` and `eightsleep.ts`; none were touched. Upstream can migrate them whenever, or never.

Default behaviour for an operator who sets nothing changes from "always LA" to "the machine's own zone", which is the intended semantics of a personal health log. Operators who genuinely want LA can set `TZ` or `LIFEOS_HEALTH_TZ` explicitly.

## Verification

Same instant (`2026-07-21T06:13:00Z`) through `dayKey()` under each zone:

| `LIFEOS_HEALTH_TZ` | day key |
|---|---|
| `America/Bogota` | `2026-07-21` |
| `America/Los_Angeles` | `2026-07-20` (old behaviour preserved) |
| `Europe/Madrid` | `2026-07-21` |
| `Asia/Tokyo` | `2026-07-21` |
| unset | `2026-07-21` (host zone) |
| `Zona/Inventada` | `2026-07-21` (invalid, falls through, no throw) |

`bun LIFEOS/TOOLS/HealthSync.ts pull` runs clean against all four providers after the change, and the fix has been running in production on a UTC-5 install since 2026-07-21.

## Files

- `LIFEOS/TOOLS/healthsync/store.ts`: +54/−6
- `LIFEOS/TOOLS/healthsync/eightsleep.ts`: +4/−1

## Related

Same class as the timezone work in PRs #762 / #780 / #806, which fixed `hooks/lib/time.ts` and `statusline-command.sh` but did not reach `LIFEOS/TOOLS/`. `Tools/FailureCapture.ts` and `Tools/RelationshipReflect.ts` still carry the same hardcode and are **not** covered by this PR.
