### PR TITLE
fix(hermes): Policy.ts CLI no longer discards the destination when --launcher is absent

### DIFF
--- a/LifeOS/install/LIFEOS/HERMES/Policy.ts
+++ b/LifeOS/install/LIFEOS/HERMES/Policy.ts
@@ -409,7 +409,9 @@ if (import.meta.main) {
   const argv = process.argv.slice(2);
   const launcherIdx = argv.indexOf("--launcher");
   const launcherName = launcherIdx !== -1 ? (argv[launcherIdx + 1] ?? "") : "";
-  const positional = argv.filter((a, i) => a !== "--launcher" && i !== launcherIdx + 1);
+  const positional = argv.filter(
+    (a, i) => a !== "--launcher" && (launcherIdx === -1 || i !== launcherIdx + 1),
+  );
   const dest = positional[0];
   if (!dest) {
     process.stdout.write(JSON.stringify(buildPolicy({ launcherName }), null, 2) + "\n");


### PR DESCRIPTION
Fixes #1859.

`Policy.ts`'s CLI filters `--launcher` and its value out of `argv` before reading the positional destination:

```ts
const positional = argv.filter((a, i) => a !== "--launcher" && i !== launcherIdx + 1);
```

When `--launcher` is absent, `launcherIdx` is `-1` and `i !== launcherIdx + 1` excludes index 0 — the destination itself. `bun Policy.ts <dest>` then prints to stdout and never writes the file, exit 0.

**Change** (one file, `LifeOS/install/LIFEOS/HERMES/Policy.ts`): guard the sentinel value so the value-slot exclusion only applies when `--launcher` was actually passed.

Verified: `bun Policy.ts /tmp/policy.json` writes the file and prints the `✓ policy v…` line; `bun Policy.ts --launcher name /tmp/policy.json` unchanged; no-arg stdout form unchanged.
