### PR TITLE
DA template: ship the schema DaSubsystem.md already defines

### DIFF
--- a/LifeOS/install/USER/DIGITAL_ASSISTANT/DA_IDENTITY.md
+++ b/LifeOS/install/USER/DIGITAL_ASSISTANT/DA_IDENTITY.md
@@ -3,6 +3,23 @@ provenance: template
 last_updated: 1970-01-01T00:00:00Z
 last_updated_by: bootstrap-template
 convention: pai-freshness-v1
+schema_version: 1
+# DA Identity Schema v1.0 (DaSubsystem.md); populated by /interview. Absent fields
+# stay absent; never invent identity content to fill a schema slot.
+core:
+  name: LifeOS
+  full_name: LifeOS Assistant
+  display_name: LifeOS
+  color: "#3B82F6"
+  role: primary
+voice:
+  provider: elevenlabs
+  source_of_truth: "settings.json daidentity (voices.main); ids never hardcoded here"
+personality:
+  base_description: "Direct, curious, opinionated when evidence warrants; a peer, not a servant"
+  traits_source: "settings.json daidentity.personality"
+autonomy:
+  must_ask: [send, spend, deploy, delete, merge]
 ---
 
 # DA Identity — LifeOS


### PR DESCRIPTION
DaSubsystem.md defines DA Identity Schema v1.0 (frontmatter: schema_version, core, voice, personality, autonomy, and the wider field set) and a migration table for existing installs. The shipped bootstrap template `install/USER/DIGITAL_ASSISTANT/DA_IDENTITY.md` never adopted it, so every fresh install is born schema-less and immediately subject to the doc's own migration path.

This PR adds the v1.0 frontmatter to the template with neutral bootstrap values only (the same "LifeOS" placeholder identity the template already uses); `/interview` populates the real values, and absent fields stay absent rather than being invented.

Validated on a live install: frontmatter added with the markdown body byte-identical pre/post (sha256 on the body), YAML parse green, and a cap/schema guard test at 4/4 with three planted-failure reds before trusting the green. Happy to contribute that guard test as a follow-up if useful.
