### PR TITLE
fix(conduit): make capture, rollup and scheduling work off macOS

### DIFF
--- a/LifeOS/install/LIFEOS/PULSE/Conduit/adapters/appFocus.ts
+++ b/LifeOS/install/LIFEOS/PULSE/Conduit/adapters/appFocus.ts
@@ -5,15 +5,41 @@
  * interpolation, per the security protocol). Captures the app NAME only, no window
  * title (window titles need Screen Recording permission; deferred to v1.1). Cheap:
  * one ~50ms osascript call per poll. Never throws — returns [] on any failure.
+ *
+ * macOS ONLY, and it says so now. `osascript` does not exist off macOS, so on any
+ * other platform every poll used to fall into the bare `catch` and return [] with no
+ * log line. That hides the gap indefinitely: capture reports ok, events accumulate,
+ * and the whole time model silently reads zero, because rollup derives every minute
+ * from app-focus. A failure this total must be audible, so the reason is logged ONCE
+ * per process — never is wrong, and every poll would drown the log.
+ *
+ * There is no drop-in replacement on Wayland: an unprivileged process cannot ask
+ * which window has focus. GNOME's org.gnome.Shell.Introspect.GetWindows answers
+ * AccessDenied, and xprop sees only XWayland clients, so it would report confidently
+ * wrong apps for native ones. A Shell extension exposing focus over D-Bus is the
+ * real port. Until then rollup.ts falls back to session-derived time.
  */
 import { execFileSync } from "node:child_process";
+import { platform } from "node:os";
 import type { ConduitConfig } from "../config.ts";
 import type { ConduitEvent } from "../types.ts";
 
 const FRONT_APP_SCRIPT =
   'tell application "System Events" to get name of first application process whose frontmost is true';
 
