### PR TITLE
Add SuggestSkills: decide which skills to build from your work history

### DIFF
--- a/LifeOS/install/skills/SuggestSkills/SKILL.md
+++ b/LifeOS/install/skills/SuggestSkills/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: SuggestSkills
+description: "Discover WHICH new skills you should create, from your own work history plus your satisfaction/frustration signals. Read-only and proposal-only: it surfaces recurring pain that no existing skill, loop, or workflow covers, then hands you a ranked shortlist to build with CreateSkill. It never creates or edits a skill itself. Frustration is a first-class signal (a topic can look 'covered' while you keep hitting the same wall inside it), so it reads low ratings and recurrence markers, not just session topics. USE WHEN should I create a skill, what skills do I need, suggest skills, skill gap, based on my recent work, am I missing a skill, what should I build. NOT FOR creating/validating/testing/optimizing an individual skill (use CreateSkill) — this only decides WHAT to build, not how."
+---
+
+# SuggestSkills — what should I build next?
+
+A read-only analytics pass over your own work. It answers one question: given what you have actually been doing and where you have been frustrated, is there a recurring problem that deserves its own skill and does not have one yet? It proposes; you decide; `CreateSkill` builds. It has no capability to create or edit a skill, by design.
+
+## Why it is separate from CreateSkill
+
+Discovery is read-only; creation mutates. Keeping the two apart is the permission boundary that makes "never auto-create" real rather than a promise in prose: this skill cannot write a skill even if asked.
+
+## The two blind spots it exists to defeat
+
+1. **Frustration is invisible to topic-matching.** A topic can be nominally covered by a build/test skill while you keep hitting the same wall inside it. Low ratings and "regressed again" recurrence are the strongest signal a skill is missing. Weight them above raw topic frequency.
+2. **Discipline gaps hide under covered topics.** "App development" maps to a build skill, but the recurring pain may be an unowned discipline (state modeling, error handling, migration safety) that the build skill never addresses. Coverage means the discipline is genuinely handled, not that the topic shares a keyword.
+
+## Workflow
+
+`Workflows/Scan.md` — the full pass. In short:
+
+1. **Gather deterministically.** Run `Tools/CollectSignals.ts` to emit a normalized corpus (recent sessions, low-rating frustrations with sentiment, and the skill/loop/workflow registry for dedup, plus warnings for any missing or malformed store). The LLM does not gather; it only judges what the tool returns, so two runs see the same evidence.
+2. **Cluster by pain.** Group the corpus into recurring themes, carrying both how often each recurs AND how much frustration it drew.
+3. **Dedup against real coverage.** For each candidate, read the bodies of the skills/loops/workflows that might cover it. Name-match is not coverage; the covering unit must actually address the failure class.
+4. **Verify with two independent passes, report the UNION.** Do not require both passes to agree before surfacing a gap (strict intersection suppresses exactly the subtle discipline gaps this exists to find). Report every gap either pass flags, tagged with its agreement level (both = high confidence, one = needs review).
+5. **Propose, never create.** Emit a ranked shortlist with evidence (session count, frustration count, the specific recurring failure) to a review location or the session summary. Route accepted proposals to `CreateSkill`. Redact secrets, client names, and personal paths from anything written out.
+
+## Gotchas
+
+- **A clean topic-coverage result with dirty frustration signals is a FALSE negative.** If the ratings show recurring frustration in an area you marked covered, re-open it — the discipline under that topic is the gap. (This is the exact failure this skill was built to fix.)
+- **Recurrence is severity-weighted, not a bare count.** Three trivial sessions matter less than one long, painful, repeated migration. A high-severity pain that recurs across a few sessions qualifies even below an arbitrary threshold.
+- **Behavior is not a skill.** "Too verbose", "misread scope", "repeated a reminder" are steering/feedback, not skill gaps. Separate them out and route them to memory/preferences, not to CreateSkill.
+- **Gathering is deterministic on purpose.** If you find yourself grepping stores by hand in the workflow, use the tool instead — hand-gathering makes runs non-reproducible and the eval meaningless.
+- **Paths are discovered, not assumed.** The tool resolves stores via flags/env/root, so it works across installs; do not hardcode a home directory.

