### PR TITLE
Pin the sticky header and size panes from its measured height

### DIFF
--- a/LifeOS/install/LIFEOS/PULSE/Observability/src/app/docs/layout.tsx
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/src/app/docs/layout.tsx
@@ -34,7 +34,7 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
   const docsTree = data?.tree ? filterDocsTree(data.tree) : [];
 
   return (
-    <div className="flex h-[calc(100vh-3.5rem)]">
+    <div className="flex h-[calc(100vh_-_var(--app-header-h,calc(3.5rem_+_1px)))]">
       <WikiSidebar tree={docsTree} onSearchClick={() => openPalette("wiki")} />
       <div className="flex-1 overflow-hidden">{children}</div>
     </div>

--- a/LifeOS/install/LIFEOS/PULSE/Observability/src/app/globals.css
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/src/app/globals.css
@@ -102,11 +102,34 @@
   * {
     @apply border-border;
   }
-  html, body {
+  :root {
+    /* Rendered height of AppHeader, for anything sizing itself against the space BELOW it.
+       This is a FALLBACK for first paint only — AppHeader measures itself and overwrites this
+       on the root element, because the real height is not a constant here: tier 1 is
+       `min-h-14` around a `flex-wrap` nav that grows a row when items wrap, and tier 2 renders
+       only inside /system. The fallback is tier 1 at its minimum (`min-h-14` + a 1px border-b),
+       which is the shortest the header is ever drawn, so a pane is briefly too tall rather
+       than clipped before hydration.
+
+       Every consumer ALSO repeats this value as a `var()` fallback, and that is not redundancy:
+       an unresolved custom property is invalid at computed-value time, so the whole declaration
+       is dropped and the pane silently reverts to `auto` height with no error anywhere. Repeating
+       it means a tree that takes those components without this stylesheet degrades to a correct
+       constant instead of a collapsed layout. Change this value and the six `var()` fallbacks
+       together — `rg 'var\(--app-header-h' src/` finds them. */
+    --app-header-h: calc(3.5rem + 1px);
+  }
+  html {
     overflow-x: hidden; /* Prevent horizontal scroll on mobile */
   }
   body {
     @apply bg-background text-foreground;
+    /* `clip`, not `hidden`, and this is load-bearing for AppHeader. Any non-`visible` overflow
+       makes `body` a scroll container, and `position: sticky` resolves against its nearest
+       scrolling ancestor — so the header's `sticky top-0` was pinning itself to a box that never
+       scrolls (the viewport scrolls, `body` does not) and travelled off-screen with the content.
+       `clip` clips identically without creating a scroll container. */
+    overflow-x: clip;
     font-family: 'concourse-t3', 'Concourse T3', system-ui, sans-serif;
     font-size: 17px;
     line-height: 1.55;

--- a/LifeOS/install/LIFEOS/PULSE/Observability/src/app/layout.tsx
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/src/app/layout.tsx
@@ -38,7 +38,10 @@ export default function RootLayout({
           <ObserverScope />
           <CommandPalette />
           <TemplateOnboarding />
-          <main className="min-h-screen max-w-[1920px] mx-auto w-full overflow-x-hidden relative">
+          {/* The header is sticky, not overlaid, so the space left for content is the viewport
+              minus the header — `min-h-screen` here made every page a full viewport TALLER than
+              its container and pushed a scrollbar onto pages that fit. */}
+          <main className="min-h-[calc(100vh_-_var(--app-header-h,calc(3.5rem_+_1px)))] max-w-[1920px] mx-auto w-full overflow-x-hidden relative">
             {children}
           </main>
         </Providers>

--- a/LifeOS/install/LIFEOS/PULSE/Observability/src/app/memory/knowledge/layout.tsx
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/src/app/memory/knowledge/layout.tsx
@@ -35,7 +35,7 @@ export default function KnowledgeLayout({ children }: { children: React.ReactNod
   const memoryTree = data?.tree ? filterMemoryTree(data.tree) : [];
 
   return (
-    <div className="flex h-[calc(100vh-3.5rem)]">
+    <div className="flex h-[calc(100vh_-_var(--app-header-h,calc(3.5rem_+_1px)))]">
       <WikiSidebar tree={memoryTree} onSearchClick={() => openPalette("wiki")} />
       <div className="flex-1 overflow-hidden">{children}</div>
     </div>

--- a/LifeOS/install/LIFEOS/PULSE/Observability/src/app/system/layout.tsx
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/src/app/system/layout.tsx
@@ -25,7 +25,7 @@ export default function LifeosLayout({ children }: { children: React.ReactNode }
   });
 
   return (
-    <div className="flex h-[calc(100vh-3.5rem)]">
+    <div className="flex h-[calc(100vh_-_var(--app-header-h,calc(3.5rem_+_1px)))]">
       <WikiSidebar tree={data?.tree || []} onSearchClick={() => openPalette("wiki")} />
       <div className="flex-1 overflow-hidden">{children}</div>
     </div>

--- a/LifeOS/install/LIFEOS/PULSE/Observability/src/components/AppHeader.tsx
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/src/components/AppHeader.tsx
@@ -27,9 +27,41 @@ export default function AppHeader() {
   const system = systemNav.filter(isEnabled);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const mobileMenuRef = useRef<HTMLDivElement>(null);
+  const headerRef = useRef<HTMLElement>(null);
   const { observerMode, toggleObserverMode } = useObserverMode();
 
   useEffect(() => { setMobileMenuOpen(false); }, [pathname]);
+
+  // Publish the PERSISTENT rows' MEASURED height as --app-header-h, for the panes below that size
+  // themselves against "the viewport minus the header". It cannot be a constant here: Tier 1's
+  // nav is `flex-wrap` and grows a row whenever items wrap (narrow window, or a module list long
+  // enough to overflow), and Tier 2 renders only inside System.
+  // globals.css carries a first-paint fallback; this refines it and keeps refining it.
+  //
+  // The open mobile menu is subtracted back out rather than measured. It is a ~20-item nav list,
+  // so including it pushed --app-header-h past the viewport height, and the consumers are
+  // `calc(100vh - var())` with no lower clamp — /docs computes a NEGATIVE height there, which CSS
+  // floors at 0, collapsing the pane and resetting its scroll offset, so closing the menu returned
+  // you to the top of the document. Subtracting costs a little transient over-scroll while the menu
+  // is open, which is the strictly better failure. The menu is `md:hidden`, so at md+ it is
+  // `display: none` and its rect height is already 0 — the subtraction is a no-op there rather
+  // than a breakpoint the caller has to know about.
+  // ResizeObserver on the header catches wrap, Tier 2 and the menu, so no pathname dep is needed.
+  useEffect(() => {
+    const el = headerRef.current;
+    if (!el) return;
+    const publish = () => {
+      const menu = mobileMenuRef.current?.getBoundingClientRect().height ?? 0;
+      const h = el.getBoundingClientRect().height - menu;
+      if (h > 0) document.documentElement.style.setProperty("--app-header-h", `${h}px`);
+    };
+    publish();
+    const ro = new ResizeObserver(publish);
+    ro.observe(el);
+    // The last measured value is deliberately left in place on teardown — the header only
+    // unmounts with the whole tree, and clearing it would flash the fallback height.
+    return () => ro.disconnect();
+  }, []);
 
   // Browser-tab naming: every page reads "Pulse | <Page>" keyed off the first path segment.
   // Next's streamed metadata commit can land AFTER this effect on initial load and reset the
@@ -69,6 +101,7 @@ export default function AppHeader() {
 
   return (
     <header
+      ref={headerRef}
       className="sticky top-0 z-50 backdrop-blur-md"
       style={{ background: "rgba(6, 11, 26, 0.85)" }}
     >

--- a/LifeOS/install/LIFEOS/PULSE/Observability/src/components/wiki/WikiMeta.tsx
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/src/components/wiki/WikiMeta.tsx
@@ -77,7 +77,7 @@ export default function WikiMeta({
   const colors = CATEGORY_COLORS[category] || CATEGORY_COLORS["system-doc"];
 
   return (
-    <aside className="w-56 shrink-0 border-l border-line-1 bg-surface-1 overflow-y-auto h-[calc(100vh-3.5rem)] p-4 space-y-5">
+    <aside className="w-56 shrink-0 border-l border-line-1 bg-surface-1 overflow-y-auto h-[calc(100vh_-_var(--app-header-h,calc(3.5rem_+_1px)))] p-4 space-y-5">
       {/* Category badge */}
       <div>
         <span

--- a/LifeOS/install/LIFEOS/PULSE/Observability/src/components/wiki/WikiSidebar.tsx
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/src/components/wiki/WikiSidebar.tsx
@@ -188,7 +188,7 @@ function TreeItem({ node, depth = 0 }: { node: TreeNode; depth?: number }) {
 
 export default function WikiSidebar({ tree, onSearchClick }: WikiSidebarProps) {
   return (
-    <aside className="w-64 shrink-0 border-r border-line-1 bg-surface-1 overflow-y-auto h-[calc(100vh-3.5rem)]">
+    <aside className="w-64 shrink-0 border-r border-line-1 bg-surface-1 overflow-y-auto h-[calc(100vh_-_var(--app-header-h,calc(3.5rem_+_1px)))]">
       {/* Search trigger */}
       <div className="p-3 border-b border-line-1">
         <button


### PR DESCRIPTION
Three layout defects in the Observability app that compound with each other. All measured in a
browser on a clean checkout, at a root font-size of 15px — worth stating, because that makes the
assumed `3.5rem` 52.5px rather than 56px, and every number below is against that.

## 1. The sticky header is not pinned

`AppHeader` is `sticky top-0`, but `globals.css` sets `overflow-x: hidden` on `body`. Any
non-`visible` overflow makes `body` a scroll container, and `position: sticky` resolves against
its nearest scrolling ancestor — so the header pins itself to a box that never scrolls (the
viewport scrolls, `body` does not) and travels off-screen with the content.

Scrolled 2136px down, the header's viewport-relative `top` reads `-2136`. Switching `body` to
`overflow-x: clip` returns it to `0`, and switching back reproduces it. `clip` clips identically
but does not create a scroll container, which is the whole difference here. `overflow-x: hidden`
stays on `html`, where it does stop the mobile horizontal scroll it was added for.

## 2. Five panes assume the header is `3.5rem` tall

`docs`, `system`, `memory/knowledge`, `WikiSidebar` and `WikiMeta` all size themselves with
`h-[calc(100vh-3.5rem)]`. But the header's height is not a constant: tier 1 is `min-h-14` around
a `flex-wrap` nav that grows a row when its items wrap, tier 2 renders only inside `/system`, and
there is a mobile menu.

| viewport width | header height | vs. `3.5rem` (52.5px) |
| --- | --- | --- |
| 676px | 53.5px | 1.02x |
| 836px | 238px | 4.53x |
| 1076px | 167.5px | 3.19x |
| 1713px | 91px | 1.73x |

The nav is already on two rows at 1713px, so the assumption is off by 38.5px on a wide desktop and
by 185.5px at the worst width — each pane is that much too tall, so its bottom edge and the end of
its scroll track fall below the fold.

`AppHeader` now measures itself with a `ResizeObserver` and publishes the height as
`--app-header-h`; the five panes consume it. `globals.css` defines a first-paint fallback of
`calc(3.5rem + 1px)` — tier 1 at its minimum plus its bottom border, so a pane is briefly slightly
too tall rather than clipped before hydration — and every consumer repeats that same value as a
`var()` fallback. That repetition is not redundancy: an unresolved custom property is invalid at
computed-value time, so the whole declaration is dropped and the pane silently reverts to `auto`
height with nothing logged anywhere.

The open mobile menu is subtracted back out of the published height. It is a long list: measured at
1297px against an 824px viewport, so including it would publish 1351.5px and make
`calc(100vh - 1351.5px)` resolve to -527.5px, which CSS floors at 0. The pane collapses, and
collapsing it resets its scroll offset — so closing the menu would return you to the top of the
document. The menu is `md:hidden`, and at md and above it is absent from the DOM entirely, so the
subtraction is a no-op there.

## 3. `main` used `min-h-screen`

The header is sticky rather than overlaid, so the space left for content is the viewport minus the
header. `min-h-screen` made every page a full viewport tall inside a container that starts below
the header, pushing a scrollbar onto pages that fit.

## Verification

8 files, +66/-7, additive on every file. In a browser, across the four widths above: the published
value equals the header's rendered height at each one, and `main`'s computed `min-height` equals
the viewport minus that height at each one. With the mobile menu open on `/docs` the published
value stays at the collapsed header's height and the pane holds 769.5px of an 824px viewport. The
measured heights span 4.4x across those widths, so no fixed value can satisfy both the 676px and
the 836px case — which is what the current constant is trying to do.

One thing I deliberately left out: wrapping the five panes in `max(0px, ...)` would make the
collapse in section 2 unreachable regardless of what is published. It is a real hardening, but it
changes all five expressions to defend against a case this patch already prevents, so it seemed
better as a separate change than mixed into this one.
