### PR TITLE
Atlas: Linux path unit for immediate event-triggered ticks (parity with darwin WatchPaths)

### DIFF
--- a/LifeOS/install/LIFEOS/ATLAS/InstallAtlas.ts
+++ b/LifeOS/install/LIFEOS/ATLAS/InstallAtlas.ts
@@ -12,10 +12,15 @@
  *     ~/Library/LaunchAgents/com.lifeos.atlas.plist, runs `launchctl bootstrap`.
  *     15-minute StartInterval plus WatchPaths on the hint file, so a mutation
  *     captured by AtlasEventCapture.hook.ts triggers a targeted sync at once.
- *   linux: substitutes into com.lifeos.atlas.{service,timer}.template, writes them
- *     to ~/.config/systemd/user/, enables the timer with `systemctl --user`, and
- *     runs `loginctl enable-linger` so it survives logout. systemd has no WatchPaths
- *     equivalent here — hints wait for the next tick, which only costs latency.
+ *   linux: substitutes into com.lifeos.atlas.{service,timer,path}.template, writes
+ *     them to ~/.config/systemd/user/, enables the timer + path unit with
+ *     `systemctl --user`, and runs `loginctl enable-linger` so both survive logout.
+ *     The path unit is systemd's WatchPaths equivalent: it fires `atlas tick`
+ *     immediately when events.jsonl changes, same fast-path as darwin, instead of
+ *     waiting out the 15-minute timer. It watches the hint file specifically, not
+ *     the whole state directory — see com.lifeos.atlas.path.template for why.
+ *     Path units don't fire on enable (no RunAtLoad equivalent), so install also
+ *     runs one manual tick to match darwin's RunAtLoad-on-install behavior.
  *
  * The darwin path is a second branch beside linux, never a replacement. Both are
  * idempotent: install tears down the prior unit before bootstrapping the fresh one.
@@ -41,10 +46,14 @@ const TARGET_PLIST = join(LAUNCH_AGENTS_DIR, `${LABEL}.plist`);
 // linux (systemd --user)
 const SERVICE_TEMPLATE_PATH = join(HOME, ".claude", "LIFEOS", "ATLAS", "com.lifeos.atlas.service.template");
 const TIMER_TEMPLATE_PATH = join(HOME, ".claude", "LIFEOS", "ATLAS", "com.lifeos.atlas.timer.template");
+const PATH_UNIT_TEMPLATE_PATH = join(HOME, ".claude", "LIFEOS", "ATLAS", "com.lifeos.atlas.path.template");
 const SYSTEMD_USER_DIR = join(HOME, ".config", "systemd", "user");
 const TARGET_SERVICE = join(SYSTEMD_USER_DIR, `${LABEL}.service`);
 const TARGET_TIMER = join(SYSTEMD_USER_DIR, `${LABEL}.timer`);
+const TARGET_PATH_UNIT = join(SYSTEMD_USER_DIR, `${LABEL}.path`);
 const TIMER_UNIT = `${LABEL}.timer`;