+/** One line per process, not per poll — a 2-minute cron would drown the log. */
+let warned = false;
+function warnOnce(reason: string): void {
+  if (warned) return;
+  warned = true;
+  console.warn(`[conduit:appFocus] disabled — ${reason}. No app-focus events will be captured; rollup falls back to session-derived time.`);
+}
+
 export function capture(config: ConduitConfig): ConduitEvent[] {
+  if (platform() !== "darwin") {
+    warnOnce(`app-focus requires macOS \`osascript\`, host is ${platform()}`);
+    return [];
+  }
   try {
     const app = execFileSync("osascript", ["-e", FRONT_APP_SCRIPT], {
       encoding: "utf8",
@@ -31,7 +57,11 @@ export function capture(config: ConduitConfig): ConduitEvent[] {
         detail: { intervalSec: config.pollIntervalSec },
       },
     ];
-  } catch {
+  } catch (err) {
+    // On macOS a throw here is a real fault (Automation permission not granted,
+    // System Events unresponsive) — not an expected platform gap, so it is worth
+    // saying out loud exactly once.
+    warnOnce(`osascript failed: ${String((err as Error)?.message ?? err).slice(0, 120)}`);
     return [];
   }
 }

--- a/LifeOS/install/LIFEOS/PULSE/Conduit/rollup.ts
+++ b/LifeOS/install/LIFEOS/PULSE/Conduit/rollup.ts
@@ -5,11 +5,46 @@
  *
  * Time model: each app-focus event represents one poll interval of that app (capped —
  * a sleep gap does not inflate time because launchd fires no polls while asleep).
+ *
+ * FALLBACK: app-focus needs macOS `osascript`, so on every other platform it yields
+ * nothing and the whole time model reads zero while capture reports healthy. When a
+ * day has no focus time, time is derived from claude-session cadence instead — the
+ * signal that IS present everywhere. It is labelled as derived in the block itself,
+ * because inferred keyboard time and measured focus time are not the same claim and
+ * the record should not blur them.
  */
 import { mkdirSync, renameSync, writeFileSync } from "node:fs";
 import { classifyApp } from "./classify.ts";
 import { DAILY_DIR, dailyPathsFor } from "./paths.ts";
 import type { ConduitEvent, DailyBlock, DailyRecord } from "./types.ts";
+
+/** Label marks the number as inferred, so a reader never mistakes it for measured focus. */
+const DERIVED_LABEL = "Claude Code (derived from session cadence)";
+
+/**
+ * Time between consecutive claude-session events, capped so an overnight gap is not
+ * counted as work. The cap self-tunes to 2× the day's median gap rather than a fixed
+ * constant: the capture cadence is set by the cron schedule (every 5 minutes at time
+ * of writing), not by pollIntervalSec, so a hardcoded cap would silently undercount
+ * the moment that schedule changed.
+ *
+ * Each event is credited with the gap BACK to the previous one — N events yield N-1
+ * spans, which deliberately claims nothing about time after the final event.
+ */
+function deriveSessionSeconds(sessionTimestamps: number[]): number {
+  if (sessionTimestamps.length < 2) return 0;
+  const sorted = [...sessionTimestamps].sort((a, b) => a - b);
+  const gaps: number[] = [];
+  for (let i = 1; i < sorted.length; i++) gaps.push((sorted[i] - sorted[i - 1]) / 1000);
+
+  const ordered = [...gaps].sort((a, b) => a - b);
+  const median = ordered[Math.floor(ordered.length / 2)] || 0;
+  // Floor/ceiling keep a degenerate median (one burst, or a single long gap) from
+  // producing an absurd cap in either direction.
+  const cap = Math.min(Math.max(median * 2, 60), 1800);
+
+  return gaps.reduce((n, g) => n + Math.min(g, cap), 0);
+}
 
 /** Aggregate a day's raw events into the deterministic record. Pure. */
 export function buildDailyRecord(
@@ -20,6 +55,7 @@ export function buildDailyRecord(
 ): DailyRecord {
   const perAppSec = new Map<string, number>();
   const seenSha = new Set<string>();
+  const sessionTimestamps: number[] = [];
   let commits = 0;
   let sessions = 0;
 
@@ -37,7 +73,16 @@ export function buildDailyRecord(
       commits++;
     } else if (e.type === "claude-session") {
       sessions++;
+      const t = Date.parse(e.ts);
+      if (!Number.isNaN(t)) sessionTimestamps.push(t);
     }
+  }
+
+  // Fallback only. Measured focus always wins where it exists, so a macOS host is
+  // completely unaffected and upstream behaviour is preserved.
+  if (perAppSec.size === 0) {
+    const derivedSec = deriveSessionSeconds(sessionTimestamps);
+    if (derivedSec > 0) perAppSec.set(DERIVED_LABEL, derivedSec);
   }
 
   const blocks: DailyBlock[] = [...perAppSec.entries()]

--- a/LifeOS/install/LIFEOS/PULSE/PULSE.toml
+++ b/LifeOS/install/LIFEOS/PULSE/PULSE.toml
@@ -206,6 +206,30 @@ command = "bun run checks/life-morning-brief.ts"
 output = "voice"
 enabled = true
 
+# ── Conduit insight ──
+
+# BuildInsight.ts ships with a launchd installer (InstallConduitInsight.ts writes
+# ~/Library/LaunchAgents/com.lifeos.conduit.insight.plist), which exists only on
+# macOS. Everywhere else nothing ever runs it, so the Conduit page permanently
+# reads "No activity captured yet today" while advertising an hourly cadence.
+# Scheduling it here makes the hourly read real on every platform.
+#
+# Safe to double-run where the launchd agent IS installed: BuildInsight is
+# idempotent against a `since` watermark and exits WITHOUT an inference call when
+# no new events have landed, so extra firings on idle hours cost nothing.
+#
+# :23 past every 2nd hour, brute-forced against every enabled job rather than
+# eyeballed. The obvious :15 collides with FIVE of them — cost-aggregation and
+# the */5 pollers all land on multiples of 5 — and this job holds an inference
+# call open for ~50s, so it should not share a tick with anything.
+[[job]]
+name = "conduit-insight"
+schedule = "23 */2 * * *"
+type = "script"
+command = "bun run Conduit/BuildInsight.ts"
+output = "log"
+enabled = true
+
 # ── Migration note (2026-05-03) ──
 # All personal/{{PRINCIPAL_NAME}}-specific jobs (cost-tracker, monitor-*, lifelog-digest,
 # apple-health-ingest, local-intelligence-refresh, update-pai-state, the


### PR DESCRIPTION
Three related macOS assumptions in Conduit that leave it visibly broken on other platforms, each failing silently. Two commits: the capture/rollup fix, and the scheduling fix.

## Problem 1 — app-focus fails silently, taking the whole time model with it

Conduit's `app-focus` adapter shells out to `osascript`, which only exists on macOS. On any other platform `execFileSync` throws straight into a bare `catch { return [] }` — the adapter emits nothing and says nothing.

That's invisible rather than merely degraded, because `rollup.ts` derives `totalMinutes`, `creationMinutes`, `consumptionMinutes` and every block **exclusively** from `app-focus` events. Commits and `claude-session` events are counted but contribute no time.

On a Linux host the result is a dashboard that looks healthy from every angle you'd normally check:

- the capture job reports `ok`
- events accumulate normally (in my case 304 `claude-session` + 39 `git-commit` over 18 days)
- `/api/conduit` responds with sensible `commits` and `sessions` counts
- …and the timeline renders empty, `totalMinutes: 0`, with **zero** `app-focus` events ever recorded and no log line anywhere explaining why

## Changes

**1. `adapters/appFocus.ts` — make the failure audible**

Platform-check before shelling out, and log the reason **once per process**:

```
[conduit:appFocus] disabled — app-focus requires macOS `osascript`, host is linux.
No app-focus events will be captured; rollup falls back to session-derived time.
```

The `catch` reports now too. On macOS a throw there is a real fault — Automation permission not granted, System Events unresponsive — not an expected platform gap, so it deserves to be audible as well. Once per process rather than per poll, since a frequent cron would drown the log.

**2. `rollup.ts` — derive time from the signal that exists everywhere**

When a day has no focus time at all, time is derived from `claude-session` cadence. Each session event is credited with the gap back to the previous one, capped so an overnight gap isn't counted as work.

The cap self-tunes to 2× the day's median gap rather than a fixed constant: the capture cadence comes from the cron schedule, not `pollIntervalSec`, so a hardcoded value would silently undercount the moment that schedule changed.

## Problem 2 — the insight job is scheduled by launchd only

`BuildInsight.ts` is scheduled exclusively by `InstallConduitInsight.ts`, which writes `~/Library/LaunchAgents/com.lifeos.conduit.insight.plist`. launchd only exists on macOS, so everywhere else nothing ever runs it — while the Conduit page advertises an "hourly read" and permanently shows *"No activity captured yet today"*.

**3. `PULSE.toml` — schedule it through the scheduler LifeOS already ships**

```toml
[[job]]
name = "conduit-insight"
schedule = "23 */2 * * *"
type = "script"
command = "bun run Conduit/BuildInsight.ts"
output = "log"
enabled = true
```

The launchd agent still works where it's installed; this just makes the hourly read real on every other platform. Double-running is harmless — `BuildInsight` is idempotent against a `since` watermark and exits **without** an inference call when no new events have landed. Verified by running it twice in succession; the second printed `no new events since <watermark> — skipped (no inference call)`.

The minute was brute-forced against every enabled job in the shipped config rather than eyeballed. The obvious `:15` collides with **five** of them — `cost-aggregation` (`*/15`) and the `*/5` pollers all land on multiples of 5 — and this job holds an inference call open for ~50s, so it shouldn't share a tick with anything. `:23` is clear across all of them.

## Design notes

- **macOS behaviour is unchanged.** The fallback engages only when there is no measured focus time, so a host with a working `osascript` never takes this path.
- **Derived time is labelled as derived** — the block reads `Claude Code (derived from session cadence)` rather than being blended into an unqualified number. Inferred keyboard time and measured focus time aren't the same claim and the record shouldn't blur them.
- **N events yield N−1 spans.** Nothing is claimed about time after the final event.

## Why not just port app-focus to Linux?

There's no drop-in replacement on Wayland — an unprivileged process deliberately cannot ask which window has focus. I tested both routes on Fedora/GNOME:

| approach | result |
|---|---|
| `org.gnome.Shell.Introspect.GetWindows` | `AccessDenied: GetWindows is not allowed` |
| `xprop -root _NET_ACTIVE_WINDOW` | responds, but sees only XWayland clients — would report confidently wrong apps for native Wayland ones |
| `xdotool` / `wmctrl` | X11-only, and not installed by default |

A GNOME Shell extension exposing focus over D-Bus is the real port. This PR makes the gap visible and keeps the timeline useful until someone writes it.

## Verification

I didn't add a test file — the repo has no test infrastructure (no root `package.json`, no `.test.ts` files), and I didn't want to impose a framework in a bugfix PR. Happy to add one if you'd like it. The fallback was verified against a 10-case matrix, all passing:

| case | expectation | result |
|---|---|---|
| app-focus present alongside sessions | focus wins, derived path does not engage | ✅ |
| app-focus minutes with both present | unchanged from current behaviour | ✅ |
| 5 sessions at 5-min cadence, no focus | 20 min derived | ✅ |
| derived block labelling | contains "derived" | ✅ |
| derived block classification | `creation` | ✅ |
| 10-hour gap between sessions | capped, not counted | ✅ |
| single session event | 0 minutes — proves nothing | ✅ |
| no events at all | 0 minutes, 0 blocks | ✅ |
| duplicate commit SHAs | de-duped to 1 | ✅ |
| commits only | counted, contribute no time | ✅ |

End-to-end on a Fedora 42 / GNOME / Wayland host: Conduit went from `totalMinutes: 0` with an empty timeline to `189.2` minutes across one labelled derived block, with commits and sessions counts unchanged.

For the scheduling commit: Pulse loaded the job (15 → 16 jobs), the loader resolves it as `schedule=23 */2 * * * type=script output=log enabled=true`, and a full 24-hour minute sweep against all other enabled jobs returns zero collisions. The insight itself produced a correct read from 33 events on first run, and skipped without inference on the second.
