### PR TITLE
fix(pulse/finances): non-USD amounts parse as zero, plus two adjacent data-loss bugs

### DIFF
--- a/LifeOS/install/LIFEOS/PULSE/Observability/observability.ts
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/observability.ts
@@ -2120,13 +2120,18 @@ function parseCurrencyTable(content: string): { label: string; annual: number }[
 
 function parseCurrencyCell(cell: string): number {
   if (!cell) return 0
-  const cleaned = cell.replace(/\*\*/g, "").replace(/[~$,]/g, "").trim()
-  const km = cleaned.match(/^([\d.]+)\s*([KkMm])\b/)
+  // Strip £ and € alongside $. A GBP cell such as "£1,234" previously survived
+  // cleaning as "£1234", failed the leading-digit match and returned 0, so every
+  // row on a non-USD dashboard silently became zero rather than failing visibly.
+  // Also accept the Unicode minus (U+2212) so negative rows parse instead of
+  // being dropped by the `amount > 0` filter in parseCurrencyTable.
+  const cleaned = cell.replace(/\*\*/g, "").replace(/[~$£€,]/g, "").replace(/−/g, "-").trim()
+  const km = cleaned.match(/^(-?[\d.]+)\s*([KkMm])\b/)
   if (km) {
     const base = parseFloat(km[1])
     return km[2].toLowerCase() === "m" ? base * 1_000_000 : base * 1_000
   }
-  const plain = cleaned.match(/^[\d.]+/)
+  const plain = cleaned.match(/^-?[\d.]+/)
   return plain ? parseFloat(plain[0]) : 0
 }
 
@@ -2478,7 +2483,9 @@ function handleLifeFinances(): Response {
           ...o,
           id: typeof o.id === "string" ? o.id : slugify(name),
           name,
-          scope: "personal",
+          // Honour an explicit scope when the file states one. Hardcoding this
+          // mislabelled every business-paid obligation as personal.
+          scope: typeof (o as any).scope === "string" ? (o as any).scope : "personal",
           cadence: o.cadence ?? FREQUENCY_TO_CADENCE[o.frequency] ?? "variable",
           amount_usd: amount,
           category: o.category ?? "other",
@@ -2540,7 +2547,9 @@ function handleLifeFinances(): Response {
       return {
         id: o.id,
         name: o.name ?? o.id,
-        scope: "personal",
+        // Second place the same field was flattened; fixing only the normalizer
+        // above has no visible effect because this override runs after it.
+        scope: (o as any).scope ?? "personal",
         monthly_usd: Math.round(monthly * 100) / 100,
         annual_usd: Math.round(monthly * 12 * 100) / 100,
         source: "manual",
@@ -2555,10 +2564,15 @@ function handleLifeFinances(): Response {
     // Matching is case-insensitive substring in either direction.
     // Guarded + empty-filtered: a missing id/name must neither throw nor add
     // "" to the set (an empty known label substring-matches every expense row).
+    // Only suppress an EXPENSES.md row when the matching vendor/obligation actually
+    // contributes spend. A £0 "unconfigured" entry — every row of the shipped sample
+    // vendors.yaml, until a user clears it — has nothing to double-count, so letting
+    // it match silently deleted real expenses from the outbound total.
+    const contributes = (l: ResolvedLine) => l.monthly_usd > 0 || l.annual_usd > 0
     const knownLabels = new Set<string>([
-      ...resolvedVendors.map(v => (v.name ?? v.id ?? "").toLowerCase()),
-      ...resolvedVendors.map(v => (v.id ?? v.name ?? "").toLowerCase()),
-      ...resolvedObligations.map(o => (o.name ?? o.id ?? "").toLowerCase()),
+      ...resolvedVendors.filter(contributes).map(v => (v.name ?? v.id ?? "").toLowerCase()),
+      ...resolvedVendors.filter(contributes).map(v => (v.id ?? v.name ?? "").toLowerCase()),
+      ...resolvedObligations.filter(contributes).map(o => (o.name ?? o.id ?? "").toLowerCase()),
     ].filter(Boolean))
     const otherOutbound: ResolvedLine[] = expenseCategories
       .filter(e => {

--- a/LifeOS/install/LIFEOS/PULSE/Observability/src/app/finances/page.tsx
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/src/app/finances/page.tsx
@@ -162,6 +162,7 @@ interface FinancesDataV2 {
     targets: { headers: string[]; rows: string[][] } | null;
     sections: Section[];
   };
+  state?: { currency?: string; [k: string]: unknown };
   incomeStreams?: Stream[];
   expenseCategories?: Stream[];
   annualIncome?: number;
@@ -183,20 +184,31 @@ interface FinancesDataV2 {
 
 // ─── Formatting ───
 
-function fmtHero(dollars: number | null | undefined): string {
-  const n = Number(dollars) || 0;
-  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 10_000) return `$${Math.round(n / 1000)}K`;
-  if (n >= 1_000) {
-    const k = n / 1000;
-    return k % 1 === 0 ? `$${k.toFixed(0)}K` : `$${k.toFixed(1)}K`;
-  }
-  return `$${Math.round(n).toLocaleString()}`;
+// Currency symbol, driven by state.json's `currency` field via the API payload.
+// Defaults to "$" so an install that never sets it behaves exactly as before.
+const CURRENCY_SYMBOLS: Record<string, string> = { USD: "$", GBP: "£", EUR: "€" };
+let CURRENCY = "$";
+let CURRENCY_LOCALE = "en-US";
+export function setCurrency(code: string | null | undefined) {
+  if (!code) return;
+  CURRENCY = CURRENCY_SYMBOLS[code.toUpperCase()] ?? "$";
+  CURRENCY_LOCALE = code.toUpperCase() === "GBP" ? "en-GB" : "en-US";
 }
 
-function fmtExact(dollars: number | null | undefined): string {
-  const n = Number(dollars) || 0;
-  return `$${n.toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
+function fmtHero(amount: number | null | undefined): string {
+  const n = Number(amount) || 0;
+  if (n >= 1_000_000) return `${CURRENCY}${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 10_000) return `${CURRENCY}${Math.round(n / 1000)}K`;
+  if (n >= 1_000) {
+    const k = n / 1000;
+    return k % 1 === 0 ? `${CURRENCY}${k.toFixed(0)}K` : `${CURRENCY}${k.toFixed(1)}K`;
+  }
+  return `${CURRENCY}${Math.round(n).toLocaleString()}`;
+}
+
+function fmtExact(amount: number | null | undefined): string {
+  const n = Number(amount) || 0;
+  return `${CURRENCY}${n.toLocaleString(CURRENCY_LOCALE, { maximumFractionDigits: 0 })}`;
 }
 
 function fmtPct(rate: number | null | undefined): string {
@@ -530,7 +542,7 @@ function TrendChart({ trend }: { trend: TrendPoint[] }) {
             <YAxis
               stroke="var(--ink-3)"
               fontSize={11}
-              tickFormatter={(v) => `$${Math.round(v / 1000)}K`}
+              tickFormatter={(v) => `${CURRENCY}${Math.round(v / 1000)}K`}
             />
             <Tooltip
               contentStyle={{
@@ -1403,7 +1415,10 @@ export default function FinancesPage() {
   useEffect(() => {
     fetch("/api/life/finances")
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
-      .then(setData)
+      .then((d: FinancesDataV2) => {
+        setCurrency(d?.state?.currency);
+        setData(d);
+      })
       .catch((e) => setError(String(e)));
   }, []);
 


### PR DESCRIPTION
Three defects in the Pulse Finances data layer, plus the frontend change needed to see the fix. Each bug produces a plausible-looking but wrong dashboard rather than a visible failure, which is why they're easy to miss.

Found while populating the Finances tab with real GBP data on a fresh install.

## 1. Non-USD amounts parse as zero

`parseCurrencyCell` strips `$` and commas but not `£` or `€`:

```ts
const cleaned = cell.replace(/\*\*/g, "").replace(/[~$,]/g, "").trim()
```

`"£1,234"` survives as `"£1234"`, fails `cleaned.match(/^[\d.]+/)`, and returns `0`. Every row on a non-USD dashboard silently becomes zero — the tab renders normally and shows a total of 0.

Also now accepts the Unicode minus (U+2212), which typographic pipelines emit, so negative rows parse rather than being dropped by the `amount > 0` filter in `parseCurrencyTable`.

USD behaviour is unchanged; regression cases below.

## 2. Obligation `scope` is hardcoded in two places

`obligations.yaml` can declare `scope: business`, but the value is overwritten with `"personal"` both in the YAML normalizer and again in the resolver. Fixing only the first has no visible effect, which makes this awkward to debug. Every business-paid obligation renders as personal.

## 3. Sample vendors silently delete real expenses

`knownLabels` is built from all vendors and obligations, then substring-matched against `EXPENSES.md` rows to avoid double-counting:

```ts
if (lower.includes(known) || known.includes(lower)) return false
```

Every row of the shipped `install/USER/FINANCES/vendors.yaml` is a zero-value `unconfigured` sample (`"Sample Employer Inc."`, `"Sample Landlord"`, …). A user who fills in `EXPENSES.md` but leaves the sample file alone — it looks inert — has those sample names suppress their genuine expense rows.

On my install this removed roughly 40% of real expenses from the outbound total with no warning: the tab showed £32k against a true £55k.

A zero-value entry has nothing to double-count, so suppression is pure data loss. Only entries that actually contribute spend can now suppress a row.

## 4. Frontend: currency symbol from `state.json`

`fmtHero`/`fmtExact` hardcode `$`. They now read `state.currency` (already present in the API payload) and fall back to `$` when absent, so existing installs are unaffected. Without this the parser fix is invisible: a GBP install shows `$0` everywhere, then `$98K`.

## Verification

Parser, including USD regression:

| Input | Result |
|---|---|
| `£1,234` | 1234 |
| `**£31,570.56**` | 31570.56 |
| `−£6,408.47` | -6408.47 |
| `€2,500` | 2500 |
| `$1,234` | 1234 |
| `~$500` | 500 |
| `$12K` | 12000 |
| `£1.2M` | 1200000 |
| `-$50` | -50 |
| `""` / `n/a` | 0 |

End to end on a real GBP install: income and expense totals correct, obligations splitting business from personal correctly, and the Expenses tab total moving from the wrong £32k to the correct £55k once sample vendors stopped matching.

Happy to split this into separate PRs if you'd prefer them reviewed independently.
