### PR TITLE
IntegrityCheck: tolerate UTF-8 BOM and CRLF in frontmatter parsing (#1732)

### DIFF
--- a/LifeOS/install/LIFEOS/TOOLS/IntegrityCheck.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/IntegrityCheck.ts
@@ -655,6 +655,9 @@ function checkFrontmatterUnits(name: string, dir: string, requireName: boolean):
   for (const f of files) {
     let content = '';
     try { content = readFileSync(join(dir, f), 'utf8'); } catch { continue; }
+    // Tolerate UTF-8 BOM and CRLF before anchoring — both defeat ^---\n and
+    // produced false "no frontmatter block" findings on Windows checkouts (#1732).
+    content = content.replace(/^\uFEFF/, '').replace(/\r\n/g, '\n');
     const fm = content.match(/^---\n([\s\S]*?)\n---/);
     if (!fm) { findings.push({ detail: `${name}/${f}: no frontmatter block`, blocking: true }); continue; }
     if (requireName && !/^name:\s*\S/m.test(fm[1])) findings.push({ detail: `${name}/${f}: missing frontmatter 'name:'`, blocking: true });
@@ -739,6 +742,7 @@ function checkSkills(): void {
     const rel = skillMd.replace(CLAUDE_DIR + '/', '');
     let content = '';
     try { content = readFileSync(skillMd, 'utf8'); } catch { continue; }
+    content = content.replace(/^\uFEFF/, '').replace(/\r\n/g, '\n'); // BOM/CRLF tolerance (#1732)
     const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
     if (!fmMatch) { findings.push({ detail: `${rel}: no frontmatter block`, blocking: true }); continue; }
     const fm = fmMatch[1];


### PR DESCRIPTION
Fixes #1732 (the CRLF/BOM false-positive class).

## Problem

Both frontmatter anchor regexes in `IntegrityCheck.ts` (`/^---\n([\s\S]*?)\n---/`, used by the commands/agents check and the skills check) fail on Windows checkouts:

- a UTF-8 BOM defeats the `^` anchor
- CRLF line endings defeat the `---\n` match

Every affected file then produces a false blocking `no frontmatter block` finding.

## Fix

Normalize the file read (strip `﻿`, convert CRLF to LF) before matching, at both parse sites. Four lines, no behavior change for LF files.

## Verification

A/B on Windows 11 (bun 1.3.14): a fixture `.md` written with a real BOM + CRLF (`EF BB BF` leading bytes) is flagged `BLOCK: no frontmatter block` by the current build and produces zero findings after this change.

Found while validating LifeOS native on Windows — the full hook pipeline runs there (verified against live `claude -p` sessions, plus a `windows-latest` CI probe suite). If Windows support is welcome, I have a small stack of similarly-scoped fixes ready to submit one at a time: `Bun.which()` for tool detection (`command -v` is absent from the Windows spawn shell), a directory-junction fallback in `setupUserSeparation` (the sibling of #1730's fix), a backslash-path normalization sweep for the hook layer (the #1119 class, with unit tests), and launcher spawn support for the `.cmd`/`.ps1` shims npm actually installs. Happy to open them in whatever order/shape you prefer.

Developed with Claude (co-author trailer on the commit); every change was probed on a real Windows machine before submission.
