### PR TITLE
fix(TokenXray): dedupe API calls by requestId

### DIFF
--- a/LifeOS/install/LIFEOS/TOOLS/TokenXray/TokenXray.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/TokenXray/TokenXray.ts
@@ -104,6 +104,23 @@ function* readJsonl(path: string): IterableIterator<Record<string, unknown>> {
   }
 }
 
+// Claude Code writes the same assistant message into several transcript files
+// (sidechains, resumed sessions, worktree copies), so summing every `usage`
+// block counts one API call many times. Measured on a real corpus: 292,757
+// requestId occurrences for 139,447 unique calls, a 2.10x inflation that put
+// billed input ~1.8x above ccusage, which dedupes on the same key.
+// Entries without a requestId cannot be keyed, so they are kept.
+function makeDedup(): (o: Record<string, unknown>) => boolean {
+  const seen = new Set<string>();
+  return (o) => {
+    const id = o.requestId;
+    if (typeof id !== "string" || id === "") return true;
+    if (seen.has(id)) return false;
+    seen.add(id);
+    return true;
+  };
+}
+
 function mainLogs(): string[] {
   return glob(join(homedir(), ".claude/projects/*/*.jsonl"));
 }
@@ -151,10 +168,12 @@ function computeCostTotals(): CostTotals {
     write_1h: 0,
     write_5m: 0,
   };
+  const fresh = makeDedup();
   for (const f of mainLogs()) {
     for (const o of readJsonl(f)) {
       const m = o.message as Record<string, unknown> | undefined;
       if (!m || typeof m !== "object" || m.role !== "assistant") continue;
+      if (!fresh(o)) continue;
       const u = (m.usage as Record<string, unknown>) ?? {};
       T.cache_read += Number(u.cache_read_input_tokens ?? 0);
       T.uncached += Number(u.input_tokens ?? 0);
@@ -518,6 +537,7 @@ function analyze(files: string[]): SplitResult {
     per_session: [],
   };
   const bump = (m: Map<string, number>, k: string, v: number) => m.set(k, (m.get(k) ?? 0) + v);
+  const fresh = makeDedup();
   for (const f of files) {
     let fc = 0;
     for (const o of readJsonl(f)) {
@@ -526,6 +546,7 @@ function analyze(files: string[]): SplitResult {
       const role = m.role as string | undefined;
       const u = m.usage as Record<string, unknown> | undefined;
       if (u && typeof u === "object" && role === "assistant") {
+        if (!fresh(o)) continue;
         R.calls += 1;
         fc += 1;
         const ui = Number(u.input_tokens ?? 0);
@@ -714,6 +735,7 @@ function runReread(jsonOut: boolean): void {
   const uniq = new Map<string, number>();
   const cumu = new Map<string, number>();
   let measured = 0;
+  const fresh = makeDedup();
   const bump = (m: Map<string, number>, k: string, v: number) => m.set(k, (m.get(k) ?? 0) + v);
 
   for (const f of mainLogs()) {
@@ -746,10 +768,12 @@ function runReread(jsonOut: boolean): void {
           bump(ctx, "system", sp);
           first = false;
         }
-        measured +=
-          Number(u.cache_read_input_tokens ?? 0) +
-          Number(u.cache_creation_input_tokens ?? 0) +
-          Number(u.input_tokens ?? 0);
+        if (fresh(o)) {
+          measured +=
+            Number(u.cache_read_input_tokens ?? 0) +
+            Number(u.cache_creation_input_tokens ?? 0) +
+            Number(u.input_tokens ?? 0);
+        }
         for (const [k, v] of ctx) bump(cumu, k, v);
         const ot = Number(u.output_tokens ?? 0);
         let tc = 0;


### PR DESCRIPTION
## Problem

`TokenXray` sums every `usage` block in `~/.claude/projects/*/*.jsonl`. Claude Code
writes the same assistant message into more than one transcript file. Sidechains,
resumed sessions, and worktree copies all repeat the same record. The tool counts
one API call several times.

On one machine the transcripts hold 292,757 `requestId` values. Only 139,447 are
unique. That is a duplication factor of 2.10.

The effect is visible against `ccusage`, which reads the same files and dedupes on
`requestId`. For the same machine:

| Tool | Billed input |
|---|---|
| `TokenXray split` | ~100.6B |
| `ccusage` | ~56.8B |

The same cause makes two `TokenXray` subcommands disagree with each other.
`split` reports 94.4B cache-read tokens. `reread` reports 82.1B billed input and
labels it "measured, exact". The two subcommands accumulate at different sites, so
the duplicate records land unevenly.

## Change

This PR adds `makeDedup()` after `readJsonl()`. The function returns a closure. The
closure holds a `Set` of `requestId` values and reports whether an entry is the
first sighting. Each subcommand creates its own set.

Entries without a `requestId` cannot be keyed. The filter keeps them. No record is
dropped in silence.

The guard is applied at three accumulation sites:

- `cost`, on the `mainLogs()` billed totals
- `split`, on the main totals and the sidecar totals
- `reread`, on the `measured` accumulator

## Limitation

The unique-content tallies in `breakdown` and `reread` are not deduped. Those
entries carry no `requestId`. A duplicated transcript file still counts its text
twice. Billed-token figures are correct after this change. Unique-content figures
stay approximate.

## Verification

- A grep of the original file for `requestId`, `messageId`, `dedup`, and `seen.`
  returns one unrelated `Set<string>`. No dedup existed.
- The duplication factor comes from
  `find . -name "*.jsonl" -print0 | xargs -0 grep -ho '"requestId":"[^"]*"'`,
  compared against `sort -u`.
- `split` was run against the pre-change file and the post-change file on the same
  corpus.

## Why it matters

`TokenXray` is the token counter a LifeOS user reaches for. A user who compares it
against `ccusage` sees two different answers and cannot tell which one to trust.

## Measured result

Same corpus, 28,844 files, `split` COMBINED:

| Metric | Before | After |
|---|---:|---:|
| assistant calls | 398,830 | 246,718 |
| cache read | 94.91B | 54.82B |
| cache write | 5.87B | 3.63B |
| output | 401.4M | 213.1M |

`ccusage` reports about 56.8B total tokens for the same machine. After this
change TokenXray totals about 59.0B. The two agree to within about 4%. Before
the change the gap was about 1.8x.

The call count falls by 1.62x, not by the 2.10x duplication factor. Entries
without a `requestId` are kept, as described above.