--- a/LifeOS/install/skills/SuggestSkills/Tools/CollectSignals.ts
+++ b/LifeOS/install/skills/SuggestSkills/Tools/CollectSignals.ts
@@ -1,0 +1,230 @@
+#!/usr/bin/env bun
+/**
+ * CollectSignals — deterministic, read-only signal collector for skill-gap discovery.
+ *
+ * Emits a normalized corpus (JSON to stdout) so the LLM step only clusters and judges;
+ * it never gathers. Run at a fixed point in time over unchanged stores, it is deterministic
+ * (output ordering is fully tie-broken). Writes nothing.
+ *
+ * Paths are DISCOVERED, never hardcoded to a person's home. Resolution order per store:
+ *   1. explicit CLI flag  2. env var  3. a conventional default under --root
+ * An explicit flag pointing at a nonexistent path is reported (never silently replaced by a
+ * default). Anything missing or malformed is reported in `warnings`/`missing`, never fatal.
+ *
+ * Usage:
+ *   bun CollectSignals.ts [--root <dir>] [--days <n>] [--max-rating <n>]
+ *                         [--ratings <file>] [--work <dir>] [--skills <dir>] [--loops <dir>]
+ *   env: SKILLSCAN_MEMORY_ROOT, SKILLSCAN_RATINGS_FILE, SKILLSCAN_WORK_DIR,
+ *        SKILLSCAN_SKILLS_DIR, SKILLSCAN_LOOPS_DIR
+ *
+ * Contract (stdout JSON):
+ *   {
+ *     window:       { days, since },
+ *     sessions:     { slug, mtime }[],                              // recent work-session dirs (. and _ prefixed skipped as system dirs)
+ *     frustrations: { date, rating, note }[],                       // low ratings + sentiment, sorted
+ *     registries:   { kind: "skill"|"loop"|"workflow", name, description }[],  // for dedup; bodies read by the LLM step
+ *     warnings:     string[],                                       // malformed rows, unreadable/oversized files (non-fatal)
+ *     missing:      string[],                                       // stores that don't exist in this install
+ *     sources:      Record<string,string>                          // resolved paths actually used
+ *   }
+ * Exit 0 even when stores are missing (a fresh install is a valid, empty corpus);
+ * non-zero only on an unexpected internal error.
+ */
+import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
+import { join, basename } from "node:path";
+
+const MAX_RATINGS_BYTES = 10_000_000; // guard against a huge/FIFO ratings store
+const MAX_NOTE_CHARS = 500;
+
+type Session = { slug: string; mtime: string };
+type Frustration = { date: string; rating: number; note: string };
+type RegistryEntry = { kind: "skill" | "loop" | "workflow"; name: string; description: string };
+type Corpus = {
+  window: { days: number; since: string };
+  sessions: Session[];
+  frustrations: Frustration[];
+  registries: RegistryEntry[];
+  warnings: string[];
+  missing: string[];
+  sources: Record<string, string>;
+};
+
+/** Value for `flag`, or undefined. A following token that is itself a flag (starts with "-") is NOT a value. */
+function arg(flag: string): string | undefined {
+  const i = process.argv.indexOf(flag);
+  if (i < 0 || i + 1 >= process.argv.length) return undefined;
+  const v = process.argv[i + 1];
+  return v.startsWith("-") ? undefined : v;
+}
+
+/** Strict integer flag, clamped to [min,max]; warns (never silently accepts garbage or out-of-range). */
+function intArg(flag: string, dflt: number, min: number, max: number, warnings: string[]): number {
+  const v = arg(flag);
+  if (v === undefined) return dflt;
+  if (!/^-?\d+$/.test(v)) { warnings.push(`${flag}: not an integer (${v}); using ${dflt}`); return dflt; }
+  let n = Number.parseInt(v, 10);
+  if (n < min) { warnings.push(`${flag}: ${n} below ${min}; clamped`); n = min; }
+  else if (n > max) { warnings.push(`${flag}: ${n} above ${max}; clamped`); n = max; }
+  return n;
+}
+
+/**
+ * Resolve a store path: explicit flag > env var > default under root.
+ * An explicit path that does not exist is a warning + null (never silently falls through to a default).
+ * `defaultRel === null` means the store has no conventional default (opt-in only, e.g. loops).
+ */
+function resolveStore(
+  explicit: string | undefined,
+  envVar: string,
+  defaultRel: string | null,
+  root: string,
+  label: string,
+  warnings: string[],
+): string | null {
+  if (explicit !== undefined) {
+    if (existsSync(explicit)) return explicit;
+    warnings.push(`${label}: --${label} path ${explicit} does not exist`);
+    return null;
+  }
+  const env = process.env[envVar];
+  if (env && existsSync(env)) return env;
+  if (defaultRel) { const d = join(root, defaultRel); if (existsSync(d)) return d; }
+  return null;
+}
+
+function parseFrustrations(file: string | null, maxRating: number, since: Date, warnings: string[], missing: string[]): Frustration[] {
+  if (!file) { missing.push("ratings"); return []; }
+  try {
+    const st = statSync(file);
+    if (!st.isFile()) { warnings.push(`ratings: not a regular file`); return []; }
+    if (st.size > MAX_RATINGS_BYTES) { warnings.push(`ratings: too large (${st.size} bytes), skipped`); return []; }
+  } catch (e) { warnings.push(`ratings unreadable: ${(e as Error).message}`); return []; }
+
+  let raw: string;
+  try { raw = readFileSync(file, "utf8"); } catch (e) { warnings.push(`ratings unreadable: ${(e as Error).message}`); return []; }
+
+  const out: Frustration[] = [];
+  let bad = 0;
+  for (const line of raw.split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+    let j: unknown;
+    try { j = JSON.parse(t); } catch { bad++; continue; }
+    const r = j as Record<string, unknown>;
+    const rating = typeof r.rating === "number" ? r.rating : NaN;
+    const ts = typeof r.timestamp === "string" ? r.timestamp : "";
+    if (!Number.isFinite(rating) || !ts) { bad++; continue; }
+    if (rating > maxRating) continue;
+    const ms = new Date(ts).getTime();
+    if (Number.isNaN(ms)) { bad++; continue; } // unparseable timestamp = malformed, not "out of window"
+    if (ms < since.getTime()) continue;
+    const note = (typeof r.sentiment_summary === "string" ? r.sentiment_summary : "")
+      .replace(/[\u0000-\u001f\u007f]/g, " ")
+      .slice(0, MAX_NOTE_CHARS);
+    out.push({ date: new Date(ms).toISOString().slice(0, 10), rating, note });
+  }
+  if (bad > 0) warnings.push(`ratings: skipped ${bad} malformed/incomplete line(s)`);
+  return out.sort((a, b) => a.rating - b.rating || a.date.localeCompare(b.date) || a.note.localeCompare(b.note));
+}
+
+function collectSessions(dir: string | null, since: Date, warnings: string[], missing: string[]): Session[] {
+  if (!dir) { missing.push("work-sessions"); return []; }
+  let names: string[];
+  try { names = readdirSync(dir); } catch (e) { warnings.push(`work dir unreadable: ${(e as Error).message}`); return []; }
+  const out: Session[] = [];
+  for (const name of names) {
+    if (name.startsWith(".") || name.startsWith("_")) continue; // skip hidden / system dirs
+    try {
+      const st = statSync(join(dir, name));
+      if (st.isDirectory() && st.mtime.getTime() >= since.getTime()) out.push({ slug: name, mtime: st.mtime.toISOString().slice(0, 10) });
+    } catch { /* transient race on a dir entry — skip, don't fail the run */ }
+  }
+  return out.sort((a, b) => b.mtime.localeCompare(a.mtime) || a.slug.localeCompare(b.slug));
+}
+
+/**
+ * name + description from a SKILL.md's YAML frontmatter block. Handles folded/block scalars
+ * (`description: >` / `|`) by gathering the indented continuation lines. Returns null if there
+ * is no frontmatter `name:`.
+ */
+function readMeta(skillMd: string): { name: string; description: string } | null {
+  let txt: string;
+  try { txt = readFileSync(skillMd, "utf8"); } catch { return null; }
+  const fm = /^---\r?\n([\s\S]*?)\r?\n---/.exec(txt);
+  const block = fm ? fm[1] : txt;
+  const name = /^name:\s*(.+)$/m.exec(block)?.[1]?.trim();
+  if (!name) return null;
+
+  let desc = /^description:\s*(.+)$/m.exec(block)?.[1]?.trim().replace(/^["']|["']$/g, "") ?? "";
+  if (/^[>|][+-]?\d*$/.test(desc)) { // block scalar indicator — gather indented continuation
+    const lines = block.split("\n");
+    const di = lines.findIndex((l) => /^description:\s*[>|]/.test(l));
+    const cont: string[] = [];
+    for (let k = di + 1; k < lines.length; k++) {
+      if (/^\s+\S/.test(lines[k])) cont.push(lines[k].trim());
+      else break;
+    }
+    desc = cont.join(" ");
+  }
+  return { name, description: desc };
+}
+
+function collectRegistries(skillsDir: string | null, loopsDir: string | null, warnings: string[], missing: string[]): RegistryEntry[] {
+  const out: RegistryEntry[] = [];
+  if (!skillsDir) { missing.push("skills"); }
+  else {
+    let dirs: string[] = [];
+    try { dirs = readdirSync(skillsDir); } catch (e) { warnings.push(`skills dir unreadable: ${(e as Error).message}`); }
+    for (const d of dirs) {
+      const md = join(skillsDir, d, "SKILL.md");
+      if (!existsSync(md)) continue;
+      const meta = readMeta(md);
+      if (!meta) { warnings.push(`skills: ${d}/SKILL.md unreadable or missing name:`); continue; }
+      out.push({ kind: "skill", name: meta.name, description: meta.description });
+      const wf = join(skillsDir, d, "Workflows"); // workflows are reusable coverage too
+      if (existsSync(wf)) {
+        try { for (const f of readdirSync(wf)) if (f.endsWith(".md")) out.push({ kind: "workflow", name: `${meta.name}/${basename(f, ".md")}`, description: "" }); } catch { /* skip */ }
+      }
+    }
+  }
+  if (loopsDir) {
+    try { for (const f of readdirSync(loopsDir)) if (f.endsWith(".md")) out.push({ kind: "loop", name: basename(f, ".md"), description: "" }); }
+    catch (e) { warnings.push(`loops dir unreadable: ${(e as Error).message}`); }
+  }
+  return out.sort((a, b) => a.kind.localeCompare(b.kind) || a.name.localeCompare(b.name));
+}
+
+function main(): void {
+  const warnings: string[] = [];
+  const missing: string[] = [];
+
+  const root = arg("--root") ?? process.env.SKILLSCAN_MEMORY_ROOT ?? join(process.env.HOME ?? ".", ".claude");
+  const days = intArg("--days", 45, 1, 3650, warnings);
+  const maxRating = intArg("--max-rating", 4, 1, 10, warnings);
+  const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+  const ratingsFile = resolveStore(arg("--ratings"), "SKILLSCAN_RATINGS_FILE", "MEMORY/LEARNING/SIGNALS/ratings.jsonl", root, "ratings", warnings);
+  const workDir = resolveStore(arg("--work"), "SKILLSCAN_WORK_DIR", "MEMORY/WORK", root, "work", warnings);
+  const skillsDir = resolveStore(arg("--skills"), "SKILLSCAN_SKILLS_DIR", "skills", root, "skills", warnings);
+  const loopsDir = resolveStore(arg("--loops"), "SKILLSCAN_LOOPS_DIR", null, root, "loops", warnings); // opt-in; no personal default
+
+  const corpus: Corpus = {
+    window: { days, since: since.toISOString().slice(0, 10) },
+    sessions: collectSessions(workDir, since, warnings, missing),
+    frustrations: parseFrustrations(ratingsFile, maxRating, since, warnings, missing),
+    registries: collectRegistries(skillsDir, loopsDir, warnings, missing),
+    warnings,
+    missing,
+    sources: {
+      root,
+      ratings: ratingsFile ?? "(none)",
+      work: workDir ?? "(none)",
+      skills: skillsDir ?? "(none)",
+      loops: loopsDir ?? "(none)",
+    },
+  };
+
+  process.stdout.write(JSON.stringify(corpus, null, 2) + "\n");
+}
+
+main();

--- a/LifeOS/install/skills/SuggestSkills/Workflows/Scan.md
+++ b/LifeOS/install/skills/SuggestSkills/Workflows/Scan.md
@@ -1,0 +1,47 @@
+# Scan — discover skill gaps from work history + frustration
+
+Read-only. Proposes only. Never creates a skill (that is CreateSkill, after you approve).
+
+## Step 1 — gather deterministically (tool, not prose)
+
+```bash
+bun Tools/CollectSignals.ts --days 45 > /tmp/skill-scan-corpus.json
+# flags: --root <dir> --ratings <file> --work <dir> --skills <dir> --loops <dir> --max-rating <n>
+# resolves each store via flag > env > default under --root (env: SKILLSCAN_MEMORY_ROOT for --root,
+# then SKILLSCAN_RATINGS_FILE / SKILLSCAN_WORK_DIR / SKILLSCAN_SKILLS_DIR / SKILLSCAN_LOOPS_DIR).
+# loops is opt-in: it has no default, so pass --loops (or SKILLSCAN_LOOPS_DIR) if your setup has a loop catalog.
+```
+
+The corpus is `{ window, sessions[], frustrations[], registries[], warnings[], missing[], sources }`. Read `warnings`/`missing` first: a missing ratings store means the frustration signal is unavailable this run (say so in the report rather than pretending the topic-only result is complete). Do not re-gather by hand; the tool is the single source of evidence so two runs judge the same corpus.
+
+## Step 2 — cluster by pain
+
+Group `sessions` + `frustrations` into recurring themes. For each theme carry two numbers: recurrence (how many sessions) and friction (how many low ratings / recurrence markers like "regressed again"). Frustration outweighs raw topic frequency.
+
+## Step 3 — classify each cluster
+
+- **BEHAVIOR-FEEDBACK** — verbosity, scope misreads, reminder cadence. Not a skill; route to memory/preferences. Exclude.
+- **COVERED** — an existing skill/loop/workflow genuinely handles the *discipline*. Confirm by reading the covering unit's body, not its name; map the specific failure class to explicit guidance in it. If the body does not address the failure, it is not covered.
+- **GAP** — recurs (severity-weighted; a high-severity repeated pain qualifies even below ~3) AND uncovered, INCLUDING a discipline gap under a topic a build/test skill nominally covers.
+
+## Step 4 — verify with two independent passes, report the UNION
+
+Spawn two agents that classify the clusters from the same corpus. Report every cluster either flags as GAP, tagged by agreement: `both` (high confidence) or `one` (needs review). Do NOT drop single-pass gaps — strict intersection hides the subtle discipline gaps this skill exists to surface.
+
+## Step 5 — propose, never create
+
+Emit a ranked shortlist. Each proposal: name, one-line description, and evidence (recurrence, friction, the specific recurring failure it would prevent). Redact secrets, client/project names, and personal paths from anything written to a review location. Accepted proposals go to `CreateSkill` as a separate, human-approved step. This workflow writes no skill.
+
+## Output
+
+```
+## Skill-gap scan (last N days, M sessions; frustration store: present/absent)
+### Gaps worth building
+- <Name> [confidence: both|one] — <desc>. Evidence: N sessions, K frustration signals, recurring failure = "<...>". → CreateSkill?
+### Covered (verified against bodies, no action)
+- <theme> → <skill/loop/workflow>
+### Behavior-feedback (route to memory, not a skill)
+- <theme>
+### Recommendation
+<1-2 sentences; "nothing new" is valid ONLY when the frustration signals are also clean>
+```


### PR DESCRIPTION
## What

Adds SuggestSkills, a read-only skill that tells you which new skills are worth building, from your own work history and satisfaction signals. It proposes a ranked shortlist and routes accepted items to CreateSkill. It never creates or edits a skill itself.

## Why

CreateSkill covers building, validating, testing, and improving a skill. Nothing covers the step before it: deciding what to build. A plain topic scan of your sessions gives a false "nothing here", because the real gaps hide in two places a topic scan cannot see. First, frustration: a topic can look covered while you keep hitting the same wall inside it. Second, discipline gaps under a covered topic: a build skill owns "app work" while the recurring pain is an unowned discipline the build skill never touches. SuggestSkills reads the frustration signal LifeOS already captures via SatisfactionCapture, alongside work sessions, so it catches both.

## Shape

Read-only and proposal-only. It has no capability to create a skill, which is what makes "never auto-create" a boundary rather than a promise in prose.

Deterministic gathering. Tools/CollectSignals.ts emits a normalized corpus (sessions, low-rating frustrations, the skill/loop/workflow registry, and warnings for any missing or malformed store). The model only clusters and judges what the tool returns, so two runs see the same evidence. Store paths are discovered via flag, env, or root, so it works across installs.

Two verification passes, reported as a union with an agreement tag. Requiring both passes to agree would hide the subtle gaps this exists to find.

## Evidence

Blind test on real history: a topic-only pass missed a recurring state-modeling gap and reported nothing. The frustration-aware pass, run over the same window with the answer hidden, surfaced it in both passes independently. It also files behavior corrections such as verbosity or scope misreads as steering, not skills.

## Contents

SKILL.md, Workflows/Scan.md, Tools/CollectSignals.ts. Generic, no external dependencies.

## Credit

The idea comes from Hermes Agent by Nous Research, whose learning loop creates skills from experience. Hermes creates and grooms them autonomously. This takes the discovery half and inverts the risk: it is read-only, proposes only, and a human approves every skill before CreateSkill builds it.
