### PR TITLE
fix(telos): read Context Filter from TELOS.md instead of a hardcoded value

### DIFF
--- a/LifeOS/install/LIFEOS/TOOLS/GenerateTelosSummary.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/GenerateTelosSummary.ts
@@ -188,6 +188,24 @@ function paragraphItems(content: string, prefix: string): ParsedItem[] {
 /**
  * Parse mission items from MISSION.md
  */
+/** Read the "## Context Filter" H2 body from the unified TELOS.md. */
+function readContextFilter(): string {
+  try {
+    const raw = readFileSync(join(TELOS_DIR, 'TELOS.md'), 'utf-8');
+    const i = raw.indexOf('## Context Filter');
+    if (i < 0) return '';
+    const rest = raw.slice(i + '## Context Filter'.length);
+    const nxt = rest.indexOf('\n## ');
+    const m: string[] | null = ['', nxt >= 0 ? rest.slice(0, nxt) : rest];
+    if (!m) return '';
+    return m[1]
+      .split('\n')
+      .filter(l => !l.trim().startsWith('<!--'))
+      .join('\n')
+      .trim();
+  } catch { return ''; }
+}
+
 function parseMissions(): string[] {
   const content = readTelosFile('MISSION.md');
   const items = parseItems(content, 'M');
@@ -579,7 +597,10 @@ function generate(): string {
     '',
     '## Context Filter',
     '',
-    'When steering work, bias toward: human flourishing, Human 3.0 transition, AI augmentation strategies, becoming one\'s full self, correct framing.',
+    // Read the principal's own Context Filter from unified TELOS.md rather than
+    // shipping a hardcoded personal value statement (local patch 2026-08-09;
+    // upstream candidate — the literal below overwrote every user's filter).
+    readContextFilter() || 'When steering work, bias toward: (define your Context Filter in TELOS.md).',
   );
 
   return lines.join('\n') + '\n';


### PR DESCRIPTION
## Problem

`GenerateTelosSummary.ts` emits a hardcoded string as the Context Filter section of `PRINCIPAL_TELOS.md`:

```
'When steering work, bias toward: human flourishing, Human 3.0 transition,
 AI augmentation strategies, becoming one's full self, correct framing.'
```

`PRINCIPAL_TELOS.md` is `@`-imported at every session start, and the Context Filter is the field that steers prioritisation. Because the literal is unconditional, every install renders the same filter regardless of what the user wrote in their own `TELOS.md`, silently replacing their steering criteria with someone else's.

## Fix

Read the `## Context Filter` section from unified `TELOS.md`, falling back to a neutral prompt when the section is absent.

## Verification

On a live 7.28.3 install with a populated Context Filter, `PRINCIPAL_TELOS.md` now renders the user's own text. With the section absent, it renders the fallback prompt rather than an unrelated value.

Scope: one function plus its call site. No behaviour change for any other section.

---
*Found and fixed with AI assistance while installing 7.28.3; verified on a live install rather than by inspection.*
