### PR TITLE
fix(PromptProcessing): look for transcripts under claudeDir, not LIFEOS

### DIFF
--- a/LifeOS/install/hooks/PromptProcessing.hook.ts
+++ b/LifeOS/install/hooks/PromptProcessing.hook.ts
@@ -43,7 +43,7 @@ import { inference } from '../LIFEOS/TOOLS/Inference';
 import { getIdentity, getPrincipal } from './lib/identity';
 import { isValidWorkingTitle, getWorkingFallback, trimToValidTitle } from './lib/output-validators';
 import { getSessionOneWord, readTabState, setAscentTab } from './lib/tab-setter';
-import { paiPath } from './lib/paths';
+import { paiPath, getClaudeDir } from './lib/paths';
 import { updateSessionNameInWorkJson, upsertSession } from './lib/isa-utils';
 import { isDesktopChannel, logSkippedVoice, getNotificationChannel } from './lib/notification-channel';
 import { PULSE_BASE } from '../LIFEOS/PULSE/endpoint';
@@ -671,7 +671,10 @@ function storeName(sessionId: string, label: string, source: string): void {
 /** Find Claude Code's session JSONL path for a given session ID. */
 function findSessionJsonl(sessionId: string): string | null {
   try {
-    for (const dir of [paiPath('projects'), paiPath('Projects')]) {
+    // Transcripts belong to the harness and live at <claudeDir>/projects, NOT under
+    // LIFEOS/. paiPath() resolves against getLifeosDir(), so paiPath('projects') is
+    // <claudeDir>/LIFEOS/projects — a directory that does not exist in any install.
+    for (const dir of [join(getClaudeDir(), 'projects'), join(getClaudeDir(), 'Projects')]) {
       if (!existsSync(dir)) continue;
       const r = Bun.spawnSync(['find', dir, '-maxdepth', '2', '-name', `${sessionId}.jsonl`],
         { stdout: 'pipe', stderr: 'pipe', timeout: 2000 });


### PR DESCRIPTION
`findSessionJsonl` searches `paiPath('projects')`. `paiPath()` resolves against `getLifeosDir()`, so that path is `<claudeDir>/LIFEOS/projects` — but Claude Code writes transcripts to `<claudeDir>/projects`. The directory never exists, `existsSync` skips both candidates, and the function always returns `null`.

Both callers then fail silently:

- **`syncNameToJsonl()`** never appends the `custom-title` row, so the name LifeOS derives from the first prompt never reaches the transcript. `/sessions` and the harness surfaces show the raw first prompt instead of the session name.
- **`getCustomTitle()`** always returns `null`, so a name the user sets with `/rename` is never read back as canonical on the next prompt.

### Evidence

On one install, before the fix: **zero `custom-title` rows across all 64 transcripts**, while `session-names.json` held a correct name for every session. After the fix, the row is written on the next prompt and the real name shows up.

```
paiPath('projects')             -> ~/.claude/LIFEOS/projects   (does not exist)
join(getClaudeDir(), 'projects') -> ~/.claude/projects          (64 .jsonl files)
```

### The change

Two lines: import `getClaudeDir` alongside `paiPath`, and build the search roots from it. `PromptProcessing.hook.ts` is the only caller of `paiPath('projects')` in the payload, so nothing else is affected. The `Projects` capitalisation fallback is kept as-is.