+const PATH_UNIT = `${LABEL}.path`;
+const SERVICE_UNIT = `${LABEL}.service`;
 
 async function run(cmd: string[]): Promise<{ ok: boolean; out: string; err: string }> {
   const proc = Bun.spawn(cmd, { stdout: "pipe", stderr: "pipe" });
@@ -181,9 +190,21 @@ async function status(): Promise<void> {
 
 // ── linux (systemd --user) ──
 
+/** Enable + start a unit, logging and exiting on failure. Shared by the timer and path-unit enable steps. */
+async function enableUnit(unit: string, humanLabel: string): Promise<void> {
+  const r = await run(["systemctl", "--user", "enable", "--now", unit]);
+  if (!r.ok) {
+    console.error(`[InstallAtlas] enable --now ${humanLabel} failed: ${r.err.trim()}`);
+    process.exit(1);
+  }
+  console.log(`[InstallAtlas] systemd ${humanLabel} enabled — ${unit} active`);
+}
+
 async function installLinux(): Promise<void> {
-  if (!existsSync(SERVICE_TEMPLATE_PATH) || !existsSync(TIMER_TEMPLATE_PATH)) {
-    console.error(`[InstallAtlas] template missing — expected ${SERVICE_TEMPLATE_PATH} and ${TIMER_TEMPLATE_PATH}`);
+  if (!existsSync(SERVICE_TEMPLATE_PATH) || !existsSync(TIMER_TEMPLATE_PATH) || !existsSync(PATH_UNIT_TEMPLATE_PATH)) {
+    console.error(
+      `[InstallAtlas] template missing — expected ${SERVICE_TEMPLATE_PATH}, ${TIMER_TEMPLATE_PATH}, and ${PATH_UNIT_TEMPLATE_PATH}`,
+    );
     process.exit(1);
   }
   const { bunPath, path } = await detected();
@@ -192,25 +213,29 @@ async function installLinux(): Promise<void> {
 
   // Idempotent teardown (ignore failures — first install has nothing to remove)
   await run(["systemctl", "--user", "disable", "--now", TIMER_UNIT]);
+  await run(["systemctl", "--user", "disable", "--now", PATH_UNIT]);
 
   writeFileSync(TARGET_SERVICE, materialize(SERVICE_TEMPLATE_PATH, bunPath, path));
   writeFileSync(TARGET_TIMER, materialize(TIMER_TEMPLATE_PATH, bunPath, path));
+  writeFileSync(TARGET_PATH_UNIT, materialize(PATH_UNIT_TEMPLATE_PATH, bunPath, path));
   console.log(`[InstallAtlas] wrote ${TARGET_SERVICE}`);
   console.log(`[InstallAtlas] wrote ${TARGET_TIMER}`);
+  console.log(`[InstallAtlas] wrote ${TARGET_PATH_UNIT}`);
 
   await run(["systemctl", "--user", "daemon-reload"]);
 
   // Survive logout/reboot. An empty username would make `enable-linger` fail, so skip loudly.
   const lingerUser = await username();
   if (lingerUser) await run(["loginctl", "enable-linger", lingerUser]);
-  else console.warn("[InstallAtlas] could not resolve username via 'id -un' — skipping loginctl enable-linger (timer may not survive logout)");
+  else console.warn("[InstallAtlas] could not resolve username via 'id -un' — skipping loginctl enable-linger (timer/path unit may not survive logout)");
 
-  const r = await run(["systemctl", "--user", "enable", "--now", TIMER_UNIT]);
-  if (!r.ok) {
-    console.error(`[InstallAtlas] enable --now failed: ${r.err.trim()}`);
-    process.exit(1);
-  }
-  console.log(`[InstallAtlas] systemd timer enabled — ${TIMER_UNIT} active`);
+  await enableUnit(TIMER_UNIT, "timer");
+  await enableUnit(PATH_UNIT, "path watcher");
+
+  // Path units start watching but don't fire immediately (no RunAtLoad equivalent) —
+  // run the service once manually so install gets darwin's "sync now" parity.
+  const first = await run(["systemctl", "--user", "start", SERVICE_UNIT]);
+  console.log(`[InstallAtlas] initial tick ${first.ok ? "OK" : "FAILED: " + first.err.trim()}`);
 
   const list = await run(["systemctl", "--user", "list-timers", TIMER_UNIT, "--no-pager"]);
   if (list.ok) console.log(list.out.trim());
@@ -218,8 +243,9 @@ async function installLinux(): Promise<void> {
 
 async function uninstallLinux(): Promise<void> {
   await run(["systemctl", "--user", "disable", "--now", TIMER_UNIT]);
+  await run(["systemctl", "--user", "disable", "--now", PATH_UNIT]);
   let removed = false;
-  for (const f of [TARGET_SERVICE, TARGET_TIMER]) {
+  for (const f of [TARGET_SERVICE, TARGET_TIMER, TARGET_PATH_UNIT]) {
     if (existsSync(f)) {
       try { unlinkSync(f); console.log(`[InstallAtlas] removed ${f}`); removed = true; } catch {}
     }
@@ -231,9 +257,13 @@ async function uninstallLinux(): Promise<void> {
 async function statusLinux(): Promise<void> {
   const r = await run(["systemctl", "--user", "status", TIMER_UNIT, "--no-pager"]);
   console.log(r.out || r.err);
+  const p = await run(["systemctl", "--user", "status", PATH_UNIT, "--no-pager"]);
+  console.log(p.out || p.err);
   const list = await run(["systemctl", "--user", "list-timers", TIMER_UNIT, "--no-pager"]);
   if (list.ok) console.log(list.out.trim());
-  if (!r.ok) process.exit(1);
+  // Both units must be healthy — a dead path watcher silently loses the fast
+  // path back to 15-minute-latency polling, which a timer-only exit code hides.
+  if (!r.ok || !p.ok) process.exit(1);
 }
 
 function unsupported(): never {

--- a/LifeOS/install/LIFEOS/ATLAS/collectors/Systemd.ts
+++ b/LifeOS/install/LIFEOS/ATLAS/collectors/Systemd.ts
@@ -48,19 +48,21 @@ export const systemd: Collector = {
     // a machine without this dir (macOS, or a fresh Linux box pre-install) reports
     // incompleteness rather than a permanent sync failure.
     if (!existsSync(UNITS_DIR)) return { complete: false, assets: [], edges: [] };
-    const files = readdirSync(UNITS_DIR).filter((f) => /^com\.(lifeos|pai)\..*\.(service|timer)$/.test(f));
-    // Group by label (strip .service/.timer) so a paired unit reports one asset
-    // with both its schedule (from the .timer) and its exec (from the .service).
-    const labels = new Map<string, { service?: string; timer?: string }>();
+    const files = readdirSync(UNITS_DIR).filter((f) => /^com\.(lifeos|pai)\..*\.(service|timer|path)$/.test(f));
+    // Group by label (strip .service/.timer/.path) so a paired unit reports one
+    // asset with its schedule (from the .timer), its exec (from the .service),
+    // and whether it also has an event-triggered fast path (from the .path unit).
+    const labels = new Map<string, { service?: string; timer?: string; path?: string }>();
     for (const f of files) {
-      const isTimer = f.endsWith(".timer");
-      const label = f.replace(/\.(service|timer)$/, "");
+      const label = f.replace(/\.(service|timer|path)$/, "");
       const entry = labels.get(label) ?? {};
-      if (isTimer) entry.timer = f; else entry.service = f;
+      if (f.endsWith(".timer")) entry.timer = f;
+      else if (f.endsWith(".path")) entry.path = f;
+      else entry.service = f;
       labels.set(label, entry);
     }
 
-    for (const [label, { service, timer }] of labels) {
+    for (const [label, { service, timer, path: pathUnit }] of labels) {
       let onUnitActiveSec: number | null = null;
       let onBootSec: string | null = null;
       let persistent = false;
@@ -78,6 +80,7 @@ export const systemd: Collector = {
         attrs: {
           service_unit: service ?? null,
           timer_unit: timer ?? null,
+          path_unit: pathUnit ?? null,
           on_unit_active_sec: onUnitActiveSec,
           on_boot_sec: onBootSec,
           persistent,

--- a/LifeOS/install/LIFEOS/ATLAS/com.lifeos.atlas.path.template
+++ b/LifeOS/install/LIFEOS/ATLAS/com.lifeos.atlas.path.template
@@ -1,0 +1,21 @@
+# com.lifeos.atlas.path.template — systemd --user path unit, the Linux sibling
+# of the darwin plist's WatchPaths. Fires `atlas tick` immediately when
+# events.jsonl changes instead of waiting out the 15-minute timer, matching
+# darwin's fast-path behavior instead of accepting the latency gap.
+#
+# Watches EVENTS_PATH specifically — NOT the whole Atlas state directory,
+# which Atlas's own tick rewrites (db/wal/snapshot.json) on every run.
+# Watching the directory self-triggers a restart loop that trips systemd's
+# default start-limit within seconds, since every tick's own writes would
+# re-arm the watch. Watching the single hint file avoids that: the tick that
+# consumes and renames events.jsonl (see Atlas.ts's atomic claim) does not
+# touch the file at this exact path again until a new hint is captured.
+[Unit]
+Description=LifeOS Atlas watcher — fires on events.jsonl changes
+
+[Path]
+PathModified={{HOME}}/.local/state/lifeos/atlas/events.jsonl
+Unit=com.lifeos.atlas.service
+
+[Install]
+WantedBy=default.target

--- a/LifeOS/install/LIFEOS/ATLAS/com.lifeos.atlas.service.template
+++ b/LifeOS/install/LIFEOS/ATLAS/com.lifeos.atlas.service.template
@@ -1,8 +1,19 @@
 # com.lifeos.atlas.service.template — oneshot unit that runs `atlas tick`.
 # Widened PATH so bun/gh resolve regardless of install method (homebrew, ~/.bun, linuxbrew).
 # ported from public PR #1743, @schmetti-dev
+#
+# StartLimitIntervalSec/Burst: this unit is now also triggered by
+# com.lifeos.atlas.path (see that template), so it can fire several times in
+# quick succession during a legitimate burst of activity, not just on the
+# 15-minute timer. Darwin's equivalent (ThrottleInterval=60) only delays extra
+# runs; systemd's default start-limit (5 starts/10s) instead fails the unit
+# into start-limit-hit, which refuses further starts until a manual
+# `systemctl --user reset-failed`. Widening the window gives normal bursts
+# room while still catching a true self-trigger loop within a minute.
 [Unit]
 Description=LifeOS Atlas asset-graph tick (events-then-hourly-full-sync)
+StartLimitIntervalSec=60
+StartLimitBurst=20
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
## What

Linux's `InstallAtlas.ts` had a capability gap against darwin: the plist gets `WatchPaths` on `events.jsonl` for an immediate targeted sync when a hint lands, but linux only had the 15-minute timer — a captured event could sit for up to 15 minutes before Atlas picked it up.

Adds `com.lifeos.atlas.path.template`, a systemd --user `.path` unit watching `events.jsonl` specifically (not the whole Atlas state directory — watching the directory would self-trigger a restart loop, since Atlas's own tick rewrites `db`/`wal`/`snapshot.json` on every run). `InstallAtlas.ts` now materializes, enables, and tears down the path unit alongside the timer, and runs one manual tick on install since `.path` units don't fire on enable the way darwin's `RunAtLoad` does.

Since the path unit means the service can now fire several times in quick succession during a legitimate burst (not just on the 15-min timer), this also adds:
- `StartLimitIntervalSec=60` / `StartLimitBurst=20` on `com.lifeos.atlas.service.template`, so a normal burst doesn't trip systemd's default 5-starts/10s limit into a hard `start-limit-hit` failure (darwin's `ThrottleInterval=60` only delays extra runs, it doesn't hard-fail)
- `statusLinux()`'s exit code now reflects the path unit's health too, not just the timer's
- `collectors/Systemd.ts` now recognizes `.path` units, so Atlas's own asset graph has a record of the unit this same change installs

## Why draft

Opening as draft for a maintainer look before marking ready — this is my first PR touching the Linux install path specifically, want a sanity check on the systemd conventions before finalizing.

## Testing

- `bun build` on both changed `.ts` files (clean)
- Manually verified the existing (pre-this-PR) equivalent has been running on my own box for a while without the restart-loop the comment describes — this PR ports that same design into the template-based installer structure this repo now uses