### PR TITLE
fix(paths): resolve the install root from CLAUDE_CONFIG_DIR / LIFEOS_DIR

### DIFF
--- a/LifeOS/install/LIFEOS/ATLAS/InstallAtlas.ts
+++ b/LifeOS/install/LIFEOS/ATLAS/InstallAtlas.ts
@@ -29,18 +29,20 @@ import { join } from "path";
 declare const Bun: { spawn: (cmd: string[], opts?: any) => any };
 
 const HOME = process.env.HOME || "";
+const CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR ?? join(HOME, ".claude");
+const LIFEOS_DIR = process.env.LIFEOS_DIR ?? join(CLAUDE_CONFIG_DIR, "LIFEOS");
 const LABEL = "com.lifeos.atlas";
 const IS_LINUX = process.platform === "linux";
 const IS_MACOS = process.platform === "darwin";
 
 // darwin (launchd)
-const TEMPLATE_PATH = join(HOME, ".claude", "LIFEOS", "ATLAS", "com.lifeos.atlas.plist.template");
+const TEMPLATE_PATH = join(LIFEOS_DIR, "ATLAS", "com.lifeos.atlas.plist.template");
 const LAUNCH_AGENTS_DIR = join(HOME, "Library", "LaunchAgents");
 const TARGET_PLIST = join(LAUNCH_AGENTS_DIR, `${LABEL}.plist`);
 
 // linux (systemd --user)
-const SERVICE_TEMPLATE_PATH = join(HOME, ".claude", "LIFEOS", "ATLAS", "com.lifeos.atlas.service.template");
-const TIMER_TEMPLATE_PATH = join(HOME, ".claude", "LIFEOS", "ATLAS", "com.lifeos.atlas.timer.template");
+const SERVICE_TEMPLATE_PATH = join(LIFEOS_DIR, "ATLAS", "com.lifeos.atlas.service.template");
+const TIMER_TEMPLATE_PATH = join(LIFEOS_DIR, "ATLAS", "com.lifeos.atlas.timer.template");
 const SYSTEMD_USER_DIR = join(HOME, ".config", "systemd", "user");
 const TARGET_SERVICE = join(SYSTEMD_USER_DIR, `${LABEL}.service`);
 const TARGET_TIMER = join(SYSTEMD_USER_DIR, `${LABEL}.timer`);
@@ -111,7 +113,7 @@ function unitPath(bunDir: string, ghDir: string | null): string {
 
 function materialize(templatePath: string, bunPath: string, path: string): string {
   return readFileSync(templatePath, "utf-8")
-    .replace(/\{\{HOME\}\}/g, HOME)
+    .replace(/\{\{HOME\}\}/g, HOME).replace(/\{\{CLAUDE_CONFIG_DIR\}\}/g, CLAUDE_CONFIG_DIR).replace(/\{\{LIFEOS_DIR\}\}/g, LIFEOS_DIR)
     .replace(/\{\{BUN\}\}/g, bunPath)
     .replace(/\{\{PATH\}\}/g, path);
 }

--- a/LifeOS/install/LIFEOS/ATLAS/com.lifeos.atlas.plist.template
+++ b/LifeOS/install/LIFEOS/ATLAS/com.lifeos.atlas.plist.template
@@ -27,11 +27,15 @@
   <key>ProgramArguments</key>
   <array>
     <string>{{BUN}}</string>
-    <string>{{HOME}}/.claude/LIFEOS/ATLAS/Atlas.ts</string>
+    <string>{{LIFEOS_DIR}}/ATLAS/Atlas.ts</string>
     <string>tick</string>
   </array>
   <key>EnvironmentVariables</key>
   <dict>
+    <key>CLAUDE_CONFIG_DIR</key>
+    <string>{{CLAUDE_CONFIG_DIR}}</string>
+    <key>LIFEOS_DIR</key>
+    <string>{{LIFEOS_DIR}}</string>
     <key>HOME</key>
     <string>{{HOME}}</string>
     <key>PATH</key>
@@ -48,10 +52,10 @@
   <key>ThrottleInterval</key>
   <integer>60</integer>
   <key>WorkingDirectory</key>
-  <string>{{HOME}}/.claude</string>
+  <string>{{CLAUDE_CONFIG_DIR}}</string>
   <key>StandardOutPath</key>
-  <string>{{HOME}}/.claude/LIFEOS/MEMORY/OBSERVABILITY/atlas-launchd.log</string>
+  <string>{{LIFEOS_DIR}}/MEMORY/OBSERVABILITY/atlas-launchd.log</string>
   <key>StandardErrorPath</key>
-  <string>{{HOME}}/.claude/LIFEOS/MEMORY/OBSERVABILITY/atlas-launchd.log</string>
+  <string>{{LIFEOS_DIR}}/MEMORY/OBSERVABILITY/atlas-launchd.log</string>
 </dict>
 </plist>

--- a/LifeOS/install/LIFEOS/LIFEOS_StatusLine.sh
+++ b/LifeOS/install/LIFEOS/LIFEOS_StatusLine.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Install root. CLAUDE_CONFIG_DIR is the harness's own override for where the
+# config dir lives; fall back to ~/.claude so a default install is unchanged.
+CLAUDE_CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$CLAUDE_CONFIG_DIR}"
 # ═══════════════════════════════════════════════════════════════════════════════
 # LifeOS Status Line — Responsive display with 4 modes by terminal width:
 #   nano (<35), micro (35-54), mini (55-79), normal (80+)
@@ -18,9 +22,9 @@ if [ -z "$HOME" ]; then
     [ -z "$HOME" ] && HOME="$(eval echo "~$(id -un)" 2>/dev/null)"
 fi
 
-LIFEOS_DIR="${LIFEOS_DIR:-$HOME/.claude/LIFEOS}"
+LIFEOS_DIR="${LIFEOS_DIR:-$CLAUDE_CONFIG_DIR/LIFEOS}"
 # Claude Code injects settings.json env values without shell expansion (LifeOS#1404):
-# a shipped value of "$HOME/.claude/LIFEOS" arrives literal. Expand it here.
+# a shipped value of "$CLAUDE_CONFIG_DIR/LIFEOS" arrives literal. Expand it here.
 LIFEOS_DIR="${LIFEOS_DIR/#\$HOME/$HOME}"
 LIFEOS_DIR="${LIFEOS_DIR/#\$\{HOME\}/$HOME}"
 LIFEOS_DIR="${LIFEOS_DIR/#\~\//$HOME/}"
@@ -58,7 +62,7 @@ case "$LIFEOS_DIR" in
     *'$HOME'*|*'${HOME}'*|*'~'*) echo "LifeOS"; exit 0 ;;
 esac
 
-CLAUDE_HOME="$HOME/.claude"
+CLAUDE_HOME="$CLAUDE_CONFIG_DIR"
 
 # BUN_BIN — defensive only. MEASURED 2026-07-27: the statusline inherits the
 # full interactive PATH (/opt/homebrew/bin included), so a bare `bun` resolves
@@ -140,7 +144,7 @@ USER_TZ="${USER_TZ:-UTC}"
 LIFEOS_VERSION=""
 for _pai_v_path in \
     "$LIFEOS_DIR/VERSION" \
-    "$HOME/.claude/LIFEOS/VERSION" \
+    "$CLAUDE_CONFIG_DIR/LIFEOS/VERSION" \
     "/Users/$(id -un 2>/dev/null)/.claude/LIFEOS/VERSION" \
     "$(eval echo ~"$(id -un 2>/dev/null)")/.claude/LIFEOS/VERSION"; do
     if [ -n "$_pai_v_path" ] && [ -f "$_pai_v_path" ]; then
@@ -156,7 +160,7 @@ LIFEOS_VERSION="${LIFEOS_VERSION:-—}"
 ALGO_VERSION=""
 for _algo_path in \
     "$LIFEOS_DIR/ALGORITHM/LATEST" \
-    "$HOME/.claude/LIFEOS/ALGORITHM/LATEST" \
+    "$CLAUDE_CONFIG_DIR/LIFEOS/ALGORITHM/LATEST" \
     "/Users/$(id -un 2>/dev/null)/.claude/LIFEOS/ALGORITHM/LATEST" \
     "$(eval echo ~"$(id -un 2>/dev/null)")/.claude/LIFEOS/ALGORITHM/LATEST"; do
     if [ -n "$_algo_path" ] && [ -f "$_algo_path" ]; then
@@ -191,10 +195,10 @@ USAGE_SCOPED_TTL=180     # Fast lane for the scoped-model (FABLE) window when TH
 USAGE_HARD_EXPIRY=21600  # P5: 6h. Show last-known-good (dimmed + stale badge) until here, then hide —
                          # replaces the old 1800s cliff that deleted the cache and vanished the counters.
 
-# Source .env for API keys. Canonical location is $HOME/.claude/.env (which is
-# typically a symlink to $HOME/.config/LIFEOS/.env). The historical $HOME/.claude/LIFEOS/.env
+# Source .env for API keys. Canonical location is $CLAUDE_CONFIG_DIR/.env (which is
+# typically a symlink to $HOME/.config/LIFEOS/.env). The historical $CLAUDE_CONFIG_DIR/LIFEOS/.env
 # path is wrong and has been removed everywhere else — do not reintroduce it.
-[ -f "$HOME/.claude/.env" ] && source "$HOME/.claude/.env"
+[ -f "$CLAUDE_CONFIG_DIR/.env" ] && source "$CLAUDE_CONFIG_DIR/.env"
 
 # Cross-platform file mtime (seconds since epoch). Detect stat flavor once;
 # probing both variants on every mtime check is expensive on macOS.
@@ -882,7 +886,7 @@ if [ "$MODE" != "nano" ]; then
     # Hook count flows through GetCounts.ts — same source banner uses. --single hooks
     # short-circuits all other walks (~20ms). Don't reintroduce inline jq here.
     _hooks_cnt=0
-    [ -n "$BUN_BIN" ] && _hooks_cnt=$("$BUN_BIN" "$HOME/.claude/LIFEOS/TOOLS/GetCounts.ts" --single hooks 2>/dev/null || echo 0)
+    [ -n "$BUN_BIN" ] && _hooks_cnt=$("$BUN_BIN" "$CLAUDE_CONFIG_DIR/LIFEOS/TOOLS/GetCounts.ts" --single hooks 2>/dev/null || echo 0)
 
     _ratings_cnt=0
     [ -f "$RATINGS_FILE" ] && _ratings_cnt=$(wc -l < "$RATINGS_FILE" 2>/dev/null | tr -d ' ')
@@ -1019,7 +1023,7 @@ if [ "$MODE" = "normal" ]; then
                     if [ "$(uname -s)" = "Darwin" ]; then
                         cred_json=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null)
                     else
-                        cred_json=$(cat "${HOME}/.claude/.credentials.json" 2>/dev/null)
+                        cred_json=$(cat "$CLAUDE_CONFIG_DIR/.credentials.json" 2>/dev/null)
                     fi
                     token=$(echo "$cred_json" | jq -r '.claudeAiOauth.accessToken // empty' 2>/dev/null)
 
@@ -2106,7 +2110,7 @@ if [ "$MODE" = "normal" ]; then
     # the last 2 min IS a live agent; its .meta.json carries the model. Depth
     # is fixed (projects/<slug>/<session>/subagents/*), so the find is bounded
     # (~30ms). Run ONCE; _bg_transcripts/_bg_count are reused by ▸ LIVE below.
-    _bg_transcripts=$(find "$HOME/.claude/projects" -mindepth 4 -maxdepth 4 -path '*/subagents/agent-*.jsonl' -mmin -2 2>/dev/null)
+    _bg_transcripts=$(find "$CLAUDE_CONFIG_DIR/projects" -mindepth 4 -maxdepth 4 -path '*/subagents/agent-*.jsonl' -mmin -2 2>/dev/null)
     _bg_count=0
     _bg_models=""
     while IFS= read -r _bg_t; do
@@ -2231,7 +2235,7 @@ if [ "$MODE" = "normal" ]; then
     # regex + panel label) loads from a USER-zone overlay that never ships.
     # No overlay → no lane; a public install renders MAX/FORGE only.
     _cyber_agent_re=""; _cyber_agent_lbl=""
-    _cyber_overlay="$HOME/.claude/LIFEOS/USER/CUSTOMIZATIONS/StatusLineCyberLane.sh"
+    _cyber_overlay="$CLAUDE_CONFIG_DIR/LIFEOS/USER/CUSTOMIZATIONS/StatusLineCyberLane.sh"
     [ -f "$_cyber_overlay" ] && . "$_cyber_overlay"
     [ -n "$_cyber_agent_lbl" ] && _ar_line+="$(_ar_tok "$_rs_cyber" cyber "$_lbl_cyber" "$mix_cyber") "
     _ar_line+="$(_ar_tok "$_rs_max"   max    "$_lbl_max"  "$mix_max")"
@@ -2244,7 +2248,7 @@ if [ "$MODE" = "normal" ]; then
     # agents ran, right next to which models did. Live = agent-starts or bg
     # meta types in the 300s window; used = this session's subagent metas.
     _sess_types=""
-    for _d in "$HOME/.claude/projects"/*/"$session_id"/subagents; do
+    for _d in "$CLAUDE_CONFIG_DIR/projects"/*/"$session_id"/subagents; do
         if [ -d "$_d" ]; then
             _sess_types=$(cat "$_d"/*.meta.json 2>/dev/null | jq -r -s \
                 '[.[] | (.agentType // "") + " " + (.customAgentType // "")] | join(" ")' 2>/dev/null)
@@ -2301,7 +2305,7 @@ fi
 # _bg_transcripts is computed by the single find in the ACTIVE block above
 # (normal mode); in narrower modes that block never ran, so compute it here.
 if [ -z "${_bg_count:-}" ]; then
-    _bg_transcripts=$(find "$HOME/.claude/projects" -mindepth 4 -maxdepth 4 -path '*/subagents/agent-*.jsonl' -mmin -2 2>/dev/null)
+    _bg_transcripts=$(find "$CLAUDE_CONFIG_DIR/projects" -mindepth 4 -maxdepth 4 -path '*/subagents/agent-*.jsonl' -mmin -2 2>/dev/null)
 fi
 while IFS= read -r _bg_t; do
     [ -z "$_bg_t" ] && continue
@@ -2778,7 +2782,7 @@ fi
 
 if [ "$MODE" = "normal" ]; then
     # Live login email from ~/.claude.json (.oauthAccount.emailAddress updates on /login)
-    _acct_email=$(jq -r '.oauthAccount.emailAddress // empty' "$HOME/.claude.json" 2>/dev/null)
+    _acct_email=$(jq -r '.oauthAccount.emailAddress // empty' "$CLAUDE_CONFIG_DIR.json" 2>/dev/null)
     [ -n "$_acct_email" ] && printf "${SLATE_500}${_acct_email}${RESET}\n"
 fi
 

--- a/LifeOS/install/LIFEOS/PULSE/MenuBar/com.lifeos.pulse-menubar.plist
+++ b/LifeOS/install/LIFEOS/PULSE/MenuBar/com.lifeos.pulse-menubar.plist
@@ -14,12 +14,16 @@
     <true/>
     <key>EnvironmentVariables</key>
     <dict>
+      <key>CLAUDE_CONFIG_DIR</key>
+      <string>__CLAUDE_CONFIG_DIR__</string>
+      <key>LIFEOS_DIR</key>
+      <string>__LIFEOS_DIR__</string>
         <key>LIFEOS_PULSE_DIR</key>
-        <string>__HOME__/.claude/LIFEOS/PULSE</string>
+        <string>__LIFEOS_DIR__/PULSE</string>
     </dict>
     <key>StandardOutPath</key>
-    <string>__HOME__/.claude/LIFEOS/PULSE/logs/menubar-stdout.log</string>
+    <string>__LIFEOS_DIR__/PULSE/logs/menubar-stdout.log</string>
     <key>StandardErrorPath</key>
-    <string>__HOME__/.claude/LIFEOS/PULSE/logs/menubar-stderr.log</string>
+    <string>__LIFEOS_DIR__/PULSE/logs/menubar-stderr.log</string>
 </dict>
 </plist>

--- a/LifeOS/install/LIFEOS/PULSE/MenuBar/install.sh
+++ b/LifeOS/install/LIFEOS/PULSE/MenuBar/install.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+CLAUDE_CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+LIFEOS_DIR="${LIFEOS_DIR:-$CLAUDE_CONFIG_DIR/LIFEOS}"
 # LifeOS Pulse Menu Bar — Install Script
 # Builds, deploys, removes old Monitor, installs launchd plist, launches
 
@@ -64,7 +67,7 @@ echo "  Installed $APP_DEST"
 echo "[6/6] Installing LaunchAgent..."
 
 # Substitute __HOME__ placeholder with actual home directory
-sed "s|__HOME__|$HOME_DIR|g" "$PLIST_SRC" > "$PLIST_DST"
+sed -e "s|__HOME__|$HOME_DIR|g" -e "s|__CLAUDE_CONFIG_DIR__|$CLAUDE_CONFIG_DIR|g" -e "s|__LIFEOS_DIR__|$LIFEOS_DIR|g" "$PLIST_SRC" > "$PLIST_DST"
 echo "  Installed $PLIST_DST"
 
 # Ensure logs directory exists

--- a/LifeOS/install/LIFEOS/PULSE/Observability/observability.ts
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/observability.ts
@@ -72,7 +72,7 @@ export interface ObservabilityConfig {
 // ── Path Construction ──
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir()
-const LIFEOS_DIR = join(HOME, ".claude", "LIFEOS")
+const LIFEOS_DIR = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"))
 const MEMORY_DIR = join(LIFEOS_DIR, "MEMORY")
 
 const WORK_JSON_PATH = join(MEMORY_DIR, "STATE", "work.json")
@@ -82,7 +82,7 @@ const SUBAGENT_EVENTS_PATH = join(MEMORY_DIR, "OBSERVABILITY", "subagent-events.
 const VOICE_EVENTS_PATH = join(MEMORY_DIR, "VOICE", "voice-events.jsonl")
 const TOOL_FAILURES_PATH = join(MEMORY_DIR, "OBSERVABILITY", "tool-failures.jsonl")
 const TOOL_ACTIVITY_PATH = join(MEMORY_DIR, "OBSERVABILITY", "tool-activity.jsonl")
-const SETTINGS_PATH = join(HOME, ".claude", "settings.json")
+const SETTINGS_PATH = join(process.env.CLAUDE_CONFIG_DIR || join(HOME, ".claude"), "settings.json")
 const LADDER_DIR = join(HOME, "Projects", "Ladder")
 
 const DEFAULT_DASHBOARD_DIR = join(LIFEOS_DIR, "PULSE", "Observability", "out")
@@ -191,7 +191,7 @@ function getDashboardDir(): string {
   const dir = config.dashboard_dir ?? DEFAULT_DASHBOARD_DIR
   // Resolve relative paths against Pulse directory
   if (!dir.startsWith("/")) {
-    return join(HOME, ".claude", "LIFEOS", "PULSE", dir)
+    return join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"), "PULSE", dir)
   }
   return dir
 }

--- a/LifeOS/install/LIFEOS/PULSE/Performance/cost-aggregator.ts
+++ b/LifeOS/install/LIFEOS/PULSE/Performance/cost-aggregator.ts
@@ -15,8 +15,8 @@ import { existsSync, readFileSync, writeFileSync, appendFileSync, readdirSync, s
 import { homedir } from "node:os";
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir()
-const LIFEOS_DIR = join(HOME, ".claude", "LIFEOS")
-const PROJECTS_DIR = join(HOME, ".claude", "projects")
+const LIFEOS_DIR = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"))
+const PROJECTS_DIR = join(process.env.CLAUDE_CONFIG_DIR || join(HOME, ".claude"), "projects")
 const OUTPUT_FILE = join(LIFEOS_DIR, "MEMORY", "OBSERVABILITY", "session-costs.jsonl")
 const STATE_FILE = join(LIFEOS_DIR, "PULSE", "Performance", "aggregator-state.json")
 

--- a/LifeOS/install/LIFEOS/PULSE/Performance/module.ts
+++ b/LifeOS/install/LIFEOS/PULSE/Performance/module.ts
@@ -15,7 +15,7 @@ import { existsSync, readFileSync } from "fs"
 import { homedir } from "node:os";
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir()
-const LIFEOS_DIR = join(HOME, ".claude", "LIFEOS")
+const LIFEOS_DIR = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"))
 const MEMORY_DIR = join(LIFEOS_DIR, "MEMORY")
 const SESSION_COSTS_PATH = join(MEMORY_DIR, "OBSERVABILITY", "session-costs.jsonl")
 const TOOL_FAILURES_PATH = join(MEMORY_DIR, "OBSERVABILITY", "tool-failures.jsonl")

--- a/LifeOS/install/LIFEOS/PULSE/Tools/SnapshotFromFixture.ts
+++ b/LifeOS/install/LIFEOS/PULSE/Tools/SnapshotFromFixture.ts
@@ -7,8 +7,8 @@ import { PageDataSchema } from "../Schema/PulseSchema";
 import { homedir } from "node:os";
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
-const FIX_DIR = resolve(HOME, ".claude", "LIFEOS", "PULSE", "Schema", "Fixtures");
-const OUT_DIR = resolve(HOME, ".claude", "LIFEOS", "PULSE", "Schema", "Snapshots");
+const FIX_DIR = resolve(process.env.LIFEOS_DIR || resolve(HOME, ".claude", "LIFEOS"), "PULSE", "Schema", "Fixtures");
+const OUT_DIR = resolve(process.env.LIFEOS_DIR || resolve(HOME, ".claude", "LIFEOS"), "PULSE", "Schema", "Snapshots");
 mkdirSync(OUT_DIR, { recursive: true });
 
 const fixtures = readdirSync(FIX_DIR).filter((f) => f.endsWith(".json") && !f.startsWith("invalid"));

--- a/LifeOS/install/LIFEOS/PULSE/Tools/SnapshotPages.ts
+++ b/LifeOS/install/LIFEOS/PULSE/Tools/SnapshotPages.ts
@@ -8,7 +8,7 @@ import { loadAllManifests } from "../lib/manifest-loader";
 import { homedir } from "node:os";
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
-const SNAP_DIR = resolve(HOME, ".claude", "LIFEOS", "PULSE", "Schema", "Snapshots");
+const SNAP_DIR = resolve(process.env.LIFEOS_DIR || resolve(HOME, ".claude", "LIFEOS"), "PULSE", "Schema", "Snapshots");
 mkdirSync(SNAP_DIR, { recursive: true });
 
 const idx = readIndex();

--- a/LifeOS/install/LIFEOS/PULSE/VoiceServer/voice.ts
+++ b/LifeOS/install/LIFEOS/PULSE/VoiceServer/voice.ts
@@ -167,7 +167,7 @@ function escapeRegex(str: string): string {
 }
 
 function loadPronunciations(customPath?: string): void {
-  const paiDir = join(homedir(), ".claude", "LIFEOS")
+  const paiDir = join(process.env.LIFEOS_DIR || join(homedir(), ".claude", "LIFEOS"))
   const userPronPath = customPath ?? join(paiDir, "USER", "PRINCIPAL", "PRONUNCIATIONS.json")
 
   try {
@@ -207,7 +207,7 @@ function applyPronunciations(text: string): string {
 // ── Voice Config from settings.json ──
 
 function loadVoiceConfigFromSettings(): LoadedVoiceConfig {
-  const settingsPath = join(homedir(), ".claude", "settings.json")
+  const settingsPath = join(process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude"), "settings.json")
 
   try {
     if (!existsSync(settingsPath)) {
@@ -768,7 +768,7 @@ export async function handleVoiceRequest(req: Request): Promise<Response | null>
       // /notify/personality honest with whatever the user last selected.
       let voiceId: string | null = null
       try {
-        const settingsFile = join(homedir(), ".claude", "settings.json")
+        const settingsFile = join(process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude"), "settings.json")
         const settings = JSON.parse(readFileSync(settingsFile, "utf-8"))
         const main = settings?.daidentity?.voices?.main
         const vid = (main?.voiceId || main?.VOICE_ID || main?.voice_id) as string | undefined

--- a/LifeOS/install/LIFEOS/PULSE/adapters/AdapterRunner.ts
+++ b/LifeOS/install/LIFEOS/PULSE/adapters/AdapterRunner.ts
@@ -13,7 +13,7 @@ import { modelToLevel } from "./model-level";
 import { homedir } from "node:os";
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
-const OBSERVABILITY_DIR = resolve(HOME, ".claude", "LIFEOS", "MEMORY", "OBSERVABILITY");
+const OBSERVABILITY_DIR = resolve(process.env.LIFEOS_DIR || resolve(HOME, ".claude", "LIFEOS"), "MEMORY", "OBSERVABILITY");
 const RUNS_LOG = join(OBSERVABILITY_DIR, "adapter-runs.jsonl");
 
 const ADAPTER_TIMEOUT_MS = 120_000;

--- a/LifeOS/install/LIFEOS/PULSE/checks/airgradient-poll.ts
+++ b/LifeOS/install/LIFEOS/PULSE/checks/airgradient-poll.ts
@@ -20,7 +20,7 @@ import { mkdirSync, writeFileSync, appendFileSync, readFileSync, existsSync } fr
 import { homedir } from "node:os";
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir()
-const CACHE_DIR = join(HOME, ".claude", "LIFEOS", "MEMORY", "_AIRGRADIENT")
+const CACHE_DIR = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"), "MEMORY", "_AIRGRADIENT")
 const LATEST = join(CACHE_DIR, "latest.json")
 const HISTORY = join(CACHE_DIR, "history.jsonl")
 
@@ -29,7 +29,7 @@ const API_BASE = "https://api.airgradient.com/public/api/v1"
 // Bun auto-loads .env from CWD only; Pulse cron runs from LIFEOS/PULSE/, so the
 // symlink at ~/.claude/.env isn't picked up. Read it directly if env is empty.
 function loadTokenFromDotenv(): string | null {
-  const envPath = join(HOME, ".claude", ".env")
+  const envPath = join(process.env.CLAUDE_CONFIG_DIR || join(HOME, ".claude"), ".env")
   if (!existsSync(envPath)) return null
   try {
     const raw = readFileSync(envPath, "utf8")

--- a/LifeOS/install/LIFEOS/PULSE/checks/calendar.ts
+++ b/LifeOS/install/LIFEOS/PULSE/checks/calendar.ts
@@ -18,7 +18,7 @@ const LOOKAHEAD_MS = 30 * 60 * 1000
 function loadEnv(): Record<string, string> {
   const env: Record<string, string> = {}
   try {
-    const content = readFileSync(join(HOME, ".claude", ".env"), "utf-8")
+    const content = readFileSync(join(process.env.CLAUDE_CONFIG_DIR || join(HOME, ".claude"), ".env"), "utf-8")
     for (const line of content.split("\n")) {
       const match = line.match(/^([^#=]+)=(.*)$/)
       if (match) {

--- a/LifeOS/install/LIFEOS/PULSE/checks/github-work.ts
+++ b/LifeOS/install/LIFEOS/PULSE/checks/github-work.ts
@@ -15,7 +15,7 @@ import { SignJWT, importPKCS8 } from "jose"
 import { homedir } from "node:os";
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir()
-const PULSE_DIR = join(HOME, ".claude", "LIFEOS", "PULSE")
+const PULSE_DIR = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"), "PULSE")
 const STATE_FILE = join(PULSE_DIR, "state", "work-token.json")
 
 // ── Worker Config (from PULSE.toml [worker] section) ──

--- a/LifeOS/install/LIFEOS/PULSE/checks/github.ts
+++ b/LifeOS/install/LIFEOS/PULSE/checks/github.ts
@@ -13,8 +13,8 @@ import { dirname, join } from "path"
 import { homedir } from "node:os";
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir()
-const LEGACY_STATE_FILE = join(HOME, ".claude", "LIFEOS", "PULSE", "state", "github-seen.json")
-const STATE_FILE = join(HOME, ".claude", "LIFEOS", "PULSE", "state", "github-seen.jsonl")
+const LEGACY_STATE_FILE = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"), "PULSE", "state", "github-seen.json")
+const STATE_FILE = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"), "PULSE", "state", "github-seen.jsonl")
 // Repos to monitor for new issues / activity. Override via LIFEOS_PULSE_REPOS
 // env var (comma-separated "owner/name" pairs). Empty default keeps fresh
 // installs from polling repos the user hasn't opted into.

--- a/LifeOS/install/LIFEOS/PULSE/checks/life-morning-brief.ts
+++ b/LifeOS/install/LIFEOS/PULSE/checks/life-morning-brief.ts
@@ -14,7 +14,7 @@ import { existsSync, readFileSync } from "fs"
 import { homedir } from "node:os";
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir()
-const TELOS_DIR = join(HOME, ".claude", "LIFEOS", "USER", "TELOS")
+const TELOS_DIR = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"), "USER", "TELOS")
 
 function readFile(name: string): string {
   const p = join(TELOS_DIR, name)

--- a/LifeOS/install/LIFEOS/PULSE/com.lifeos.deriver.plist
+++ b/LifeOS/install/LIFEOS/PULSE/com.lifeos.deriver.plist
@@ -9,13 +9,17 @@
     <array>
         <string>__BUN_PATH__</string>
         <string>run</string>
-        <string>__HOME__/.claude/LIFEOS/TOOLS/LearningPatternSynthesis.ts</string>
+        <string>__LIFEOS_DIR__/TOOLS/LearningPatternSynthesis.ts</string>
         <string>--hypothesize</string>
     </array>
     <key>WorkingDirectory</key>
-    <string>__HOME__/.claude</string>
+    <string>__CLAUDE_CONFIG_DIR__</string>
     <key>EnvironmentVariables</key>
     <dict>
+      <key>CLAUDE_CONFIG_DIR</key>
+      <string>__CLAUDE_CONFIG_DIR__</string>
+      <key>LIFEOS_DIR</key>
+      <string>__LIFEOS_DIR__</string>
         <key>HOME</key>
         <string>__HOME__</string>
         <key>PATH</key>
@@ -31,9 +35,9 @@
     <key>RunAtLoad</key>
     <false/>
     <key>StandardOutPath</key>
-    <string>__HOME__/.claude/LIFEOS/MEMORY/OBSERVABILITY/deriver.log</string>
+    <string>__LIFEOS_DIR__/MEMORY/OBSERVABILITY/deriver.log</string>
     <key>StandardErrorPath</key>
-    <string>__HOME__/.claude/LIFEOS/MEMORY/OBSERVABILITY/deriver.log</string>
+    <string>__LIFEOS_DIR__/MEMORY/OBSERVABILITY/deriver.log</string>
     <key>ThrottleInterval</key>
     <integer>60</integer>
 </dict>

--- a/LifeOS/install/LIFEOS/PULSE/com.lifeos.pulse.plist
+++ b/LifeOS/install/LIFEOS/PULSE/com.lifeos.pulse.plist
@@ -12,9 +12,13 @@
         <string>pulse.ts</string>
     </array>
     <key>WorkingDirectory</key>
-    <string>__HOME__/.claude/LIFEOS/PULSE</string>
+    <string>__LIFEOS_DIR__/PULSE</string>
     <key>EnvironmentVariables</key>
     <dict>
+      <key>CLAUDE_CONFIG_DIR</key>
+      <string>__CLAUDE_CONFIG_DIR__</string>
+      <key>LIFEOS_DIR</key>
+      <string>__LIFEOS_DIR__</string>
         <key>HOME</key>
         <string>__HOME__</string>
         <key>PATH</key>
@@ -25,9 +29,9 @@
     <key>KeepAlive</key>
     <true/>
     <key>StandardOutPath</key>
-    <string>__HOME__/.claude/LIFEOS/PULSE/logs/pulse-stdout.log</string>
+    <string>__LIFEOS_DIR__/PULSE/logs/pulse-stdout.log</string>
     <key>StandardErrorPath</key>
-    <string>__HOME__/.claude/LIFEOS/PULSE/logs/pulse-stderr.log</string>
+    <string>__LIFEOS_DIR__/PULSE/logs/pulse-stderr.log</string>
     <key>ThrottleInterval</key>
     <integer>30</integer>
 </dict>

--- a/LifeOS/install/LIFEOS/PULSE/edit/edit-handler.ts
+++ b/LifeOS/install/LIFEOS/PULSE/edit/edit-handler.ts
@@ -6,8 +6,8 @@ import { sha256Hex } from "../lib/cache";
 import { homedir } from "node:os";
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
-const USER_ROOT = resolve(HOME, ".claude", "LIFEOS", "USER");
-const EDITS_LOG = resolve(HOME, ".claude", "LIFEOS", "MEMORY", "OBSERVABILITY", "pulse-edits.jsonl");
+const USER_ROOT = resolve(process.env.LIFEOS_DIR || resolve(HOME, ".claude", "LIFEOS"), "USER");
+const EDITS_LOG = resolve(process.env.LIFEOS_DIR || resolve(HOME, ".claude", "LIFEOS"), "MEMORY", "OBSERVABILITY", "pulse-edits.jsonl");
 const CONTAINMENT_PREFIX_DENY = ["MEMORY/PULSE_DATA", "MEMORY/OBSERVABILITY"];
 
 export interface EditRequest {
@@ -33,7 +33,7 @@ function isInUserTree(absPath: string): boolean {
 }
 
 function isContainmentPath(absPath: string): boolean {
-  const rel = absPath.replace(resolve(HOME, ".claude", "LIFEOS") + "/", "");
+  const rel = absPath.replace(resolve(process.env.LIFEOS_DIR || resolve(HOME, ".claude", "LIFEOS")) + "/", "");
   return CONTAINMENT_PREFIX_DENY.some((p) => rel.startsWith(p));
 }
 

--- a/LifeOS/install/LIFEOS/PULSE/lib.ts
+++ b/LifeOS/install/LIFEOS/PULSE/lib.ts
@@ -75,9 +75,7 @@ export interface DaemonConfig {
 // written here is automatically stripped from shadow releases. That's the
 // structural privacy lever — no separate scrub policy needed.
 
-export const USER_CRON_PATH = join(
-  homedir(),
-  ".claude", "LIFEOS", "USER", "CONFIG", "PULSE.user.toml",
+export const USER_CRON_PATH = join(process.env.LIFEOS_DIR || join(homedir(), ".claude", "LIFEOS"), "USER", "CONFIG", "PULSE.user.toml",
 )
 
 export interface JobState {
@@ -580,7 +578,7 @@ export async function spawnScript(command: string, timeoutMs = 60_000): Promise<
   const proc = Bun.spawn([BASH_PATH, "-c", command], {
     stdout: "pipe",
     stderr: "pipe",
-    cwd: join(homedir(), ".claude", "LIFEOS", "PULSE"),
+    cwd: join(process.env.LIFEOS_DIR || join(homedir(), ".claude", "LIFEOS"), "PULSE"),
     env: { ...process.env },
   })
 

--- a/LifeOS/install/LIFEOS/PULSE/lib/data-plane.ts
+++ b/LifeOS/install/LIFEOS/PULSE/lib/data-plane.ts
@@ -6,7 +6,7 @@ import type { PageData, PageMeta, Provenance } from "../Schema/PulseSchema";
 import { homedir } from "node:os";
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
-export const PULSE_DATA_DIR = resolve(HOME, ".claude", "LIFEOS", "MEMORY", "PULSE_DATA");
+export const PULSE_DATA_DIR = resolve(process.env.LIFEOS_DIR || resolve(HOME, ".claude", "LIFEOS"), "MEMORY", "PULSE_DATA");
 
 export interface DataPlaneFile {
   schemaVersion: string;

--- a/LifeOS/install/LIFEOS/PULSE/lib/lifeos-context.ts
+++ b/LifeOS/install/LIFEOS/PULSE/lib/lifeos-context.ts
@@ -16,7 +16,7 @@ import { getRelevantContext } from "../../TOOLS/MemoryRetriever"
 import { homedir } from "node:os";
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir()
-const LIFEOS_DIR = join(HOME, ".claude", "LIFEOS")
+const LIFEOS_DIR = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"))
 
 // Ceiling on the per-turn LifeOS memory injection — fits DA + PRINCIPAL
 // identity + TELOS + active sessions + the two _MEMORY.md hot-layer files

--- a/LifeOS/install/LIFEOS/PULSE/lib/memory-proposals.ts
+++ b/LifeOS/install/LIFEOS/PULSE/lib/memory-proposals.ts
@@ -30,7 +30,7 @@ import {
 import { assertInsideUserData } from "../../TOOLS/lib/ForeignDataCheck";
 
 const HOME = process.env.HOME ?? homedir();
-const OBS_DIR = join(HOME, ".claude", "LIFEOS", "MEMORY", "OBSERVABILITY");
+const OBS_DIR = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"), "MEMORY", "OBSERVABILITY");
 const PROPOSAL_REPLIES_LOG_PATH = join(OBS_DIR, "proposal-replies.jsonl");
 const IDENTITY_PROPOSALS_LOG_PATH = join(OBS_DIR, "identity-proposals.jsonl");
 
@@ -235,7 +235,7 @@ export function applyProposalEdit(targetFile: string, editText: string): { ok: t
   // from LIFEOS/PULSE, so a bare relative path resolved to a nonexistent nested path and every
   // apply failed with "target file missing" even though the file was present (public PR #1507,
   // credit @anikinsasha).
-  const resolved = isAbsolute(targetFile) ? targetFile : join(HOME, ".claude", targetFile);
+  const resolved = isAbsolute(targetFile) ? targetFile : join(process.env.CLAUDE_CONFIG_DIR || join(HOME, ".claude"), targetFile);
   if (!existsSync(resolved)) return { ok: false, reason: `target file missing: ${targetFile}` };
   // Boundary (2026-08-11 incident class): a proposal edit is personal content —
   // its target must physically resolve into the USER_DATA repo. pinProposalTargetFile

--- a/LifeOS/install/LIFEOS/PULSE/lib/provenance-watcher.ts
+++ b/LifeOS/install/LIFEOS/PULSE/lib/provenance-watcher.ts
@@ -6,7 +6,7 @@ import { parseFrontmatter, serializeFrontmatter } from "./frontmatter";
 import { homedir } from "node:os";
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
-const EDITS_LOG = resolve(HOME, ".claude", "LIFEOS", "MEMORY", "OBSERVABILITY", "pulse-edits.jsonl");
+const EDITS_LOG = resolve(process.env.LIFEOS_DIR || resolve(HOME, ".claude", "LIFEOS"), "MEMORY", "OBSERVABILITY", "pulse-edits.jsonl");
 const PULSE_EDIT_GRACE_MS = 5_000;
 
 export interface WatcherOptions {

--- a/LifeOS/install/LIFEOS/PULSE/manage-deriver.sh
+++ b/LifeOS/install/LIFEOS/PULSE/manage-deriver.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+# Install root. CLAUDE_CONFIG_DIR is the harness's own override for where the
+# config dir lives; fall back to ~/.claude so a default install is unchanged.
+CLAUDE_CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$CLAUDE_CONFIG_DIR}"
 # manage-deriver.sh — install / control the proactive deriver loop launchd agent.
 #
 # The deriver runs nightly via LearningPatternSynthesis.ts --hypothesize,
@@ -13,11 +17,11 @@
 
 set -euo pipefail
 
-PULSE_DIR="$HOME/.claude/LIFEOS/PULSE"
+PULSE_DIR="$CLAUDE_CONFIG_DIR/LIFEOS/PULSE"
 PLIST_NAME="com.lifeos.deriver"
 PLIST_SRC="$PULSE_DIR/$PLIST_NAME.plist"
 PLIST_DST="$HOME/Library/LaunchAgents/$PLIST_NAME.plist"
-OBSERVABILITY_DIR="$HOME/.claude/LIFEOS/MEMORY/OBSERVABILITY"
+OBSERVABILITY_DIR="$CLAUDE_CONFIG_DIR/LIFEOS/MEMORY/OBSERVABILITY"
 
 if [ -x "$HOME/.bun/bin/bun" ]; then
   BUN_PATH="$HOME/.bun/bin/bun"
@@ -49,7 +53,7 @@ case "${1:-}" in
     if [ -f "$PLIST_DST" ]; then
       launchctl unload "$PLIST_DST" 2>/dev/null || true
     fi
-    sed -e "s|__HOME__|$HOME|g" -e "s|__BUN_PATH__|$BUN_PATH|g" "$PLIST_SRC" > "$PLIST_DST"
+    sed -e "s|__HOME__|$HOME|g" -e "s|__BUN_PATH__|$BUN_PATH|g" -e "s|__CLAUDE_CONFIG_DIR__|$CLAUDE_CONFIG_DIR|g" -e "s|__LIFEOS_DIR__|$LIFEOS_DIR|g" "$PLIST_SRC" > "$PLIST_DST"
     launchctl load "$PLIST_DST"
     echo "LifeOS deriver installed (bun: $BUN_PATH, schedule: daily 03:00)"
     ;;
@@ -81,7 +85,7 @@ case "${1:-}" in
 
   run-now)
     # One-shot manual invocation for testing / first-run priming.
-    exec "$BUN_PATH" run "$HOME/.claude/LIFEOS/TOOLS/LearningPatternSynthesis.ts" --hypothesize
+    exec "$BUN_PATH" run "$CLAUDE_CONFIG_DIR/LIFEOS/TOOLS/LearningPatternSynthesis.ts" --hypothesize
     ;;
 
   *)

--- a/LifeOS/install/LIFEOS/PULSE/manage.sh
+++ b/LifeOS/install/LIFEOS/PULSE/manage.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
+
+# Install root. CLAUDE_CONFIG_DIR is the harness's own override for where the
+# config dir lives; fall back to ~/.claude so a default install is unchanged.
+CLAUDE_CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$CLAUDE_CONFIG_DIR}"
 # LifeOS Pulse — Process Management
 # Usage: manage.sh {start|stop|restart|status|install|uninstall}
 
-PULSE_DIR="$HOME/.claude/LIFEOS/PULSE"
+PULSE_DIR="$CLAUDE_CONFIG_DIR/LIFEOS/PULSE"
 PLIST_NAME="com.lifeos.pulse"
 PLIST_SRC="$PULSE_DIR/$PLIST_NAME.plist"
 PLIST_DST="$HOME/Library/LaunchAgents/$PLIST_NAME.plist"
@@ -43,7 +47,7 @@ case "$1" in
       if [ ! -f "$PLIST_DST" ]; then
         # Substitute __HOME__ + __BUN_PATH__ placeholders (public template);
         # no-op on plists that already have literal paths.
-        sed -e "s|__HOME__|$HOME|g" -e "s|__BUN_PATH__|$BUN_PATH|g" "$PLIST_SRC" > "$PLIST_DST"
+        sed -e "s|__HOME__|$HOME|g" -e "s|__BUN_PATH__|$BUN_PATH|g" -e "s|__CLAUDE_CONFIG_DIR__|$CLAUDE_CONFIG_DIR|g" -e "s|__LIFEOS_DIR__|$LIFEOS_DIR|g" "$PLIST_SRC" > "$PLIST_DST"
       fi
       launchctl load "$PLIST_DST" 2>/dev/null
       echo "LifeOS Pulse started"
@@ -118,7 +122,7 @@ case "$1" in
       sleep 1
       # Substitute __HOME__ + __BUN_PATH__ placeholders (public template);
       # no-op on service files that already have literal paths.
-      sed -e "s|__HOME__|$HOME|g" -e "s|__BUN_PATH__|$BUN_PATH|g" "$SERVICE_SRC" > "$SERVICE_DST"
+      sed -e "s|__HOME__|$HOME|g" -e "s|__BUN_PATH__|$BUN_PATH|g" -e "s|__CLAUDE_CONFIG_DIR__|$CLAUDE_CONFIG_DIR|g" -e "s|__LIFEOS_DIR__|$LIFEOS_DIR|g" "$SERVICE_SRC" > "$SERVICE_DST"
       # Ensure user services survive logout/reboot (no-op if already enabled)
       loginctl enable-linger "$USER" 2>/dev/null || true
       systemctl --user daemon-reload
@@ -136,7 +140,7 @@ case "$1" in
 
       # Substitute __HOME__ + __BUN_PATH__ placeholders (public template);
       # no-op on plists that already have literal paths.
-      sed -e "s|__HOME__|$HOME|g" -e "s|__BUN_PATH__|$BUN_PATH|g" "$PLIST_SRC" > "$PLIST_DST"
+      sed -e "s|__HOME__|$HOME|g" -e "s|__BUN_PATH__|$BUN_PATH|g" -e "s|__CLAUDE_CONFIG_DIR__|$CLAUDE_CONFIG_DIR|g" -e "s|__LIFEOS_DIR__|$LIFEOS_DIR|g" "$PLIST_SRC" > "$PLIST_DST"
       launchctl load "$PLIST_DST"
     fi
 

--- a/LifeOS/install/LIFEOS/PULSE/modules/bunker.ts
+++ b/LifeOS/install/LIFEOS/PULSE/modules/bunker.ts
@@ -20,7 +20,7 @@ const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
 const MODULE = "bunker";
 // Bunker CODE folded under Pulse (data/code separation); DATA (shots) lives in
 // the USER config tree, so shot images are read from there, never from BUNKER_DIR.
-const BUNKER_DIR = process.env.BUNKER_DIR || join(HOME, ".claude", "LIFEOS", "PULSE", "Bunker");
+const BUNKER_DIR = process.env.BUNKER_DIR || join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"), "PULSE", "Bunker");
 const BUNKER_BIN = join(BUNKER_DIR, "bin", "bunker.ts");
 const BUNKER_SHOTS_DIR = join(HOME, ".config", "LIFEOS", "USER", "PULSE", "Bunker", "shots");
 
@@ -302,7 +302,7 @@ function cfCreds(): { acct: string; token: string } | null {
   let token = process.env.CLOUDFLARE_API_TOKEN;
   if (!acct || !token) {
     try {
-      const env = readFileSync(join(HOME, ".claude", ".env"), "utf8");
+      const env = readFileSync(join(process.env.CLAUDE_CONFIG_DIR || join(HOME, ".claude"), ".env"), "utf8");
       acct ||= env.match(/^CLOUDFLARE_ACCOUNT_ID=["']?([^"'\n]+)/m)?.[1];
       token ||= env.match(/^CLOUDFLARE_API_TOKEN=["']?([^"'\n]+)/m)?.[1];
     } catch { /* no env file */ }

--- a/LifeOS/install/LIFEOS/PULSE/modules/imessage.ts
+++ b/LifeOS/install/LIFEOS/PULSE/modules/imessage.ts
@@ -66,8 +66,8 @@ export interface IMessageHealth {
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir()
 const CWD = join(HOME, ".claude")
-const STATE_DIR = join(HOME, ".claude", "LIFEOS", "PULSE", "state", "imessage")
-const LOGS_DIR = join(HOME, ".claude", "LIFEOS", "PULSE", "logs", "imessage")
+const STATE_DIR = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"), "PULSE", "state", "imessage")
+const LOGS_DIR = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"), "PULSE", "logs", "imessage")
 
 let pollTimer: ReturnType<typeof setInterval> | null = null
 let running = false

--- a/LifeOS/install/LIFEOS/PULSE/modules/local-intelligence.ts
+++ b/LifeOS/install/LIFEOS/PULSE/modules/local-intelligence.ts
@@ -25,13 +25,13 @@ const MODULE_NAME = "local-intelligence"
 
 // Primary path: user-scoped customizations directory (per {{PRINCIPAL_NAME}} directive 2026-05-03).
 // Fallback path: legacy MEMORY/DATA path (used when customizations file absent).
-const CUSTOMIZATIONS_DIR = join(HOME, ".claude", "LIFEOS", "USER", "CUSTOMIZATIONS", "SKILLS", "LocalIntelligence")
-const LEGACY_DATA_DIR = join(HOME, ".claude", "LIFEOS", "MEMORY", "DATA", "LocalIntelligence")
+const CUSTOMIZATIONS_DIR = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"), "USER", "CUSTOMIZATIONS", "SKILLS", "LocalIntelligence")
+const LEGACY_DATA_DIR = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"), "MEMORY", "DATA", "LocalIntelligence")
 const LATEST_PATH = join(CUSTOMIZATIONS_DIR, "latest.json")
 const LEGACY_LATEST_PATH = join(LEGACY_DATA_DIR, "latest.json")
 const DATA_DIR = CUSTOMIZATIONS_DIR  // alias for existing references in this file
 const RUNS_DIR = join(CUSTOMIZATIONS_DIR, "runs")
-const REFRESH_SCRIPT = join(HOME, ".claude", "skills", "LocalIntelligence", "Tools", "Refresh.ts")
+const REFRESH_SCRIPT = join(process.env.CLAUDE_CONFIG_DIR || join(HOME, ".claude"), "skills", "LocalIntelligence", "Tools", "Refresh.ts")
 
 async function readLatest(): Promise<string | null> {
   try { return await readFile(LATEST_PATH, "utf8") } catch {}

--- a/LifeOS/install/LIFEOS/PULSE/modules/syslog.ts
+++ b/LifeOS/install/LIFEOS/PULSE/modules/syslog.ts
@@ -22,10 +22,7 @@ const MODULE_NAME = "syslog"
 const DEFAULT_PORT = 5514
 const MAX_FILE_SIZE = 50 * 1024 * 1024 // 50 MB rotation threshold
 
-const LOG_PATH = join(
-  HOME,
-  ".claude",
-  "LIFEOS",
+const LOG_PATH = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"),
   "MEMORY",
   "OBSERVABILITY",
   "unifi-syslog.jsonl",

--- a/LifeOS/install/LIFEOS/PULSE/modules/tab-freshness.ts
+++ b/LifeOS/install/LIFEOS/PULSE/modules/tab-freshness.ts
@@ -31,7 +31,7 @@ import { join } from "path"
 import { homedir } from "node:os";
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir()
-const LIFEOS_DIR = join(HOME, ".claude", "LIFEOS")
+const LIFEOS_DIR = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"))
 const USER_DIR = join(LIFEOS_DIR, "USER")
 const TELOS_DIR = join(USER_DIR, "TELOS")
 
@@ -83,8 +83,8 @@ const REGISTRY: Record<string, SourceSpec[]> = {
     { name: "KNOWLEDGE/", path: join(LIFEOS_DIR, "MEMORY", "KNOWLEDGE"), expand: true },
   ],
   hooks: [
-    { name: "hooks/", path: join(HOME, ".claude", "hooks"), expand: true },
-    { name: "settings.json", path: join(HOME, ".claude", "settings.json") },
+    { name: "hooks/", path: join(process.env.CLAUDE_CONFIG_DIR || join(HOME, ".claude"), "hooks"), expand: true },
+    { name: "settings.json", path: join(process.env.CLAUDE_CONFIG_DIR || join(HOME, ".claude"), "settings.json") },
   ],
   algorithm: [
     { name: "ALGORITHM/", path: join(LIFEOS_DIR, "ALGORITHM"), expand: true },
@@ -93,10 +93,10 @@ const REGISTRY: Record<string, SourceSpec[]> = {
     { name: "OPERATIONAL_RULES.md", path: join(USER_DIR, "CONFIG", "OPERATIONAL_RULES.md") },
   ],
   skills: [
-    { name: "skills/", path: join(HOME, ".claude", "skills"), expand: true },
+    { name: "skills/", path: join(process.env.CLAUDE_CONFIG_DIR || join(HOME, ".claude"), "skills"), expand: true },
   ],
   agents: [
-    { name: "agents/", path: join(HOME, ".claude", "agents"), expand: true },
+    { name: "agents/", path: join(process.env.CLAUDE_CONFIG_DIR || join(HOME, ".claude"), "agents"), expand: true },
   ],
   docs: [
     { name: "DOCUMENTATION/", path: join(LIFEOS_DIR, "DOCUMENTATION"), expand: true },
@@ -112,7 +112,7 @@ const REGISTRY: Record<string, SourceSpec[]> = {
   ],
   synapse: [
     { name: "KNOWLEDGE/Ideas/", path: join(LIFEOS_DIR, "MEMORY", "KNOWLEDGE", "Ideas"), expand: true },
-    { name: "_X/State/", path: join(HOME, ".claude", "skills", "_X", "State") },
+    { name: "_X/State/", path: join(process.env.CLAUDE_CONFIG_DIR || join(HOME, ".claude"), "skills", "_X", "State") },
   ],
   ledger: [
     { name: "SYSTEMUPDATES/index.json", path: join(LIFEOS_DIR, "MEMORY", "SYSTEMUPDATES", "index.json") },

--- a/LifeOS/install/LIFEOS/PULSE/modules/wiki.ts
+++ b/LifeOS/install/LIFEOS/PULSE/modules/wiki.ts
@@ -36,13 +36,13 @@ import { homedir } from "node:os";
 // Path Construction
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir()
-const LIFEOS_DIR = join(HOME, ".claude", "LIFEOS")
+const LIFEOS_DIR = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"))
 const DOCUMENTATION_DIR = join(LIFEOS_DIR, "DOCUMENTATION")
 const KNOWLEDGE_DIR = join(LIFEOS_DIR, "MEMORY", "KNOWLEDGE")
 const ALGORITHM_DIR = join(LIFEOS_DIR, "ALGORITHM")
-const SKILLS_DIR = join(HOME, ".claude", "skills")
-const HOOKS_DIR = join(HOME, ".claude", "hooks")
-const SETTINGS_PATH = join(HOME, ".claude", "settings.json")
+const SKILLS_DIR = join(process.env.CLAUDE_CONFIG_DIR || join(HOME, ".claude"), "skills")
+const HOOKS_DIR = join(process.env.CLAUDE_CONFIG_DIR || join(HOME, ".claude"), "hooks")
+const SETTINGS_PATH = join(process.env.CLAUDE_CONFIG_DIR || join(HOME, ".claude"), "settings.json")
 const ARBOL_WORKERS_DIR = join(LIFEOS_DIR, "USER", "CUSTOMIZATIONS", "ARBOL", "Workers")
 
 const SYSTEM_PROMPT_PATH = join(LIFEOS_DIR, "LIFEOS_SYSTEM_PROMPT.md")

--- a/LifeOS/install/LIFEOS/PULSE/modules/work.ts
+++ b/LifeOS/install/LIFEOS/PULSE/modules/work.ts
@@ -161,7 +161,7 @@ function extractSlug(title: string): string | undefined {
 // issues; the workload is bounded and the files are small.
 function extractPrincipalGoal(slug: string | undefined): string | undefined {
   if (!slug) return undefined;
-  const isaPath = join(HOME, ".claude", "LIFEOS", "MEMORY", "WORK", slug, "ISA.md");
+  const isaPath = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"), "MEMORY", "WORK", slug, "ISA.md");
   if (!existsSync(isaPath)) return undefined;
   try {
     const content = readFileSync(isaPath, "utf-8");

--- a/LifeOS/install/LIFEOS/PULSE/pulse.ts
+++ b/LifeOS/install/LIFEOS/PULSE/pulse.ts
@@ -21,10 +21,10 @@ import { isLoopbackHostHeader } from "./lib/host-guard.ts"
 // ── Load .env before anything else ──
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir()
-const LIFEOS_DIR = join(HOME, ".claude", "LIFEOS")
+const LIFEOS_DIR = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"))
 const PULSE_DIR = join(LIFEOS_DIR, "PULSE")
 
-const envPath = join(HOME, ".claude", ".env")
+const envPath = join(process.env.CLAUDE_CONFIG_DIR || join(HOME, ".claude"), ".env")
 try {
   const envContent = readFileSync(envPath, "utf-8")
   for (const line of envContent.split("\n")) {

--- a/LifeOS/install/LIFEOS/PULSE/run-job.ts
+++ b/LifeOS/install/LIFEOS/PULSE/run-job.ts
@@ -7,7 +7,7 @@ import { join } from "path"
 import { readFileSync } from "fs"
 
 // Load .env
-const envPath = join(homedir(), ".claude", ".env")
+const envPath = join(process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude"), ".env")
 try {
   const envContent = readFileSync(envPath, "utf-8")
   for (const line of envContent.split("\n")) {
@@ -32,7 +32,7 @@ if (!jobName) {
   process.exit(1)
 }
 
-const PULSE_DIR = join(homedir(), ".claude", "LIFEOS", "PULSE")
+const PULSE_DIR = join(process.env.LIFEOS_DIR || join(homedir(), ".claude", "LIFEOS"), "PULSE")
 const config = await loadConfig(PULSE_DIR)
 const job = config.jobs.find((j) => j.name === jobName)
 if (!job) {

--- a/LifeOS/install/LIFEOS/PULSE/setup.ts
+++ b/LifeOS/install/LIFEOS/PULSE/setup.ts
@@ -20,7 +20,8 @@ import { PULSE_BASE } from "./endpoint"
 import { homedir } from "node:os";
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir()
-const LIFEOS_DIR = join(HOME, ".claude", "LIFEOS")
+const CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR ?? join(HOME, ".claude");
+const LIFEOS_DIR = process.env.LIFEOS_DIR ?? join(CLAUDE_CONFIG_DIR, "LIFEOS")
 const PULSE_DIR = join(LIFEOS_DIR, "PULSE")
 
 // ── Helpers ──
@@ -274,7 +275,7 @@ enabled = true
     ``,
   ]
 
-  const envPath = join(HOME, ".claude", ".env")
+  const envPath = join(CLAUDE_CONFIG_DIR, ".env")
   if (existsSync(envPath)) {
     warn(`.env already exists — appending worker config`)
     const existing = await Bun.file(envPath).text()
@@ -313,6 +314,8 @@ async function installService(force = false): Promise<void> {
   // file is deny-list clean; the installed copy is per-user materialized.
   const template = await Bun.file(plistSrc).text()
   const materialized = template.split("__HOME__").join(HOME)
+    .split("__CLAUDE_CONFIG_DIR__").join(CLAUDE_CONFIG_DIR)
+    .split("__LIFEOS_DIR__").join(LIFEOS_DIR)
   const written = await writeConfigPreserving(plistDst, materialized, {
     force,
     onOverwrite: ({ backupPath }) =>
@@ -410,7 +413,7 @@ ${"═".repeat(50)}
   Time: ${Math.floor(elapsed / 60)}m ${elapsed % 60}s
 
   Next steps:
-  - Verify ANTHROPIC_API_KEY is set in ${join(HOME, ".claude", ".env")}
+  - Verify ANTHROPIC_API_KEY is set in ${join(CLAUDE_CONFIG_DIR, ".env")}
   - Create a test issue with label "status:ready" in one of your repos
   - Watch: tail -f ${join(PULSE_DIR, "logs", "pulse-stdout.log")}
   - Status: ${join(PULSE_DIR, "manage.sh")} status

--- a/LifeOS/install/LIFEOS/TOOLS/AgentTokenRollup.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/AgentTokenRollup.ts
@@ -22,7 +22,7 @@ import { readdirSync, existsSync, statSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 
-const PROJECTS = join(homedir(), '.claude', 'projects');
+const PROJECTS = join(process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude'), 'projects');
 
 interface Usage {
   input_tokens?: number;

--- a/LifeOS/install/LIFEOS/TOOLS/AppleHealthImport.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/AppleHealthImport.ts
@@ -45,7 +45,7 @@ const HOME = process.env.HOME ?? "~";
 //
 // Complementary path, not a rival: LIFEOS/TOOLS/healthsync/apple.ts is the CONTINUOUS sync
 // (iPhone Shortcut JSON -> DayFiles under USER/HEALTH/DATA). This is the bulk backup import.
-const DEFAULT_OUT = join(HOME, ".claude", "LIFEOS", "USER", "HEALTH", "APPLE_HEALTH.md");
+const DEFAULT_OUT = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"), "USER", "HEALTH", "APPLE_HEALTH.md");
 const DEFAULT_DAYS = 90;
 
 /**

--- a/LifeOS/install/LIFEOS/TOOLS/ArchitectureSummaryGenerator.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/ArchitectureSummaryGenerator.ts
@@ -40,7 +40,7 @@ const ARCH_SOURCE = path.join(LIFEOS_DIR, "DOCUMENTATION", "LifeosSystemArchitec
 const SUMMARY_OUTPUT = path.join(LIFEOS_DIR, "DOCUMENTATION", "ARCHITECTURE_SUMMARY.md");
 const ALGORITHM_DIR = path.join(LIFEOS_DIR, "ALGORITHM");
 const MEMORY_SYSTEM_DOC = path.join(LIFEOS_DIR, "DOCUMENTATION", "Memory", "MemorySystem.md");
-const CLAUDE_MD = path.join(HOME, ".claude", "CLAUDE.md");
+const CLAUDE_MD = path.join(process.env.CLAUDE_CONFIG_DIR || path.join(HOME, ".claude"), "CLAUDE.md");
 
 // ============================================================================
 // Version detection (source-of-truth lookups — no hardcoded versions)
@@ -276,7 +276,7 @@ function cmdCheck(): void {
 
   const sourceMtime = getMtime(ARCH_SOURCE);
   const summaryMtime = getMtime(SUMMARY_OUTPUT);
-  const claudeMdMtime = getMtime(path.join(HOME, ".claude", "CLAUDE.md"));
+  const claudeMdMtime = getMtime(path.join(process.env.CLAUDE_CONFIG_DIR || path.join(HOME, ".claude"), "CLAUDE.md"));
 
   if (sourceMtime > summaryMtime || claudeMdMtime > summaryMtime) {
     console.log("STALE: Source files are newer than summary");

--- a/LifeOS/install/LIFEOS/TOOLS/Checkpoint.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/Checkpoint.ts
@@ -21,8 +21,8 @@ import { parseCriteriaList } from '../../hooks/lib/isa-utils';
 // so the ContainmentGuard write restriction does not apply. Parser must match
 // the hook's parser exactly: skip blanks and '#' lines, expand tilde / $HOME
 // prefixes, treat the rest as absolute repo paths.
-const ALLOWLIST_PATH = join(homedir(), '.claude', 'checkpoint-repos.txt');
-const WORK_DIR = join(homedir(), '.claude', 'LIFEOS', 'MEMORY', 'WORK');
+const ALLOWLIST_PATH = join(process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude'), 'checkpoint-repos.txt');
+const WORK_DIR = join(process.env.LIFEOS_DIR || join(homedir(), '.claude', 'LIFEOS'), 'MEMORY', 'WORK');
 
 function expandPath(p: string): string {
   let s = p.trim();

--- a/LifeOS/install/LIFEOS/TOOLS/CodexUpdate.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/CodexUpdate.ts
@@ -22,7 +22,7 @@ import { homedir } from "node:os";
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
 const PKG = "@openai/codex";
-const LOG = join(HOME, ".claude", "LIFEOS", "MEMORY", "OBSERVABILITY", "codex-update.jsonl");
+const LOG = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"), "MEMORY", "OBSERVABILITY", "codex-update.jsonl");
 
 function codexVersion(): string | null {
   const r = spawnSync("codex", ["--version"], { encoding: "utf-8" });

--- a/LifeOS/install/LIFEOS/TOOLS/Conveyor/Runner.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/Conveyor/Runner.ts
@@ -40,7 +40,7 @@ import {
 
 const LIFEOS = process.env.LIFEOS_DIR || join(homedir(), '.claude', 'LIFEOS');
 const ARTIFACT_DIR = join(LIFEOS, 'MEMORY', 'STATE', 'content-pipeline', 'artifacts');
-const TRANSCRIBE = join(homedir(), '.claude', 'skills', 'AudioEditor', 'Tools', 'Transcribe.ts');
+const TRANSCRIBE = join(process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude'), 'skills', 'AudioEditor', 'Tools', 'Transcribe.ts');
 const LEASE_MS = Number(process.env.CONVEYOR_LEASE_MS || 30 * 60 * 1000);
 const MAX_ATTEMPTS = Number(process.env.CONVEYOR_MAX_ATTEMPTS || 3);
 const POLL_MS = Number(process.env.CONVEYOR_RUNNER_POLL_MS || 20_000);

--- a/LifeOS/install/LIFEOS/TOOLS/Conveyor/YouTubeAuth.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/Conveyor/YouTubeAuth.ts
@@ -16,7 +16,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 
 const CLIENT_PATH = join(homedir(), '.config', 'gws', 'client_secret.json');
-const ENV_PATH = join(homedir(), '.claude', '.env');
+const ENV_PATH = join(process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude'), '.env');
 const PORT = 8971;
 const REDIRECT = `http://127.0.0.1:${PORT}/callback`;
 const SCOPES = [

--- a/LifeOS/install/LIFEOS/TOOLS/CostTracker.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/CostTracker.ts
@@ -35,7 +35,7 @@ import { PULSE_BASE } from "../PULSE/endpoint";
 import { homedir } from "node:os";
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
-const LIFEOS_DIR = join(HOME, ".claude", "LIFEOS");
+const LIFEOS_DIR = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"));
 const OBS_DIR = join(LIFEOS_DIR, "MEMORY", "OBSERVABILITY");
 const LEDGER_PATH = join(OBS_DIR, "anthropic-cost.jsonl");
 const CALL_SITES_PATH = join(OBS_DIR, "anthropic-call-sites.json");
@@ -131,11 +131,11 @@ async function fetchApiSpend(): Promise<{ month_used_usd: number | null; source:
 
 // Paths we scan (source-of-truth for LifeOS-local billing risk)
 const SCAN_ROOTS = [
-  join(HOME, ".claude", "LIFEOS", "PULSE"),
-  join(HOME, ".claude", "LIFEOS", "TOOLS"),
-  join(HOME, ".claude", "LIFEOS", "USER"),
-  join(HOME, ".claude", "skills"),
-  join(HOME, ".claude", "hooks"),
+  join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"), "PULSE"),
+  join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"), "TOOLS"),
+  join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"), "USER"),
+  join(process.env.CLAUDE_CONFIG_DIR || join(HOME, ".claude"), "skills"),
+  join(process.env.CLAUDE_CONFIG_DIR || join(HOME, ".claude"), "hooks"),
 ];
 
 // Paths to exclude from scan

--- a/LifeOS/install/LIFEOS/TOOLS/CrossVendorAudit.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/CrossVendorAudit.ts
@@ -23,7 +23,7 @@ import { join, resolve, relative } from "node:path";
 import { CROSS_VENDOR } from "./models";
 
 const HOME = homedir();
-const LIFEOS_DIR = join(HOME, ".claude", "LIFEOS");
+const LIFEOS_DIR = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"));
 const WORK_DIR = join(LIFEOS_DIR, "MEMORY", "WORK");
 const FINDINGS_LOG = join(LIFEOS_DIR, "MEMORY", "VERIFICATION", "cato-findings.jsonl");
 const TOOL_ACTIVITY_LOG = join(LIFEOS_DIR, "MEMORY", "OBSERVABILITY", "tool-activity.jsonl");

--- a/LifeOS/install/LIFEOS/TOOLS/DAGrowth.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/DAGrowth.ts
@@ -17,7 +17,7 @@ import { getDAName } from "../../hooks/lib/identity"
 import { homedir } from "node:os";
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir()
-const LifeOS = join(HOME, ".claude", "LIFEOS")
+const LifeOS = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"))
 const REGISTRY_PATH = join(LifeOS, "USER", "DA", "_registry.yaml")
 
 // ── Types ──

--- a/LifeOS/install/LIFEOS/TOOLS/DASchedule.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/DASchedule.ts
@@ -16,7 +16,7 @@ import { getDAName } from "../../hooks/lib/identity"
 import { homedir } from "node:os";
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir()
-const LIFEOS_DIR = join(HOME, ".claude", "LIFEOS")
+const LIFEOS_DIR = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"))
 const TASKS_DIR = join(LIFEOS_DIR, "PULSE", "state", "da")
 const TASKS_PATH = join(TASKS_DIR, "scheduled-tasks.jsonl")
 

--- a/LifeOS/install/LIFEOS/TOOLS/FeatureRegistry.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/FeatureRegistry.ts
@@ -56,7 +56,7 @@ interface FeatureRegistry {
   };
 }
 
-const REGISTRY_DIR = join(homedir(), '.claude', 'LIFEOS', 'MEMORY', 'STATE', 'progress');
+const REGISTRY_DIR = join(process.env.LIFEOS_DIR || join(homedir(), '.claude', 'LIFEOS'), 'MEMORY', 'STATE', 'progress');
 
 function getRegistryPath(project: string): string {
   // Prevent path traversal: project is joined into a filename, so restrict it

--- a/LifeOS/install/LIFEOS/TOOLS/GeminiSearch.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/GeminiSearch.ts
@@ -65,7 +65,7 @@ Options:
 
 /** Canonical .env is ~/.claude/.env — never $LIFEOS_CONFIG_DIR/.env. */
 function loadEnv(): Record<string, string> {
-  const envPath = join(homedir(), '.claude', '.env')
+  const envPath = join(process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude'), '.env')
   const env: Record<string, string> = {}
   try {
     for (const line of readFileSync(envPath, 'utf-8').split('\n')) {

--- a/LifeOS/install/LIFEOS/TOOLS/GenerateTelosSummary.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/GenerateTelosSummary.ts
@@ -597,7 +597,7 @@ function principalDisplayName(): string {
   }
   if (coreName) return coreName;
   try {
-    const settings = JSON.parse(readFileSync(join(homedir(), '.claude', 'settings.json'), 'utf-8'));
+    const settings = JSON.parse(readFileSync(join(process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude'), 'settings.json'), 'utf-8'));
     const name = settings?.principal?.name;
     if (typeof name === 'string' && name.trim() && !looksLikeToken(name)) return name.trim();
   } catch { /* no settings.json — fall through */ }

--- a/LifeOS/install/LIFEOS/TOOLS/GetCounts.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/GetCounts.ts
@@ -144,7 +144,7 @@ function countSkills(): number {
  * count — only what Claude Code will actually fire.
  */
 function countHooks(): number {
-  const settingsPath = join(HOME, ".claude", "settings.json");
+  const settingsPath = join(process.env.CLAUDE_CONFIG_DIR || join(HOME, ".claude"), "settings.json");
   try {
     const fs = require('fs');
     const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));

--- a/LifeOS/install/LIFEOS/TOOLS/GrokQuery.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/GrokQuery.ts
@@ -64,7 +64,7 @@ Options:
 
 /** Canonical .env is ~/.claude/.env — never $LIFEOS_CONFIG_DIR/.env. */
 function loadEnv(): Record<string, string> {
-  const envPath = join(homedir(), '.claude', '.env')
+  const envPath = join(process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude'), '.env')
   const env: Record<string, string> = {}
   try {
     for (const line of readFileSync(envPath, 'utf-8').split('\n')) {

--- a/LifeOS/install/LIFEOS/TOOLS/HarvestExecutor.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/HarvestExecutor.ts
@@ -15,7 +15,7 @@ import { inference } from "./Inference";
 import { homedir } from "node:os";
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
-const LIFEOS_DIR = path.join(HOME, ".claude", "LIFEOS");
+const LIFEOS_DIR = path.join(process.env.LIFEOS_DIR || path.join(HOME, ".claude", "LIFEOS"));
 const MEMORY_DIR = path.join(LIFEOS_DIR, "MEMORY");
 const KNOWLEDGE_DIR = path.join(MEMORY_DIR, "KNOWLEDGE");
 const LEARNING_DIR = path.join(MEMORY_DIR, "LEARNING");

--- a/LifeOS/install/LIFEOS/TOOLS/HealthSync.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/HealthSync.ts
@@ -43,11 +43,8 @@ type CliCommand = "pull" | "status" | "current" | "auth";
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
 const PREFIX = "[HealthSync]";
 const SOURCE_NAMES: readonly SourceName[] = ["oura", "eightsleep", "apple", "function"];
-const CURRENT_PATH = join(HOME, ".claude", "LIFEOS", "USER", "HEALTH", "current.json");
-const HEALTHSYNC_LOG_PATH = join(
-  HOME,
-  ".claude",
-  "LIFEOS",
+const CURRENT_PATH = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"), "USER", "HEALTH", "current.json");
+const HEALTHSYNC_LOG_PATH = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"),
   "MEMORY",
   "OBSERVABILITY",
   "healthsync.jsonl",

--- a/LifeOS/install/LIFEOS/TOOLS/Inference.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/Inference.ts
@@ -193,7 +193,7 @@ export function verifyExecutedModel(modelUsage: unknown, expectedTier: string): 
  * exact drift this catches and makes auditable. Logging must never break inference. */
 function logModelVerification(entry: Record<string, unknown>): void {
   try {
-    const dir = join(homedir(), '.claude', 'LIFEOS', 'MEMORY', 'OBSERVABILITY');
+    const dir = join(process.env.LIFEOS_DIR || join(homedir(), '.claude', 'LIFEOS'), 'MEMORY', 'OBSERVABILITY');
     mkdirSync(dir, { recursive: true });
     appendFileSync(join(dir, 'model-verification.jsonl'), JSON.stringify({ ts: new Date().toISOString(), ...entry }) + '\n');
   } catch { /* observability must never break inference */ }

--- a/LifeOS/install/LIFEOS/TOOLS/InstallBlogDiscovery.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/InstallBlogDiscovery.ts
@@ -19,7 +19,9 @@ import { homedir } from "node:os";
 declare const Bun: { spawn: (cmd: string[], opts?: any) => any };
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
-const TEMPLATE_PATH = join(HOME, ".claude", "LIFEOS", "TOOLS", "com.lifeos.blogdiscovery.plist.template");
+const CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR ?? join(HOME, ".claude");
+const LIFEOS_DIR = process.env.LIFEOS_DIR ?? join(CLAUDE_CONFIG_DIR, "LIFEOS");
+const TEMPLATE_PATH = join(LIFEOS_DIR, "TOOLS", "com.lifeos.blogdiscovery.plist.template");
 const LAUNCH_AGENTS_DIR = join(HOME, "Library", "LaunchAgents");
 const TARGET_PLIST = join(LAUNCH_AGENTS_DIR, "com.lifeos.blogdiscovery.plist");
 const LABEL = "com.lifeos.blogdiscovery";
@@ -46,7 +48,7 @@ async function install(): Promise<void> {
   const bunPath = await detectBun(); const bunDir = bunPath.replace(/\/bun$/, "");
   console.log(`[InstallBlogDiscovery] detected bun at ${bunPath}`);
   const materialized = readFileSync(TEMPLATE_PATH, "utf-8")
-    .replace(/\{\{HOME\}\}/g, HOME).replace(/\{\{BUN\}\}/g, bunPath).replace(/\{\{BUN_DIR\}\}/g, bunDir);
+    .replace(/\{\{HOME\}\}/g, HOME).replace(/\{\{CLAUDE_CONFIG_DIR\}\}/g, CLAUDE_CONFIG_DIR).replace(/\{\{LIFEOS_DIR\}\}/g, LIFEOS_DIR).replace(/\{\{BUN\}\}/g, bunPath).replace(/\{\{BUN_DIR\}\}/g, bunDir);
   if (!existsSync(LAUNCH_AGENTS_DIR)) mkdirSync(LAUNCH_AGENTS_DIR, { recursive: true });
   const u = await uid();
   if (existsSync(TARGET_PLIST)) await launchctl(["bootout", `gui/${u}`, TARGET_PLIST]);
@@ -85,8 +87,8 @@ async function linuxSpec(): Promise<systemd.UnitSpec> {
   return {
     label: LABEL,
     description: "LifeOS blog discovery harvest",
-    exec: [bunPath, join(HOME, ".claude", "LIFEOS", "TOOLS", "BlogDiscovery.ts"), "harvest", "--batch", "300", "--level", "low", "--sources", "kagi,indieblog,bear"],
-    logPath: join(HOME, ".claude", "LIFEOS", "MEMORY", "STATE", "com.lifeos.blogdiscovery.log"),
+    exec: [bunPath, join(LIFEOS_DIR, "TOOLS", "BlogDiscovery.ts"), "harvest", "--batch", "300", "--level", "low", "--sources", "kagi,indieblog,bear"],
+    logPath: join(LIFEOS_DIR, "MEMORY", "STATE", "com.lifeos.blogdiscovery.log"),
     workingDirectory: join(HOME, ".claude"),
     schedule: { kind: "calendar", hour: 4, minute: 30 },
   };

--- a/LifeOS/install/LIFEOS/TOOLS/InstallBunkerMonitor.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/InstallBunkerMonitor.ts
@@ -24,9 +24,11 @@ import { homedir } from "node:os";
 declare const Bun: { spawn: (cmd: string[], opts?: any) => any };
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
-const BUNKER_DIR = process.env.BUNKER_DIR || join(HOME, ".claude", "LIFEOS", "PULSE", "Bunker");
+const CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR ?? join(HOME, ".claude");
+const LIFEOS_DIR = process.env.LIFEOS_DIR ?? join(CLAUDE_CONFIG_DIR, "LIFEOS");
+const BUNKER_DIR = process.env.BUNKER_DIR || join(LIFEOS_DIR, "PULSE", "Bunker");
 const BUNKER_DATA_DIR = join(HOME, ".config", "LIFEOS", "USER", "PULSE", "Bunker");
-const TEMPLATE_PATH = join(HOME, ".claude", "LIFEOS", "TOOLS", "com.lifeos.bunkermonitor.plist.template");
+const TEMPLATE_PATH = join(LIFEOS_DIR, "TOOLS", "com.lifeos.bunkermonitor.plist.template");
 const LAUNCH_AGENTS_DIR = join(HOME, "Library", "LaunchAgents");
 const TARGET_PLIST = join(LAUNCH_AGENTS_DIR, "com.lifeos.bunkermonitor.plist");
 const LABEL = "com.lifeos.bunkermonitor";
@@ -75,6 +77,8 @@ async function install(): Promise<void> {
   const template = readFileSync(TEMPLATE_PATH, "utf-8");
   const materialized = template
     .replace(/\{\{HOME\}\}/g, HOME)
+    .replace(/\{\{CLAUDE_CONFIG_DIR\}\}/g, CLAUDE_CONFIG_DIR)
+    .replace(/\{\{LIFEOS_DIR\}\}/g, LIFEOS_DIR)
     .replace(/\{\{BUN\}\}/g, bunPath)
     .replace(/\{\{BUN_DIR\}\}/g, bunDir)
     .replace(/\{\{BUNKER\}\}/g, BUNKER_DIR);

--- a/LifeOS/install/LIFEOS/TOOLS/InstallCodexUpdate.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/InstallCodexUpdate.ts
@@ -20,7 +20,9 @@ import { homedir } from "node:os";
 declare const Bun: { spawn: (cmd: string[], opts?: any) => any };
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
-const TEMPLATE_PATH = join(HOME, ".claude", "LIFEOS", "TOOLS", "com.lifeos.codexupdate.plist.template");
+const CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR ?? join(HOME, ".claude");
+const LIFEOS_DIR = process.env.LIFEOS_DIR ?? join(CLAUDE_CONFIG_DIR, "LIFEOS");
+const TEMPLATE_PATH = join(LIFEOS_DIR, "TOOLS", "com.lifeos.codexupdate.plist.template");
 const LAUNCH_AGENTS_DIR = join(HOME, "Library", "LaunchAgents");
 const TARGET_PLIST = join(LAUNCH_AGENTS_DIR, "com.lifeos.codexupdate.plist");
 const LABEL = "com.lifeos.codexupdate";
@@ -60,6 +62,8 @@ async function install(): Promise<void> {
   const template = readFileSync(TEMPLATE_PATH, "utf-8");
   const materialized = template
     .replace(/\{\{HOME\}\}/g, HOME)
+    .replace(/\{\{CLAUDE_CONFIG_DIR\}\}/g, CLAUDE_CONFIG_DIR)
+    .replace(/\{\{LIFEOS_DIR\}\}/g, LIFEOS_DIR)
     .replace(/\{\{BUN\}\}/g, bunPath)
     .replace(/\{\{BUN_DIR\}\}/g, bunDir);
   if (!existsSync(LAUNCH_AGENTS_DIR)) mkdirSync(LAUNCH_AGENTS_DIR, { recursive: true });
@@ -121,8 +125,8 @@ async function linuxSpec(): Promise<systemd.UnitSpec> {
   return {
     label: LABEL,
     description: "LifeOS codex update",
-    exec: [bunPath, join(HOME, ".claude", "LIFEOS", "TOOLS", "CodexUpdate.ts")],
-    logPath: join(HOME, ".claude", "LIFEOS", "MEMORY", "STATE", "com.lifeos.codexupdate.log"),
+    exec: [bunPath, join(LIFEOS_DIR, "TOOLS", "CodexUpdate.ts")],
+    logPath: join(LIFEOS_DIR, "MEMORY", "STATE", "com.lifeos.codexupdate.log"),
     workingDirectory: join(HOME, ".claude"),
     schedule: { kind: "calendar", hour: 4, minute: 0 },
   };

--- a/LifeOS/install/LIFEOS/TOOLS/InstallCommitmentSweep.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/InstallCommitmentSweep.ts
@@ -16,10 +16,12 @@ import * as systemd from "./lib/SystemdUser";
 import { homedir } from "node:os";
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
-const TEMPLATE = join(HOME, ".claude", "LIFEOS", "TOOLS", "com.lifeos.commitmentsweep.plist.template");
+const CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR ?? join(HOME, ".claude");
+const LIFEOS_DIR = process.env.LIFEOS_DIR ?? join(CLAUDE_CONFIG_DIR, "LIFEOS");
+const TEMPLATE = join(LIFEOS_DIR, "TOOLS", "com.lifeos.commitmentsweep.plist.template");
 const TARGET_DIR = join(HOME, "Library", "LaunchAgents");
 const TARGET = join(TARGET_DIR, "com.lifeos.commitmentsweep.plist");
-const STATE_DIR = join(HOME, ".claude", "LIFEOS", "MEMORY", "STATE");
+const STATE_DIR = join(LIFEOS_DIR, "MEMORY", "STATE");
 const LABEL = "com.lifeos.commitmentsweep";
 
 function uid(): string {
@@ -52,7 +54,9 @@ function install(): void {
   mkdirSync(STATE_DIR, { recursive: true });
 
   const raw = readFileSync(TEMPLATE, "utf8");
-  const materialized = raw.replaceAll("__HOME__", HOME);
+  const materialized = raw.replaceAll("__HOME__", HOME)
+    .replaceAll("__CLAUDE_CONFIG_DIR__", CLAUDE_CONFIG_DIR)
+    .replaceAll("__LIFEOS_DIR__", LIFEOS_DIR);
   writeFileSync(TARGET, materialized, { mode: 0o644 });
   console.log(`[InstallCommitmentSweep] wrote ${TARGET}`);
 
@@ -91,7 +95,7 @@ async function linuxSpec(): Promise<systemd.UnitSpec> {
   return {
     label: LABEL,
     description: "LifeOS commitment sweep",
-    exec: [bunPath, join(HOME, ".claude", "LIFEOS", "TOOLS", "CommitmentSweep.ts")],
+    exec: [bunPath, join(LIFEOS_DIR, "TOOLS", "CommitmentSweep.ts")],
     logPath: join(STATE_DIR, "com.lifeos.commitmentsweep.log"),
     workingDirectory: join(HOME, ".claude"),
     schedule: { kind: "calendar", hour: 7, minute: 0 },

--- a/LifeOS/install/LIFEOS/TOOLS/InstallConveyorRunner.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/InstallConveyorRunner.ts
@@ -22,7 +22,9 @@ import { homedir } from "node:os";
 declare const Bun: { spawn: (cmd: string[], opts?: any) => any };
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
-const TEMPLATE_PATH = join(HOME, ".claude", "LIFEOS", "TOOLS", "com.lifeos.conveyor-runner.plist.template");
+const CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR ?? join(HOME, ".claude");
+const LIFEOS_DIR = process.env.LIFEOS_DIR ?? join(CLAUDE_CONFIG_DIR, "LIFEOS");
+const TEMPLATE_PATH = join(LIFEOS_DIR, "TOOLS", "com.lifeos.conveyor-runner.plist.template");
 const LAUNCH_AGENTS_DIR = join(HOME, "Library", "LaunchAgents");
 const TARGET_PLIST = join(LAUNCH_AGENTS_DIR, "com.lifeos.conveyor-runner.plist");
 const LABEL = "com.lifeos.conveyor-runner";
@@ -62,6 +64,8 @@ async function install(): Promise<void> {
   const template = readFileSync(TEMPLATE_PATH, "utf-8");
   const materialized = template
     .replace(/\{\{HOME\}\}/g, HOME)
+    .replace(/\{\{CLAUDE_CONFIG_DIR\}\}/g, CLAUDE_CONFIG_DIR)
+    .replace(/\{\{LIFEOS_DIR\}\}/g, LIFEOS_DIR)
     .replace(/\{\{BUN\}\}/g, bunPath)
     .replace(/\{\{BUN_DIR\}\}/g, bunDir);
   if (!existsSync(LAUNCH_AGENTS_DIR)) mkdirSync(LAUNCH_AGENTS_DIR, { recursive: true });
@@ -122,8 +126,8 @@ async function linuxSpec(): Promise<systemd.UnitSpec> {
   return {
     label: LABEL,
     description: "LifeOS Conveyor stage engine",
-    exec: [bunPath, join(HOME, ".claude", "LIFEOS", "TOOLS", "Conveyor", "Runner.ts")],
-    logPath: join(HOME, ".claude", "LIFEOS", "MEMORY", "STATE", "com.lifeos.conveyor-runner.log"),
+    exec: [bunPath, join(LIFEOS_DIR, "TOOLS", "Conveyor", "Runner.ts")],
+    logPath: join(LIFEOS_DIR, "MEMORY", "STATE", "com.lifeos.conveyor-runner.log"),
     workingDirectory: join(HOME, ".claude"),
     schedule: { kind: "daemon", restartSec: 30 },
   };

--- a/LifeOS/install/LIFEOS/TOOLS/InstallConveyorWatcher.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/InstallConveyorWatcher.ts
@@ -21,7 +21,9 @@ import { homedir } from "node:os";
 declare const Bun: { spawn: (cmd: string[], opts?: any) => any };
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
-const TEMPLATE_PATH = join(HOME, ".claude", "LIFEOS", "TOOLS", "com.lifeos.conveyor-watcher.plist.template");
+const CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR ?? join(HOME, ".claude");
+const LIFEOS_DIR = process.env.LIFEOS_DIR ?? join(CLAUDE_CONFIG_DIR, "LIFEOS");
+const TEMPLATE_PATH = join(LIFEOS_DIR, "TOOLS", "com.lifeos.conveyor-watcher.plist.template");
 const LAUNCH_AGENTS_DIR = join(HOME, "Library", "LaunchAgents");
 const TARGET_PLIST = join(LAUNCH_AGENTS_DIR, "com.lifeos.conveyor-watcher.plist");
 const LABEL = "com.lifeos.conveyor-watcher";
@@ -62,6 +64,8 @@ async function install(): Promise<void> {
   const template = readFileSync(TEMPLATE_PATH, "utf-8");
   const materialized = template
     .replace(/\{\{HOME\}\}/g, HOME)
+    .replace(/\{\{CLAUDE_CONFIG_DIR\}\}/g, CLAUDE_CONFIG_DIR)
+    .replace(/\{\{LIFEOS_DIR\}\}/g, LIFEOS_DIR)
     .replace(/\{\{BUN\}\}/g, bunPath)
     .replace(/\{\{BUN_DIR\}\}/g, bunDir);
   if (!existsSync(LAUNCH_AGENTS_DIR)) mkdirSync(LAUNCH_AGENTS_DIR, { recursive: true });
@@ -123,8 +127,8 @@ async function linuxSpec(): Promise<systemd.UnitSpec> {
   return {
     label: LABEL,
     description: "LifeOS Conveyor inbox watcher",
-    exec: [bunPath, join(HOME, ".claude", "LIFEOS", "TOOLS", "Conveyor", "Watcher.ts")],
-    logPath: join(HOME, ".claude", "LIFEOS", "MEMORY", "STATE", "com.lifeos.conveyor-watcher.log"),
+    exec: [bunPath, join(LIFEOS_DIR, "TOOLS", "Conveyor", "Watcher.ts")],
+    logPath: join(LIFEOS_DIR, "MEMORY", "STATE", "com.lifeos.conveyor-watcher.log"),
     workingDirectory: join(HOME, ".claude"),
     schedule: { kind: "daemon", restartSec: 30 },
   };

--- a/LifeOS/install/LIFEOS/TOOLS/InstallDerivedSync.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/InstallDerivedSync.ts
@@ -36,7 +36,9 @@ type LaunchctlResult = {
 };
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
-const TEMPLATE_PATH = join(HOME, ".claude", "LIFEOS", "TOOLS", "com.lifeos.derivedsync.plist.template");
+const CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR ?? join(HOME, ".claude");
+const LIFEOS_DIR = process.env.LIFEOS_DIR ?? join(CLAUDE_CONFIG_DIR, "LIFEOS");
+const TEMPLATE_PATH = join(LIFEOS_DIR, "TOOLS", "com.lifeos.derivedsync.plist.template");
 const LAUNCH_AGENTS_DIR = join(HOME, "Library", "LaunchAgents");
 const TARGET_PLIST = join(LAUNCH_AGENTS_DIR, "com.lifeos.derivedsync.plist");
 const LABEL = "com.lifeos.derivedsync";
@@ -89,11 +91,11 @@ async function install(): Promise<void> {
   }
   const bunPath = await detectBun();
   const bunDir = bunPath.replace(/\/bun$/, "");
-  const userDir = realpathSync(join(HOME, ".claude", "LIFEOS", "USER"));
+  const userDir = realpathSync(join(LIFEOS_DIR, "USER"));
   console.log(`[InstallDerivedSync] detected bun at ${bunPath}`);
   const template = readFileSync(TEMPLATE_PATH, "utf-8");
   const materialized = template
-    .replace(/\{\{HOME\}\}/g, HOME)
+    .replace(/\{\{HOME\}\}/g, HOME).replace(/\{\{CLAUDE_CONFIG_DIR\}\}/g, CLAUDE_CONFIG_DIR).replace(/\{\{LIFEOS_DIR\}\}/g, LIFEOS_DIR)
     .replace(/\{\{BUN\}\}/g, bunPath)
     .replace(/\{\{BUN_DIR\}\}/g, bunDir)
     .replace(/\{\{USER_DIR\}\}/g, userDir);
@@ -157,12 +159,12 @@ async function linuxSpec(): Promise<systemd.UnitSpec> {
   // realpathSync, matching the {{USER_DIR}} substitution the plist path uses:
   // LIFEOS/USER is a symlink into the private config repo, and watching the
   // link rather than its target would never fire on a write to the real file.
-  const userDir = realpathSync(join(HOME, ".claude", "LIFEOS", "USER"));
+  const userDir = realpathSync(join(LIFEOS_DIR, "USER"));
   return {
     label: LABEL,
     description: "LifeOS derived-file sync",
-    exec: [bunPath, join(HOME, ".claude", "LIFEOS", "TOOLS", "DerivedSync.ts")],
-    logPath: join(HOME, ".claude", "LIFEOS", "MEMORY", "OBSERVABILITY", "derived-sync-systemd.log"),
+    exec: [bunPath, join(LIFEOS_DIR, "TOOLS", "DerivedSync.ts")],
+    logPath: join(LIFEOS_DIR, "MEMORY", "OBSERVABILITY", "derived-sync-systemd.log"),
     workingDirectory: join(HOME, ".claude"),
     schedule: {
       kind: "watch",

--- a/LifeOS/install/LIFEOS/TOOLS/InstallHealthSync.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/InstallHealthSync.ts
@@ -32,7 +32,9 @@ type LaunchctlResult = {
 };
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
-const TEMPLATE_PATH = join(HOME, ".claude", "LIFEOS", "TOOLS", "com.lifeos.healthsync.plist.template");
+const CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR ?? join(HOME, ".claude");
+const LIFEOS_DIR = process.env.LIFEOS_DIR ?? join(CLAUDE_CONFIG_DIR, "LIFEOS");
+const TEMPLATE_PATH = join(LIFEOS_DIR, "TOOLS", "com.lifeos.healthsync.plist.template");
 const LAUNCH_AGENTS_DIR = join(HOME, "Library", "LaunchAgents");
 const TARGET_PLIST = join(LAUNCH_AGENTS_DIR, "com.lifeos.healthsync.plist");
 const LABEL = "com.lifeos.healthsync";
@@ -88,7 +90,7 @@ async function install(): Promise<void> {
   console.log(`[InstallHealthSync] detected bun at ${bunPath}`);
   const template = readFileSync(TEMPLATE_PATH, "utf-8");
   const materialized = template
-    .replace(/\{\{HOME\}\}/g, HOME)
+    .replace(/\{\{HOME\}\}/g, HOME).replace(/\{\{CLAUDE_CONFIG_DIR\}\}/g, CLAUDE_CONFIG_DIR).replace(/\{\{LIFEOS_DIR\}\}/g, LIFEOS_DIR)
     .replace(/\{\{BUN\}\}/g, bunPath)
     .replace(/\{\{BUN_DIR\}\}/g, bunDir);
   if (!existsSync(LAUNCH_AGENTS_DIR)) mkdirSync(LAUNCH_AGENTS_DIR, { recursive: true });
@@ -152,8 +154,8 @@ async function linuxSpec(): Promise<systemd.UnitSpec> {
   return {
     label: LABEL,
     description: "LifeOS health sync",
-    exec: [bunPath, join(HOME, ".claude", "LIFEOS", "TOOLS", "HealthSync.ts"), "pull"],
-    logPath: join(HOME, ".claude", "LIFEOS", "MEMORY", "OBSERVABILITY", "health-sync.log"),
+    exec: [bunPath, join(LIFEOS_DIR, "TOOLS", "HealthSync.ts"), "pull"],
+    logPath: join(LIFEOS_DIR, "MEMORY", "OBSERVABILITY", "health-sync.log"),
     workingDirectory: join(HOME, ".claude"),
     schedule: { kind: "interval", seconds: 3600 },
   };

--- a/LifeOS/install/LIFEOS/TOOLS/InstallInboxSweep.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/InstallInboxSweep.ts
@@ -20,10 +20,12 @@ import { homedir } from "node:os";
 declare const Bun: { spawn: (cmd: string[], opts?: any) => any };
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
+const CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR ?? join(HOME, ".claude");
+const LIFEOS_DIR = process.env.LIFEOS_DIR ?? join(CLAUDE_CONFIG_DIR, "LIFEOS");
 // The template lives with the skill that owns the service — its scheduled
 // executable is skills/_INBOX/Tools/triage.ts, so a public LIFEOS/TOOLS copy
 // pointed across the boundary into a stripped skill (relocated 2026-07-25).
-const TEMPLATE_PATH = join(HOME, ".claude", "skills", "_INBOX", "com.lifeos.inboxsweep.plist.template");
+const TEMPLATE_PATH = join(CLAUDE_CONFIG_DIR, "skills", "_INBOX", "com.lifeos.inboxsweep.plist.template");
 const LAUNCH_AGENTS_DIR = join(HOME, "Library", "LaunchAgents");
 const TARGET_PLIST = join(LAUNCH_AGENTS_DIR, "com.lifeos.inboxsweep.plist");
 const LABEL = "com.lifeos.inboxsweep";
@@ -64,6 +66,8 @@ async function install(): Promise<void> {
   const template = readFileSync(TEMPLATE_PATH, "utf-8");
   const materialized = template
     .replace(/\{\{HOME\}\}/g, HOME)
+    .replace(/\{\{CLAUDE_CONFIG_DIR\}\}/g, CLAUDE_CONFIG_DIR)
+    .replace(/\{\{LIFEOS_DIR\}\}/g, LIFEOS_DIR)
     .replace(/\{\{BUN\}\}/g, bunPath)
     .replace(/\{\{BUN_DIR\}\}/g, bunDir);
   if (!existsSync(LAUNCH_AGENTS_DIR)) mkdirSync(LAUNCH_AGENTS_DIR, { recursive: true });

--- a/LifeOS/install/LIFEOS/TOOLS/InstallInterviewDue.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/InstallInterviewDue.ts
@@ -36,7 +36,9 @@ type LaunchctlResult = {
 };
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
-const TEMPLATE_PATH = join(HOME, ".claude", "LIFEOS", "TOOLS", "com.lifeos.interviewdue.plist.template");
+const CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR ?? join(HOME, ".claude");
+const LIFEOS_DIR = process.env.LIFEOS_DIR ?? join(CLAUDE_CONFIG_DIR, "LIFEOS");
+const TEMPLATE_PATH = join(LIFEOS_DIR, "TOOLS", "com.lifeos.interviewdue.plist.template");
 const LAUNCH_AGENTS_DIR = join(HOME, "Library", "LaunchAgents");
 const TARGET_PLIST = join(LAUNCH_AGENTS_DIR, "com.lifeos.interviewdue.plist");
 const LABEL = "com.lifeos.interviewdue";
@@ -92,7 +94,7 @@ async function install(): Promise<void> {
   console.log(`[InstallInterviewDue] detected bun at ${bunPath}`);
   const template = readFileSync(TEMPLATE_PATH, "utf-8");
   const materialized = template
-    .replace(/\{\{HOME\}\}/g, HOME)
+    .replace(/\{\{HOME\}\}/g, HOME).replace(/\{\{CLAUDE_CONFIG_DIR\}\}/g, CLAUDE_CONFIG_DIR).replace(/\{\{LIFEOS_DIR\}\}/g, LIFEOS_DIR)
     .replace(/\{\{BUN\}\}/g, bunPath)
     .replace(/\{\{BUN_DIR\}\}/g, bunDir);
   if (!existsSync(LAUNCH_AGENTS_DIR)) mkdirSync(LAUNCH_AGENTS_DIR, { recursive: true });
@@ -153,8 +155,8 @@ async function linuxSpec(): Promise<systemd.UnitSpec> {
   return {
     label: LABEL,
     description: "LifeOS interview-due cache refresh",
-    exec: [bunPath, join(HOME, ".claude", "LIFEOS", "TOOLS", "InterviewDue.ts"), "--refresh"],
-    logPath: join(HOME, ".claude", "LIFEOS", "MEMORY", "OBSERVABILITY", "interview-due.log"),
+    exec: [bunPath, join(LIFEOS_DIR, "TOOLS", "InterviewDue.ts"), "--refresh"],
+    logPath: join(LIFEOS_DIR, "MEMORY", "OBSERVABILITY", "interview-due.log"),
     workingDirectory: join(HOME, ".claude"),
     schedule: { kind: "calendar", hour: 7, minute: 10 },
   };

--- a/LifeOS/install/LIFEOS/TOOLS/InstallPegWatch.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/InstallPegWatch.ts
@@ -12,8 +12,10 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
 const HOME = homedir();
+const CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR ?? join(HOME, ".claude");
+const LIFEOS_DIR = process.env.LIFEOS_DIR ?? join(CLAUDE_CONFIG_DIR, "LIFEOS");
 const LABEL = "com.lifeos.pegwatch";
-const TEMPLATE = join(HOME, ".claude", "LIFEOS", "TOOLS", `${LABEL}.plist.template`);
+const TEMPLATE = join(LIFEOS_DIR, "TOOLS", `${LABEL}.plist.template`);
 const TARGET = join(HOME, "Library", "LaunchAgents", `${LABEL}.plist`);
 
 async function sh(cmd: string[]): Promise<{ exit: number; out: string }> {

--- a/LifeOS/install/LIFEOS/TOOLS/InstallUsageAggregator.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/InstallUsageAggregator.ts
@@ -19,7 +19,9 @@ import { homedir } from "node:os";
 declare const Bun: { spawn: (cmd: string[], opts?: any) => any };
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
-const TEMPLATE_PATH = join(HOME, ".claude", "LIFEOS", "TOOLS", "com.lifeos.usage-aggregator.plist.template");
+const CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR ?? join(HOME, ".claude");
+const LIFEOS_DIR = process.env.LIFEOS_DIR ?? join(CLAUDE_CONFIG_DIR, "LIFEOS");
+const TEMPLATE_PATH = join(LIFEOS_DIR, "TOOLS", "com.lifeos.usage-aggregator.plist.template");
 const LAUNCH_AGENTS_DIR = join(HOME, "Library", "LaunchAgents");
 const TARGET_PLIST = join(LAUNCH_AGENTS_DIR, "com.lifeos.usage-aggregator.plist");
 const LABEL = "com.lifeos.usage-aggregator";
@@ -59,6 +61,8 @@ async function install(): Promise<void> {
   const template = readFileSync(TEMPLATE_PATH, "utf-8");
   const materialized = template
     .replace(/\{\{HOME\}\}/g, HOME)
+    .replace(/\{\{CLAUDE_CONFIG_DIR\}\}/g, CLAUDE_CONFIG_DIR)
+    .replace(/\{\{LIFEOS_DIR\}\}/g, LIFEOS_DIR)
     .replace(/\{\{BUN\}\}/g, bunPath)
     .replace(/\{\{BUN_DIR\}\}/g, bunDir);
   if (!existsSync(LAUNCH_AGENTS_DIR)) mkdirSync(LAUNCH_AGENTS_DIR, { recursive: true });
@@ -120,8 +124,8 @@ async function linuxSpec(): Promise<systemd.UnitSpec> {
   return {
     label: LABEL,
     description: "LifeOS usage aggregator",
-    exec: [bunPath, join(HOME, ".claude", "LIFEOS", "TOOLS", "UsageAggregator.ts")],
-    logPath: join(HOME, ".claude", "LIFEOS", "MEMORY", "STATE", "com.lifeos.usage-aggregator.log"),
+    exec: [bunPath, join(LIFEOS_DIR, "TOOLS", "UsageAggregator.ts")],
+    logPath: join(LIFEOS_DIR, "MEMORY", "STATE", "com.lifeos.usage-aggregator.log"),
     workingDirectory: join(HOME, ".claude"),
     schedule: { kind: "calendar", hour: 3, minute: 30 },
   };

--- a/LifeOS/install/LIFEOS/TOOLS/InstallWorkSweep.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/InstallWorkSweep.ts
@@ -29,17 +29,19 @@ import { homedir } from "node:os";
 declare const Bun: { spawn: (cmd: string[], opts?: any) => any };
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
+const CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR ?? join(HOME, ".claude");
+const LIFEOS_DIR = process.env.LIFEOS_DIR ?? join(CLAUDE_CONFIG_DIR, "LIFEOS");
 const LABEL = "com.lifeos.worksweep";
 const IS_LINUX = process.platform === "linux";
 
 // darwin (launchd)
-const TEMPLATE_PATH = join(HOME, ".claude", "LIFEOS", "TOOLS", "com.lifeos.worksweep.plist.template");
+const TEMPLATE_PATH = join(LIFEOS_DIR, "TOOLS", "com.lifeos.worksweep.plist.template");
 const LAUNCH_AGENTS_DIR = join(HOME, "Library", "LaunchAgents");
 const TARGET_PLIST = join(LAUNCH_AGENTS_DIR, "com.lifeos.worksweep.plist");
 
 // linux (systemd --user)
-const SERVICE_TEMPLATE_PATH = join(HOME, ".claude", "LIFEOS", "TOOLS", "com.lifeos.worksweep.service.template");
-const TIMER_TEMPLATE_PATH = join(HOME, ".claude", "LIFEOS", "TOOLS", "com.lifeos.worksweep.timer.template");
+const SERVICE_TEMPLATE_PATH = join(LIFEOS_DIR, "TOOLS", "com.lifeos.worksweep.service.template");
+const TIMER_TEMPLATE_PATH = join(LIFEOS_DIR, "TOOLS", "com.lifeos.worksweep.timer.template");
 const SYSTEMD_USER_DIR = join(HOME, ".config", "systemd", "user");
 const TARGET_SERVICE = join(SYSTEMD_USER_DIR, `${LABEL}.service`);
 const TARGET_TIMER = join(SYSTEMD_USER_DIR, `${LABEL}.timer`);
@@ -72,6 +74,8 @@ async function run(cmd: string[]): Promise<{ ok: boolean; out: string; err: stri
 function materialize(templatePath: string, bunPath: string, bunDir: string): string {
   return readFileSync(templatePath, "utf-8")
     .replace(/\{\{HOME\}\}/g, HOME)
+    .replace(/\{\{CLAUDE_CONFIG_DIR\}\}/g, CLAUDE_CONFIG_DIR)
+    .replace(/\{\{LIFEOS_DIR\}\}/g, LIFEOS_DIR)
     .replace(/\{\{BUN\}\}/g, bunPath)
     .replace(/\{\{BUN_DIR\}\}/g, bunDir);
 }

--- a/LifeOS/install/LIFEOS/TOOLS/InterviewScan.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/InterviewScan.ts
@@ -105,7 +105,7 @@ const REGISTRY: RegistryTarget[] = [
   { phase: 0, path: join(LIFEOS_DIR, "PULSE", "PULSE.toml"), name: "PULSE.toml/voice", category: "setup", leverage: 9,
     prompts: ["Main DA voice — pick from ElevenLabs library, or stick with default Rachel (21m00Tcm4TlvDq8ikWAM)?",
               "Want voice notifications on by default? (default: yes)"] },
-  { phase: 0, path: join(HOME, ".claude", ".env"), name: ".env/credentials", category: "setup", leverage: 10,
+  { phase: 0, path: join(process.env.CLAUDE_CONFIG_DIR || join(HOME, ".claude"), ".env"), name: ".env/credentials", category: "setup", leverage: 10,
     prompts: ["ANTHROPIC_API_KEY — required for inference. Paste here (will write to .env, won't echo back)?",
               "ELEVENLABS_API_KEY — required for voice notifications. Skip if you don't want voice.",
               "GH_TOKEN — optional, only if you want the work pipeline. Skip if not using GitHub issues.",

--- a/LifeOS/install/LIFEOS/TOOLS/KnowledgeHarvester.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/KnowledgeHarvester.ts
@@ -59,7 +59,7 @@ const RESEARCH_DIR = path.join(MEMORY_DIR, "RESEARCH");
 const HARVEST_QUEUE_DIR = path.join(KNOWLEDGE_DIR, "_harvest-queue");
 const ARCHIVE_DIR = path.join(KNOWLEDGE_DIR, "_archive");
 
-const PROJECTS_DIR = path.join(HOME, ".claude", "projects");
+const PROJECTS_DIR = path.join(process.env.CLAUDE_CONFIG_DIR || path.join(HOME, ".claude"), "projects");
 
 /**
  * Single-pass backlink index over KNOWLEDGE/ (public PR #1574, @asdf8675309).

--- a/LifeOS/install/LIFEOS/TOOLS/LoadSkillConfig.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/LoadSkillConfig.ts
@@ -35,7 +35,7 @@ interface ExtendManifest {
 
 // Constants
 const HOME = homedir();
-const CUSTOMIZATION_DIR = join(HOME, '.claude', 'LIFEOS', 'USER', 'CUSTOMIZATIONS', 'SKILLS');
+const CUSTOMIZATION_DIR = join(process.env.LIFEOS_DIR || join(HOME, '.claude', 'LIFEOS'), 'USER', 'CUSTOMIZATIONS', 'SKILLS');
 
 /**
  * Deep merge two objects recursively

--- a/LifeOS/install/LIFEOS/TOOLS/MemoryRetriever.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/MemoryRetriever.ts
@@ -574,8 +574,8 @@ function formatResults(
 // dual-tier prefetch, no graph traversal on hot path).
 
 const MEMORY_FILES: ReadonlyArray<{ path: string; title: string }> = [
-  { path: path.join(HOME, ".claude", "LIFEOS", "USER", "PRINCIPAL", "PRINCIPAL_MEMORY.md"), title: "Principal Memory" },
-  { path: path.join(HOME, ".claude", "LIFEOS", "USER", "DIGITAL_ASSISTANT", "DA_MEMORY.md"), title: "DA Memory" },
+  { path: path.join(process.env.LIFEOS_DIR || path.join(HOME, ".claude", "LIFEOS"), "USER", "PRINCIPAL", "PRINCIPAL_MEMORY.md"), title: "Principal Memory" },
+  { path: path.join(process.env.LIFEOS_DIR || path.join(HOME, ".claude", "LIFEOS"), "USER", "DIGITAL_ASSISTANT", "DA_MEMORY.md"), title: "DA Memory" },
 ];
 
 const RELEVANT_CACHE_TTL_MS = 60_000;

--- a/LifeOS/install/LIFEOS/TOOLS/MemoryReviewer.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/MemoryReviewer.ts
@@ -57,7 +57,7 @@ import {
 // ── Constants ──
 
 const CLAUDE_ROOT = pathResolve(homedir(), ".claude");
-const HARNESS_PROJECTS_DIR = pathResolve(homedir(), ".claude", "projects");
+const HARNESS_PROJECTS_DIR = pathResolve(process.env.CLAUDE_CONFIG_DIR || pathResolve(homedir(), ".claude"), "projects");
 const RUNS_LOG_PATH = pathResolve(CLAUDE_ROOT, "LIFEOS/MEMORY/OBSERVABILITY/reviewer-runs.jsonl");
 const RUNS_DEBUG_DIR = pathResolve(CLAUDE_ROOT, "LIFEOS/MEMORY/OBSERVABILITY/reviewer-runs");
 const REVIEW_CONFIG_PATH = pathResolve(CLAUDE_ROOT, "LIFEOS/USER/CONFIG/memory-review.json");

--- a/LifeOS/install/LIFEOS/TOOLS/MergeSettings.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/MergeSettings.ts
@@ -23,10 +23,7 @@ import { homedir } from "node:os";
  * edits that haven't been merged yet never read as "drift" and never get
  * clobbered back into the overlay (the 2026-07-11 hooks-BPE incident).
  */
-export const MERGE_SNAPSHOT_PATH = path.join(
-  os.homedir(),
-  ".claude",
-  "LIFEOS",
+export const MERGE_SNAPSHOT_PATH = path.join(process.env.LIFEOS_DIR || path.join(os.homedir(), ".claude", "LIFEOS"),
   "MEMORY",
   "STATE",
   "settings-merge-snapshot.json",
@@ -588,7 +585,7 @@ async function runCli(argv: string[]): Promise<number> {
   // sat dead for days. Warn loudly whenever a root-level copy exists that is
   // not the canonical file. This runs BEFORE the fresh-install no-op guard:
   // canonical-absent + root-stray-present is exactly the footgun case.
-  const rootStray = path.join(os.homedir(), ".claude", "settings.user.json");
+  const rootStray = path.join(process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), ".claude"), "settings.user.json");
   if (existsSync(rootStray) && path.resolve(rootStray) !== path.resolve(options.userPath)) {
     process.stderr.write(
       `⚠️  MergeSettings: ${rootStray} exists but is NOT read by the merge.\n` +

--- a/LifeOS/install/LIFEOS/TOOLS/MigrateApprove.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/MigrateApprove.ts
@@ -86,7 +86,7 @@ function resolveTargetPath(target: string): string {
   }
   if (target === "memory/feedback") {
     // Feedback memories live outside LifeOS dir in projects/${HARNESS_USER_DIR}/memory/
-    return join(HOME, ".claude", "projects", "${HARNESS_USER_DIR}", "memory");
+    return join(process.env.CLAUDE_CONFIG_DIR || join(HOME, ".claude"), "projects", "${HARNESS_USER_DIR}", "memory");
   }
   return join(LIFEOS_DIR, target);
 }

--- a/LifeOS/install/LIFEOS/TOOLS/ModelMix.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/ModelMix.ts
@@ -62,7 +62,7 @@ import { EFFORT_MODEL, CURRENT, CROSS_VENDOR, type EffortLevel, type ClaudeTier 
 import { homedir } from "node:os";
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
-const PROJECTS_DIR = join(HOME, '.claude', 'projects');
+const PROJECTS_DIR = join(process.env.CLAUDE_CONFIG_DIR || join(HOME, '.claude'), 'projects');
 
 /**
  * Resolved per call, not at import: the statusline and the tests both set

--- a/LifeOS/install/LIFEOS/TOOLS/PegWatch.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/PegWatch.ts
@@ -29,9 +29,9 @@ import { dirname, join } from "node:path";
 import { invariant } from "./Invariant";
 
 const HOME = homedir();
-const OBS_DIR = join(HOME, ".claude", "LIFEOS", "MEMORY", "OBSERVABILITY");
+const OBS_DIR = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"), "MEMORY", "OBSERVABILITY");
 const LOG_PATH = join(OBS_DIR, "pegwatch.jsonl");
-const STATE_PATH = join(HOME, ".claude", "LIFEOS", "MEMORY", "STATE", "pegwatch.json");
+const STATE_PATH = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"), "MEMORY", "STATE", "pegwatch.json");
 const PULSE_NOTIFY = "http://localhost:31337/notify";
 
 const GPU_PEG = 90; // % — both samples must reach it

--- a/LifeOS/install/LIFEOS/TOOLS/PerplexitySearch.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/PerplexitySearch.ts
@@ -48,7 +48,7 @@ const colors = {
 function loadEnv(): Record<string, string> {
   // Canonical .env is ~/.claude/.env — never $LIFEOS_CONFIG_DIR/.env, which
   // resolves to the dead ~/.claude/LIFEOS/.env path (public issue #1490).
-  const envPath = join(homedir(), '.claude', '.env')
+  const envPath = join(process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude'), '.env')
   const env: Record<string, string> = {}
   try {
     const content = readFileSync(envPath, 'utf-8')

--- a/LifeOS/install/LIFEOS/TOOLS/RecurrenceLedger.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/RecurrenceLedger.ts
@@ -35,7 +35,7 @@ import * as path from "path";
 import { homedir } from "os";
 
 // ── Paths (LIFEOS_DIR override mirrors the hook/test convention) ────────────
-const LIFEOS_DIR = process.env.LIFEOS_DIR ?? path.join(homedir(), ".claude", "LIFEOS");
+const LIFEOS_DIR = process.env.LIFEOS_DIR ?? path.join(process.env.LIFEOS_DIR || path.join(homedir(), ".claude", "LIFEOS"));
 const MEMORY_DIR = path.join(LIFEOS_DIR, "MEMORY");
 const OBS_DIR = path.join(MEMORY_DIR, "OBSERVABILITY");
 const FAILURES_DIR = path.join(MEMORY_DIR, "LEARNING", "FAILURES");

--- a/LifeOS/install/LIFEOS/TOOLS/Reflect.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/Reflect.ts
@@ -45,7 +45,7 @@ import { existsSync, appendFileSync, mkdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 
-const LIFEOS = process.env.LIFEOS_DIR ?? join(homedir(), ".claude", "LIFEOS");
+const LIFEOS = process.env.LIFEOS_DIR ?? join(process.env.LIFEOS_DIR || join(homedir(), ".claude", "LIFEOS"));
 const REFLECTIONS = join(LIFEOS, "MEMORY", "LEARNING", "REFLECTIONS", "algorithm-reflections.jsonl");
 const SPEND_AUDIT = join(LIFEOS, "MEMORY", "OBSERVABILITY", "spend-audit.jsonl");
 const SUBAGENT_EVENTS = join(LIFEOS, "MEMORY", "OBSERVABILITY", "subagent-events.jsonl");

--- a/LifeOS/install/LIFEOS/TOOLS/SessionProgress.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/SessionProgress.ts
@@ -45,7 +45,7 @@ interface SessionProgress {
 }
 
 // Progress files are now in STATE/progress/ (consolidated from MEMORY/PROGRESS/)
-const PROGRESS_DIR = join(homedir(), '.claude', 'LIFEOS', 'MEMORY', 'STATE', 'progress');
+const PROGRESS_DIR = join(process.env.LIFEOS_DIR || join(homedir(), '.claude', 'LIFEOS'), 'MEMORY', 'STATE', 'progress');
 
 function getProgressPath(project: string): string {
   return join(PROGRESS_DIR, `${project}-progress.json`);

--- a/LifeOS/install/LIFEOS/TOOLS/SkillHygieneGate.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/SkillHygieneGate.ts
@@ -35,7 +35,7 @@ const maxDetail = args.includes("--max-detail") ? parseInt(args[args.indexOf("--
 
 const CLAUDE_DIR = rootArg ?? join(homedir(), ".claude");
 const SKILLS_DIR = join(CLAUDE_DIR, "skills");
-const DENY_LIST_PATH = join(homedir(), ".claude", "LIFEOS", "USER", "SECURITY", "DENY_LIST.txt");
+const DENY_LIST_PATH = join(process.env.LIFEOS_DIR || join(homedir(), ".claude", "LIFEOS"), "USER", "SECURITY", "DENY_LIST.txt");
 // Allowlist lives in the USER tree: every entry names a private `_*` skill path,
 // and one entry (the customer skill) contains a deny-listed token — so the file is
 // install-local, must be release-excluded, and SystemFileGuard must permit it to
@@ -68,7 +68,7 @@ function loadDenyPatterns(): string[] {
     // personal data IS protected elsewhere and this gate simply cannot
     // verify. Fail loud in that state instead of certifying cleanliness.
     // (public issue #1833, @xmasyx)
-    const hashesPath = join(homedir(), ".claude", "LIFEOS", "USER", "SECURITY", "DENY_HASHES.json");
+    const hashesPath = join(process.env.LIFEOS_DIR || join(homedir(), ".claude", "LIFEOS"), "USER", "SECURITY", "DENY_HASHES.json");
     if (existsSync(hashesPath)) {
       if (jsonOutput) console.log(JSON.stringify({ ok: false, skipped: true, error: `DENY_HASHES.json exists but DENY_LIST.txt is absent — personal data exists and this gate cannot scan without the plaintext list` }));
       else console.error(`CANNOT VERIFY: ${hashesPath} exists but DENY_LIST.txt is absent — personal data exists on this tree and this gate cannot scan without the plaintext list. Restore DENY_LIST.txt or run the hash-based guard.`);

--- a/LifeOS/install/LIFEOS/TOOLS/WorkSweep.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/WorkSweep.ts
@@ -623,7 +623,7 @@ async function main(): Promise<void> {
   // installs. Probe before spawning: an unconditional spawn of a missing script made
   // every public install log a Bun "module not found" at the end of every sweep.
   if (!dryRun) {
-    const regenTool = join(HOME, ".claude", "skills", "_ULWORK", "Tools", "RegenerateTasklist.ts");
+    const regenTool = join(process.env.CLAUDE_CONFIG_DIR || join(HOME, ".claude"), "skills", "_ULWORK", "Tools", "RegenerateTasklist.ts");
     if (existsSync(regenTool)) {
       const proc = Bun.spawn(["bun", regenTool, "--commit-push"], {
         stdout: "inherit", stderr: "inherit", timeout: 30000,

--- a/LifeOS/install/LIFEOS/TOOLS/YouTubeApi.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/YouTubeApi.ts
@@ -58,7 +58,7 @@ function loadEnv(): Record<string, string> {
   // Canonical .env is ~/.claude/.env. LIFEOS_CONFIG_DIR names the LIFEOS
   // directory, NOT the dir holding .env — joining it produced the dead path
   // ~/.claude/LIFEOS/.env that nothing creates (public issue #1490).
-  const envPath = join(homedir(), '.claude', '.env')
+  const envPath = join(process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude'), '.env')
   const env: Record<string, string> = {}
   try {
     const content = readFileSync(envPath, 'utf-8')

--- a/LifeOS/install/LIFEOS/TOOLS/com.lifeos.blogdiscovery.plist.template
+++ b/LifeOS/install/LIFEOS/TOOLS/com.lifeos.blogdiscovery.plist.template
@@ -23,7 +23,7 @@
   <key>ProgramArguments</key>
   <array>
     <string>{{BUN}}</string>
-    <string>{{HOME}}/.claude/LIFEOS/TOOLS/BlogDiscovery.ts</string>
+    <string>{{LIFEOS_DIR}}/TOOLS/BlogDiscovery.ts</string>
     <string>harvest</string>
     <string>--batch</string>
     <string>300</string>
@@ -50,16 +50,20 @@
   <integer>60</integer>
 
   <key>StandardOutPath</key>
-  <string>{{HOME}}/.claude/LIFEOS/MEMORY/STATE/com.lifeos.blogdiscovery.log</string>
+  <string>{{LIFEOS_DIR}}/MEMORY/STATE/com.lifeos.blogdiscovery.log</string>
 
   <key>StandardErrorPath</key>
-  <string>{{HOME}}/.claude/LIFEOS/MEMORY/STATE/com.lifeos.blogdiscovery.log</string>
+  <string>{{LIFEOS_DIR}}/MEMORY/STATE/com.lifeos.blogdiscovery.log</string>
 
   <key>WorkingDirectory</key>
-  <string>{{HOME}}/.claude</string>
+  <string>{{CLAUDE_CONFIG_DIR}}</string>
 
   <key>EnvironmentVariables</key>
   <dict>
+    <key>CLAUDE_CONFIG_DIR</key>
+    <string>{{CLAUDE_CONFIG_DIR}}</string>
+    <key>LIFEOS_DIR</key>
+    <string>{{LIFEOS_DIR}}</string>
     <key>PATH</key>
     <string>{{BUN_DIR}}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     <key>HOME</key>

--- a/LifeOS/install/LIFEOS/TOOLS/com.lifeos.bunkermonitor.plist.template
+++ b/LifeOS/install/LIFEOS/TOOLS/com.lifeos.bunkermonitor.plist.template
@@ -49,6 +49,10 @@
 
   <key>EnvironmentVariables</key>
   <dict>
+    <key>CLAUDE_CONFIG_DIR</key>
+    <string>{{CLAUDE_CONFIG_DIR}}</string>
+    <key>LIFEOS_DIR</key>
+    <string>{{LIFEOS_DIR}}</string>
     <key>PATH</key>
     <string>{{BUN_DIR}}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     <key>HOME</key>

--- a/LifeOS/install/LIFEOS/TOOLS/com.lifeos.codexupdate.plist.template
+++ b/LifeOS/install/LIFEOS/TOOLS/com.lifeos.codexupdate.plist.template
@@ -25,7 +25,7 @@
   <key>ProgramArguments</key>
   <array>
     <string>{{BUN}}</string>
-    <string>{{HOME}}/.claude/LIFEOS/TOOLS/CodexUpdate.ts</string>
+    <string>{{LIFEOS_DIR}}/TOOLS/CodexUpdate.ts</string>
   </array>
 
   <key>StartCalendarInterval</key>
@@ -43,16 +43,20 @@
   <integer>60</integer>
 
   <key>StandardOutPath</key>
-  <string>{{HOME}}/.claude/LIFEOS/MEMORY/STATE/com.lifeos.codexupdate.log</string>
+  <string>{{LIFEOS_DIR}}/MEMORY/STATE/com.lifeos.codexupdate.log</string>
 
   <key>StandardErrorPath</key>
-  <string>{{HOME}}/.claude/LIFEOS/MEMORY/STATE/com.lifeos.codexupdate.log</string>
+  <string>{{LIFEOS_DIR}}/MEMORY/STATE/com.lifeos.codexupdate.log</string>
 
   <key>WorkingDirectory</key>
-  <string>{{HOME}}/.claude</string>
+  <string>{{CLAUDE_CONFIG_DIR}}</string>
 
   <key>EnvironmentVariables</key>
   <dict>
+    <key>CLAUDE_CONFIG_DIR</key>
+    <string>{{CLAUDE_CONFIG_DIR}}</string>
+    <key>LIFEOS_DIR</key>
+    <string>{{LIFEOS_DIR}}</string>
     <key>PATH</key>
     <string>{{BUN_DIR}}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     <key>HOME</key>

--- a/LifeOS/install/LIFEOS/TOOLS/com.lifeos.commitmentsweep.plist.template
+++ b/LifeOS/install/LIFEOS/TOOLS/com.lifeos.commitmentsweep.plist.template
@@ -22,7 +22,7 @@
   <key>ProgramArguments</key>
   <array>
     <string>/opt/homebrew/bin/bun</string>
-    <string>__HOME__/.claude/LIFEOS/TOOLS/CommitmentSweep.ts</string>
+    <string>__LIFEOS_DIR__/TOOLS/CommitmentSweep.ts</string>
   </array>
 
   <!-- RunAtLoad true so a missed nightly fires at next login — a laptop asleep
@@ -42,16 +42,20 @@
   <integer>60</integer>
 
   <key>StandardOutPath</key>
-  <string>__HOME__/.claude/LIFEOS/MEMORY/STATE/com.lifeos.commitmentsweep.log</string>
+  <string>__LIFEOS_DIR__/MEMORY/STATE/com.lifeos.commitmentsweep.log</string>
 
   <key>StandardErrorPath</key>
-  <string>__HOME__/.claude/LIFEOS/MEMORY/STATE/com.lifeos.commitmentsweep.log</string>
+  <string>__LIFEOS_DIR__/MEMORY/STATE/com.lifeos.commitmentsweep.log</string>
 
   <key>WorkingDirectory</key>
-  <string>__HOME__/.claude</string>
+  <string>__CLAUDE_CONFIG_DIR__</string>
 
   <key>EnvironmentVariables</key>
   <dict>
+    <key>CLAUDE_CONFIG_DIR</key>
+    <string>__CLAUDE_CONFIG_DIR__</string>
+    <key>LIFEOS_DIR</key>
+    <string>__LIFEOS_DIR__</string>
     <key>PATH</key>
     <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     <key>HOME</key>

--- a/LifeOS/install/LIFEOS/TOOLS/com.lifeos.conveyor-runner.plist.template
+++ b/LifeOS/install/LIFEOS/TOOLS/com.lifeos.conveyor-runner.plist.template
@@ -25,7 +25,7 @@
   <key>ProgramArguments</key>
   <array>
     <string>{{BUN}}</string>
-    <string>{{HOME}}/.claude/LIFEOS/TOOLS/Conveyor/Runner.ts</string>
+    <string>{{LIFEOS_DIR}}/TOOLS/Conveyor/Runner.ts</string>
   </array>
 
   <key>RunAtLoad</key>
@@ -38,16 +38,20 @@
   <integer>30</integer>
 
   <key>StandardOutPath</key>
-  <string>{{HOME}}/.claude/LIFEOS/MEMORY/STATE/com.lifeos.conveyor-runner.log</string>
+  <string>{{LIFEOS_DIR}}/MEMORY/STATE/com.lifeos.conveyor-runner.log</string>
 
   <key>StandardErrorPath</key>
-  <string>{{HOME}}/.claude/LIFEOS/MEMORY/STATE/com.lifeos.conveyor-runner.log</string>
+  <string>{{LIFEOS_DIR}}/MEMORY/STATE/com.lifeos.conveyor-runner.log</string>
 
   <key>WorkingDirectory</key>
-  <string>{{HOME}}/.claude</string>
+  <string>{{CLAUDE_CONFIG_DIR}}</string>
 
   <key>EnvironmentVariables</key>
   <dict>
+    <key>CLAUDE_CONFIG_DIR</key>
+    <string>{{CLAUDE_CONFIG_DIR}}</string>
+    <key>LIFEOS_DIR</key>
+    <string>{{LIFEOS_DIR}}</string>
     <key>PATH</key>
     <string>{{BUN_DIR}}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     <key>HOME</key>

--- a/LifeOS/install/LIFEOS/TOOLS/com.lifeos.conveyor-watcher.plist.template
+++ b/LifeOS/install/LIFEOS/TOOLS/com.lifeos.conveyor-watcher.plist.template
@@ -24,7 +24,7 @@
   <key>ProgramArguments</key>
   <array>
     <string>{{BUN}}</string>
-    <string>{{HOME}}/.claude/LIFEOS/TOOLS/Conveyor/Watcher.ts</string>
+    <string>{{LIFEOS_DIR}}/TOOLS/Conveyor/Watcher.ts</string>
   </array>
 
   <key>RunAtLoad</key>
@@ -37,16 +37,20 @@
   <integer>30</integer>
 
   <key>StandardOutPath</key>
-  <string>{{HOME}}/.claude/LIFEOS/MEMORY/STATE/com.lifeos.conveyor-watcher.log</string>
+  <string>{{LIFEOS_DIR}}/MEMORY/STATE/com.lifeos.conveyor-watcher.log</string>
 
   <key>StandardErrorPath</key>
-  <string>{{HOME}}/.claude/LIFEOS/MEMORY/STATE/com.lifeos.conveyor-watcher.log</string>
+  <string>{{LIFEOS_DIR}}/MEMORY/STATE/com.lifeos.conveyor-watcher.log</string>
 
   <key>WorkingDirectory</key>
-  <string>{{HOME}}/.claude</string>
+  <string>{{CLAUDE_CONFIG_DIR}}</string>
 
   <key>EnvironmentVariables</key>
   <dict>
+    <key>CLAUDE_CONFIG_DIR</key>
+    <string>{{CLAUDE_CONFIG_DIR}}</string>
+    <key>LIFEOS_DIR</key>
+    <string>{{LIFEOS_DIR}}</string>
     <key>PATH</key>
     <string>{{BUN_DIR}}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     <key>HOME</key>

--- a/LifeOS/install/LIFEOS/TOOLS/com.lifeos.derivedsync.plist.template
+++ b/LifeOS/install/LIFEOS/TOOLS/com.lifeos.derivedsync.plist.template
@@ -16,7 +16,7 @@
   <key>ProgramArguments</key>
   <array>
     <string>{{BUN}}</string>
-    <string>{{HOME}}/.claude/LIFEOS/TOOLS/DerivedSync.ts</string>
+    <string>{{LIFEOS_DIR}}/TOOLS/DerivedSync.ts</string>
   </array>
   <key>RunAtLoad</key>
   <true/>
@@ -33,13 +33,17 @@
   <key>ThrottleInterval</key>
   <integer>30</integer>
   <key>StandardOutPath</key>
-  <string>{{HOME}}/.claude/LIFEOS/MEMORY/OBSERVABILITY/derived-sync-launchd.log</string>
+  <string>{{LIFEOS_DIR}}/MEMORY/OBSERVABILITY/derived-sync-launchd.log</string>
   <key>StandardErrorPath</key>
-  <string>{{HOME}}/.claude/LIFEOS/MEMORY/OBSERVABILITY/derived-sync-launchd.log</string>
+  <string>{{LIFEOS_DIR}}/MEMORY/OBSERVABILITY/derived-sync-launchd.log</string>
   <key>WorkingDirectory</key>
-  <string>{{HOME}}/.claude</string>
+  <string>{{CLAUDE_CONFIG_DIR}}</string>
   <key>EnvironmentVariables</key>
   <dict>
+    <key>CLAUDE_CONFIG_DIR</key>
+    <string>{{CLAUDE_CONFIG_DIR}}</string>
+    <key>LIFEOS_DIR</key>
+    <string>{{LIFEOS_DIR}}</string>
     <key>PATH</key>
     <string>{{BUN_DIR}}:{{HOME}}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     <key>HOME</key>

--- a/LifeOS/install/LIFEOS/TOOLS/com.lifeos.healthsync.plist.template
+++ b/LifeOS/install/LIFEOS/TOOLS/com.lifeos.healthsync.plist.template
@@ -15,7 +15,7 @@
   <key>ProgramArguments</key>
   <array>
     <string>{{BUN}}</string>
-    <string>{{HOME}}/.claude/LIFEOS/TOOLS/HealthSync.ts</string>
+    <string>{{LIFEOS_DIR}}/TOOLS/HealthSync.ts</string>
     <string>pull</string>
   </array>
   <key>RunAtLoad</key>
@@ -23,13 +23,17 @@
   <key>StartInterval</key>
   <integer>3600</integer>
   <key>StandardOutPath</key>
-  <string>{{HOME}}/.claude/LIFEOS/MEMORY/OBSERVABILITY/health-sync.log</string>
+  <string>{{LIFEOS_DIR}}/MEMORY/OBSERVABILITY/health-sync.log</string>
   <key>StandardErrorPath</key>
-  <string>{{HOME}}/.claude/LIFEOS/MEMORY/OBSERVABILITY/health-sync.log</string>
+  <string>{{LIFEOS_DIR}}/MEMORY/OBSERVABILITY/health-sync.log</string>
   <key>WorkingDirectory</key>
-  <string>{{HOME}}/.claude</string>
+  <string>{{CLAUDE_CONFIG_DIR}}</string>
   <key>EnvironmentVariables</key>
   <dict>
+    <key>CLAUDE_CONFIG_DIR</key>
+    <string>{{CLAUDE_CONFIG_DIR}}</string>
+    <key>LIFEOS_DIR</key>
+    <string>{{LIFEOS_DIR}}</string>
     <key>PATH</key>
     <string>{{BUN_DIR}}:{{HOME}}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     <key>HOME</key>

--- a/LifeOS/install/LIFEOS/TOOLS/com.lifeos.interviewdue.plist.template
+++ b/LifeOS/install/LIFEOS/TOOLS/com.lifeos.interviewdue.plist.template
@@ -17,7 +17,7 @@
   <key>ProgramArguments</key>
   <array>
     <string>{{BUN}}</string>
-    <string>{{HOME}}/.claude/LIFEOS/TOOLS/InterviewDue.ts</string>
+    <string>{{LIFEOS_DIR}}/TOOLS/InterviewDue.ts</string>
     <string>--refresh</string>
   </array>
   <key>RunAtLoad</key>
@@ -30,13 +30,17 @@
     <integer>10</integer>
   </dict>
   <key>StandardOutPath</key>
-  <string>{{HOME}}/.claude/LIFEOS/MEMORY/OBSERVABILITY/interview-due.log</string>
+  <string>{{LIFEOS_DIR}}/MEMORY/OBSERVABILITY/interview-due.log</string>
   <key>StandardErrorPath</key>
-  <string>{{HOME}}/.claude/LIFEOS/MEMORY/OBSERVABILITY/interview-due.log</string>
+  <string>{{LIFEOS_DIR}}/MEMORY/OBSERVABILITY/interview-due.log</string>
   <key>WorkingDirectory</key>
-  <string>{{HOME}}/.claude</string>
+  <string>{{CLAUDE_CONFIG_DIR}}</string>
   <key>EnvironmentVariables</key>
   <dict>
+    <key>CLAUDE_CONFIG_DIR</key>
+    <string>{{CLAUDE_CONFIG_DIR}}</string>
+    <key>LIFEOS_DIR</key>
+    <string>{{LIFEOS_DIR}}</string>
     <key>PATH</key>
     <string>{{BUN_DIR}}:{{HOME}}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     <key>HOME</key>

--- a/LifeOS/install/LIFEOS/TOOLS/com.lifeos.pegwatch.plist.template
+++ b/LifeOS/install/LIFEOS/TOOLS/com.lifeos.pegwatch.plist.template
@@ -14,20 +14,24 @@
   <key>ProgramArguments</key>
   <array>
     <string>{{BUN}}</string>
-    <string>{{HOME}}/.claude/LIFEOS/TOOLS/PegWatch.ts</string>
+    <string>{{LIFEOS_DIR}}/TOOLS/PegWatch.ts</string>
   </array>
   <key>RunAtLoad</key>
   <true/>
   <key>StartInterval</key>
   <integer>960</integer>
   <key>StandardOutPath</key>
-  <string>{{HOME}}/.claude/LIFEOS/MEMORY/OBSERVABILITY/pegwatch-launchd.log</string>
+  <string>{{LIFEOS_DIR}}/MEMORY/OBSERVABILITY/pegwatch-launchd.log</string>
   <key>StandardErrorPath</key>
-  <string>{{HOME}}/.claude/LIFEOS/MEMORY/OBSERVABILITY/pegwatch-launchd.log</string>
+  <string>{{LIFEOS_DIR}}/MEMORY/OBSERVABILITY/pegwatch-launchd.log</string>
   <key>WorkingDirectory</key>
-  <string>{{HOME}}/.claude</string>
+  <string>{{CLAUDE_CONFIG_DIR}}</string>
   <key>EnvironmentVariables</key>
   <dict>
+    <key>CLAUDE_CONFIG_DIR</key>
+    <string>{{CLAUDE_CONFIG_DIR}}</string>
+    <key>LIFEOS_DIR</key>
+    <string>{{LIFEOS_DIR}}</string>
     <key>PATH</key>
     <string>{{BUN_DIR}}:{{HOME}}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
     <key>HOME</key>

--- a/LifeOS/install/LIFEOS/TOOLS/com.lifeos.usage-aggregator.plist.template
+++ b/LifeOS/install/LIFEOS/TOOLS/com.lifeos.usage-aggregator.plist.template
@@ -23,7 +23,7 @@
   <key>ProgramArguments</key>
   <array>
     <string>{{BUN}}</string>
-    <string>{{HOME}}/.claude/LIFEOS/TOOLS/UsageAggregator.ts</string>
+    <string>{{LIFEOS_DIR}}/TOOLS/UsageAggregator.ts</string>
   </array>
 
   <key>RunAtLoad</key>
@@ -41,16 +41,20 @@
   <integer>60</integer>
 
   <key>StandardOutPath</key>
-  <string>{{HOME}}/.claude/LIFEOS/MEMORY/STATE/com.lifeos.usage-aggregator.log</string>
+  <string>{{LIFEOS_DIR}}/MEMORY/STATE/com.lifeos.usage-aggregator.log</string>
 
   <key>StandardErrorPath</key>
-  <string>{{HOME}}/.claude/LIFEOS/MEMORY/STATE/com.lifeos.usage-aggregator.log</string>
+  <string>{{LIFEOS_DIR}}/MEMORY/STATE/com.lifeos.usage-aggregator.log</string>
 
   <key>WorkingDirectory</key>
-  <string>{{HOME}}/.claude</string>
+  <string>{{CLAUDE_CONFIG_DIR}}</string>
 
   <key>EnvironmentVariables</key>
   <dict>
+    <key>CLAUDE_CONFIG_DIR</key>
+    <string>{{CLAUDE_CONFIG_DIR}}</string>
+    <key>LIFEOS_DIR</key>
+    <string>{{LIFEOS_DIR}}</string>
     <key>PATH</key>
     <string>{{BUN_DIR}}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     <key>HOME</key>

--- a/LifeOS/install/LIFEOS/TOOLS/com.lifeos.worksweep.plist.template
+++ b/LifeOS/install/LIFEOS/TOOLS/com.lifeos.worksweep.plist.template
@@ -23,7 +23,7 @@
   <key>ProgramArguments</key>
   <array>
     <string>{{BUN}}</string>
-    <string>{{HOME}}/.claude/LIFEOS/TOOLS/WorkSweep.ts</string>
+    <string>{{LIFEOS_DIR}}/TOOLS/WorkSweep.ts</string>
   </array>
 
   <key>RunAtLoad</key>
@@ -36,16 +36,20 @@
   <integer>60</integer>
 
   <key>StandardOutPath</key>
-  <string>{{HOME}}/.claude/LIFEOS/MEMORY/STATE/com.lifeos.worksweep.log</string>
+  <string>{{LIFEOS_DIR}}/MEMORY/STATE/com.lifeos.worksweep.log</string>
 
   <key>StandardErrorPath</key>
-  <string>{{HOME}}/.claude/LIFEOS/MEMORY/STATE/com.lifeos.worksweep.log</string>
+  <string>{{LIFEOS_DIR}}/MEMORY/STATE/com.lifeos.worksweep.log</string>
 
   <key>WorkingDirectory</key>
-  <string>{{HOME}}/.claude</string>
+  <string>{{CLAUDE_CONFIG_DIR}}</string>
 
   <key>EnvironmentVariables</key>
   <dict>
+    <key>CLAUDE_CONFIG_DIR</key>
+    <string>{{CLAUDE_CONFIG_DIR}}</string>
+    <key>LIFEOS_DIR</key>
+    <string>{{LIFEOS_DIR}}</string>
     <key>PATH</key>
     <string>{{BUN_DIR}}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     <key>HOME</key>

--- a/LifeOS/install/LIFEOS/TOOLS/healthsync/store.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/healthsync/store.ts
@@ -11,10 +11,10 @@ import type {
 } from "./types";
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
-const ENV_PATH = join(HOME, ".claude", ".env");
-const STATE_DIR = join(HOME, ".claude", "LIFEOS", "MEMORY", "STATE");
-const DATA_DIR = join(HOME, ".claude", "LIFEOS", "USER", "HEALTH", "DATA");
-const OBS_DIR = join(HOME, ".claude", "LIFEOS", "MEMORY", "OBSERVABILITY");
+const ENV_PATH = join(process.env.CLAUDE_CONFIG_DIR || join(HOME, ".claude"), ".env");
+const STATE_DIR = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"), "MEMORY", "STATE");
+const DATA_DIR = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"), "USER", "HEALTH", "DATA");
+const OBS_DIR = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"), "MEMORY", "OBSERVABILITY");
 const TOKENS_PATH = join(STATE_DIR, "healthsync-tokens.json");
 const STATE_PATH = join(STATE_DIR, "healthsync-state.json");
 

--- a/LifeOS/install/LIFEOS/TOOLS/lib/SystemdUser.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/lib/SystemdUser.ts
@@ -52,6 +52,8 @@ import { homedir } from "node:os";
 declare const Bun: { spawn: (cmd: string[], opts?: any) => any };
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
+const CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR ?? join(HOME, ".claude");
+const LIFEOS_DIR = process.env.LIFEOS_DIR ?? join(CLAUDE_CONFIG_DIR, "LIFEOS");
 export const UNIT_DIR = join(HOME, ".config", "systemd", "user");
 
 /* ── Schedules, one per launchd shape ───────────────────────────────────── */
@@ -405,7 +407,7 @@ export function logPathFromPlist(templatePath: string, fallback: string): string
     const xml = readFileSync(templatePath, "utf-8");
     const m = xml.match(/<key>StandardOutPath<\/key>\s*<string>([^<]+)<\/string>/);
     if (!m) return fallback;
-    return m[1].replace(/\{\{HOME\}\}/g, HOME);
+    return m[1].replace(/\{\{HOME\}\}/g, HOME).replace(/\{\{CLAUDE_CONFIG_DIR\}\}/g, CLAUDE_CONFIG_DIR).replace(/\{\{LIFEOS_DIR\}\}/g, LIFEOS_DIR);
   } catch {
     return fallback;
   }

--- a/LifeOS/install/LIFEOS/TOOLS/lifeos.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/lifeos.ts
@@ -33,7 +33,7 @@ import { PULSE_BASE } from "../PULSE/endpoint";
 const CLAUDE_DIR = join(homedir(), ".claude");
 const MCP_DIR = join(CLAUDE_DIR, "MCPs");
 const ACTIVE_MCP = join(CLAUDE_DIR, ".mcp.json");
-const BANNER_SCRIPT = join(homedir(), ".claude", "LIFEOS", "TOOLS", "Banner.ts");
+const BANNER_SCRIPT = join(process.env.LIFEOS_DIR || join(homedir(), ".claude", "LIFEOS"), "TOOLS", "Banner.ts");
 const VOICE_SERVER = `${PULSE_BASE}/notify/personality`;
 const WALLPAPER_DIR = join(homedir(), "Projects", "Wallpaper");
 // Note: RAW archiving removed - Claude Code handles its own cleanup (30-day retention in projects/)

--- a/LifeOS/install/hooks/AgentInvocation.hook.ts
+++ b/LifeOS/install/hooks/AgentInvocation.hook.ts
@@ -89,7 +89,7 @@ function resolveDispatch(subagentType: string, inputModel?: string): { model: st
   if (CROSS_VENDOR[cvKey]) return { model: CROSS_VENDOR[cvKey], level: 'cross-vendor' };
   if (inputModel) return { model: inputModel, level: levelForModel(inputModel) };
   try {
-    const fm = readFileSync(join(homedir(), '.claude', 'agents', `${subagentType}.md`), 'utf-8').slice(0, 4000);
+    const fm = readFileSync(join(process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude'), 'agents', `${subagentType}.md`), 'utf-8').slice(0, 4000);
     const m = fm.match(/^model:\s*(\S+)/m);
     if (m) return { model: m[1], level: `${levelForModel(m[1])}-pin` };
   } catch { /* no agent file — built-in type */ }

--- a/LifeOS/install/hooks/CheckpointPerISC.hook.ts
+++ b/LifeOS/install/hooks/CheckpointPerISC.hook.ts
@@ -31,7 +31,7 @@ import { isForeignToSystemRepo, looksLikePersonalTranscript } from '../LIFEOS/TO
 // '#' comments and blank
 // lines are ignored. Tilde and $HOME prefixes are expanded as a quality-of-
 // life feature so users can write `~/Projects/foo` instead of the long form.
-const ALLOWLIST_PATH = join(homedir(), '.claude', 'checkpoint-repos.txt');
+const ALLOWLIST_PATH = join(process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude'), 'checkpoint-repos.txt');
 const GIT_TIMEOUT_MS = 5000;
 
 interface CheckpointState {
@@ -244,9 +244,9 @@ async function main() {
   // dir — skill trees must stay publishable-clean and the sidecar carries
   // absolute paths + SHAs, which trips SkillHygieneGate (found 2026-08-11,
   // interview-evidence upgrade). Everything else keeps the beside-the-ISA path.
-  const skillsPrefix = join(homedir(), '.claude', 'skills') + '/';
+  const skillsPrefix = join(process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude'), 'skills') + '/';
   const inSkillTree = slugDir.startsWith(skillsPrefix);
-  const skillStateDir = join(homedir(), '.claude', 'LIFEOS', 'MEMORY', 'STATE', 'checkpoints');
+  const skillStateDir = join(process.env.LIFEOS_DIR || join(homedir(), '.claude', 'LIFEOS'), 'MEMORY', 'STATE', 'checkpoints');
   if (inSkillTree) mkdirSync(skillStateDir, { recursive: true });
   const stateFile = inSkillTree
     ? join(skillStateDir, `skill-${slug}.checkpoint-state.json`)

--- a/LifeOS/install/hooks/ReminderRouter.hook.ts
+++ b/LifeOS/install/hooks/ReminderRouter.hook.ts
@@ -28,7 +28,7 @@ import { loadWorkConfig } from "./lib/work-config";
 import { homedir } from "node:os";
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
-const STATE_PATH = join(HOME, ".claude", "LIFEOS", "MEMORY", "STATE", "reminder-router-seen.json");
+const STATE_PATH = join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"), "MEMORY", "STATE", "reminder-router-seen.json");
 
 interface HookInput {
   session_id?: string;

--- a/LifeOS/install/hooks/Safety.hook.ts
+++ b/LifeOS/install/hooks/Safety.hook.ts
@@ -60,7 +60,7 @@ const LIFEOS_DIR = process.env.LIFEOS_DIR
       /^\$\{?HOME\}?(?=\/|$)/,
       HOME,
     )
-  : join(HOME, ".claude", "LIFEOS");
+  : join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"));
 const STATE_DIR = join(LIFEOS_DIR, "MEMORY", "STATE");
 const OBS_DIR = join(LIFEOS_DIR, "MEMORY", "OBSERVABILITY");
 const CACHE_PATH = join(STATE_DIR, "permission-cache.json");

--- a/LifeOS/install/hooks/WritingGate.hook.ts
+++ b/LifeOS/install/hooks/WritingGate.hook.ts
@@ -127,7 +127,7 @@ function freshRuns(): RunRec[] {
 function detectorAvailable(): boolean {
   if (process.env.PANGRAM_API_KEY) return true;
   try {
-    const env = readFileSync(join(homedir(), ".claude", ".env"), "utf8");
+    const env = readFileSync(join(process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude"), ".env"), "utf8");
     return env.split("\n").some((l) => {
       if (!l.startsWith("PANGRAM_API_KEY=")) return false;
       return l.slice("PANGRAM_API_KEY=".length).replace(/^["']|["']$/g, "").trim().length > 0;

--- a/LifeOS/install/hooks/handlers/UpdateCounts.ts
+++ b/LifeOS/install/hooks/handlers/UpdateCounts.ts
@@ -40,7 +40,7 @@ async function refreshUsageCache(paiDir: string): Promise<void> {
         { encoding: 'utf-8', timeout: 3000 }
       ).trim();
     } else {
-      const credPath = join(homedir(), '.claude', '.credentials.json');
+      const credPath = join(process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude'), '.credentials.json');
       credJson = readFileSync(credPath, 'utf-8').trim();
     }
 

--- a/LifeOS/install/hooks/lib/paths.ts
+++ b/LifeOS/install/hooks/lib/paths.ts
@@ -51,7 +51,7 @@ export function getLifeosDir(): string {
     return expandPath(envLifeosDir);
   }
 
-  return join(homedir(), '.claude', 'LIFEOS');
+  return join(getClaudeDir(), 'LIFEOS');
 }
 
 /**
@@ -59,14 +59,27 @@ export function getLifeosDir(): string {
  *
  * Plugin install: CLAUDE_PLUGIN_ROOT is the flattened plugin root that plays the
  * live ~/.claude role (skills/ and hooks/ sit directly under it, matching live
- * .claude/skills and .claude/hooks). Live default: ~/.claude — byte-identical to
- * pre-plugin behavior, since CLAUDE_PLUGIN_ROOT is unset on a normal install.
+ * .claude/skills and .claude/hooks).
+ *
+ * Relocated install: CLAUDE_CONFIG_DIR is the harness's own override for where the
+ * config dir lives. An install that is not at ~/.claude sets it, and every
+ * settings/skills/hooks/agents lookup has to follow it — those names exist in both
+ * trees, so ignoring it reads the wrong file instead of failing.
+ *
+ * Live default: ~/.claude — byte-identical to previous behavior, since both env
+ * vars are unset on a normal install.
  */
 export function getClaudeDir(): string {
   const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
 
   if (pluginRoot) {
     return expandPath(pluginRoot);
+  }
+
+  const configDir = process.env.CLAUDE_CONFIG_DIR;
+
+  if (configDir) {
+    return expandPath(configDir);
   }
 
   return join(homedir(), '.claude');

--- a/LifeOS/install/install.sh
+++ b/LifeOS/install/install.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+# Install root. CLAUDE_CONFIG_DIR is the harness's own override for where the
+# config dir lives; fall back to ~/.claude so a default install is unchanged.
+CLAUDE_CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$CLAUDE_CONFIG_DIR}"
 # ═══════════════════════════════════════════════════════════════════
 #   LifeOS — One-Line Bootstrap Installer
 #   curl -fsSL https://ourlifeos.ai/install.sh | bash
@@ -192,9 +196,9 @@ success "bun ($(command -v bun), v$(bun --version 2>/dev/null))"
 # ─── Step 2: Detect harness (no clobber) ─────────────────────────
 step "2/6  Detecting your harness"
 if [ -z "$LIFEOS_SKILLS_DIR" ]; then
-  if [ -d "$HOME/.claude" ]; then LIFEOS_SKILLS_DIR="$HOME/.claude/skills"
+  if [ -d "$CLAUDE_CONFIG_DIR" ]; then LIFEOS_SKILLS_DIR="$CLAUDE_CONFIG_DIR/skills"
   elif [ -d "$HOME/.config/claude" ]; then LIFEOS_SKILLS_DIR="$HOME/.config/claude/skills"
-  else LIFEOS_SKILLS_DIR="$HOME/.claude/skills"; fi
+  else LIFEOS_SKILLS_DIR="$CLAUDE_CONFIG_DIR/skills"; fi
 fi
 info "Skills dir: ${BOLD}${LIFEOS_SKILLS_DIR/#$HOME/~}${RESET}"
 TARGET="$LIFEOS_SKILLS_DIR/LifeOS"

--- a/LifeOS/install/skills/Art/Tools/PickExpression.ts
+++ b/LifeOS/install/skills/Art/Tools/PickExpression.ts
@@ -21,7 +21,7 @@ import { existsSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-const DIR = join(homedir(), ".claude", "LIFEOS", "USER", "CUSTOMIZATIONS", "SKILLS", "Art", "HeadshotExamples");
+const DIR = join(process.env.LIFEOS_DIR || join(homedir(), ".claude", "LIFEOS"), "USER", "CUSTOMIZATIONS", "SKILLS", "Art", "HeadshotExamples");
 
 // sentiment -> headshot filename (without .png), with topic keywords that route to it.
 const MAP: Array<{ sentiment: string; file: string; keywords: string[] }> = [

--- a/LifeOS/install/skills/Art/Tools/ThumbnailText.ts
+++ b/LifeOS/install/skills/Art/Tools/ThumbnailText.ts
@@ -41,7 +41,7 @@ const NAVY = "#1A2744";
 const PERIWINKLE = "#6B8DD6";
 const WHITE = "#FFFFFF";
 const VARIANT_BORDER: Record<string, string> = { core: "#316AE9", sponsored: "#306F1D" };
-const BRAND_LOGO = join(homedir(), ".claude", "LIFEOS", "USER", "CUSTOMIZATIONS", "SKILLS", "Art", "brand", "ti-logo-white.png");
+const BRAND_LOGO = join(process.env.LIFEOS_DIR || join(homedir(), ".claude", "LIFEOS"), "USER", "CUSTOMIZATIONS", "SKILLS", "Art", "brand", "ti-logo-white.png");
 
 function arg(name: string, def?: string): string | undefined {
   const i = process.argv.indexOf(`--${name}`);

--- a/LifeOS/install/skills/Cortex/Tools/ContextSearch.ts
+++ b/LifeOS/install/skills/Cortex/Tools/ContextSearch.ts
@@ -479,7 +479,7 @@ async function searchProjectIsas(tokens: string[], since: Date | null, until: Da
 async function searchJsonl(tokens: string[], since: Date | null, until: Date | null = null): Promise<Result[]> {
   if (tokens.length === 0 || !existsSync(PROJECTS_ROOT)) return [];
   const realDir = PROJECTS_ROOT;
-  if (!realDir.startsWith(join(HOME, ".claude", "projects"))) return [];
+  if (!realDir.startsWith(join(process.env.CLAUDE_CONFIG_DIR || join(HOME, ".claude"), "projects"))) return [];
   const pattern = tokens.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|");
   const out = await ripgrep(pattern, realDir, ["--glob", "*.jsonl", "-c"]);
   const byFile = new Map<string, { hits: number; path: string }>();

--- a/LifeOS/install/skills/Daemon/Tools/DaemonAggregator.ts
+++ b/LifeOS/install/skills/Daemon/Tools/DaemonAggregator.ts
@@ -407,7 +407,7 @@ function readExistingDaemon(): Record<string, unknown> {
   const daemonPath = join(USER_DAEMON_DIR, "daemon.md");
   if (!existsSync(daemonPath)) {
     // Fall back to old location
-    const oldPath = join(HOME, ".claude", "skills", "_DAEMON", "Mcp", "daemon.md");
+    const oldPath = join(process.env.CLAUDE_CONFIG_DIR || join(HOME, ".claude"), "skills", "_DAEMON", "Mcp", "daemon.md");
     if (!existsSync(oldPath)) return {};
     return parseDaemonMd(readFileSync(oldPath, "utf-8"));
   }

--- a/LifeOS/install/skills/Evals/Tools/GenerateCases.ts
+++ b/LifeOS/install/skills/Evals/Tools/GenerateCases.ts
@@ -23,7 +23,7 @@ import { stringify as toYaml } from 'yaml';
 import { inference } from '../../../LIFEOS/TOOLS/Inference.ts';
 import type { Assertion } from './Assertions.ts';
 
-const DRAFTS_DIR = join(homedir(), '.claude', 'LIFEOS', 'USER', 'CUSTOMIZATIONS', 'SKILLS', 'Evals', 'Suites', '_drafts');
+const DRAFTS_DIR = join(process.env.LIFEOS_DIR || join(homedir(), '.claude', 'LIFEOS'), 'USER', 'CUSTOMIZATIONS', 'SKILLS', 'Evals', 'Suites', '_drafts');
 
 interface DraftCase {
   id: string;

--- a/LifeOS/install/skills/Interceptor/Tools/Capture.sh
+++ b/LifeOS/install/skills/Interceptor/Tools/Capture.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+# Install root. CLAUDE_CONFIG_DIR is the harness's own override for where the
+# config dir lives; fall back to ~/.claude so a default install is unchanged.
+CLAUDE_CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$CLAUDE_CONFIG_DIR}"
 # Capture.sh — the ONLY sanctioned way to take an Interceptor screenshot.
 #
 # Contract:
@@ -29,7 +33,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-USER_PREFS="${HOME}/.claude/LIFEOS/USER/CUSTOMIZATIONS/SKILLS/Interceptor/preferences.env"
+USER_PREFS="$CLAUDE_CONFIG_DIR/LIFEOS/USER/CUSTOMIZATIONS/SKILLS/Interceptor/preferences.env"
 
 usage() {
     cat <<EOF
@@ -224,7 +228,7 @@ MIN_STDDEV="${INTERCEPTOR_MIN_STDDEV:-0.017}"
 guard_skipped() {
     local reason="$1"
     echo "Capture.sh: ⚠️  BLANK-FRAME GUARD SKIPPED ($reason) — this capture is NOT checked for a black/blank frame; do not treat it as pixel-verified without looking. Install ImageMagick (brew install imagemagick) to enable." >&2
-    local log="${HOME}/.claude/LIFEOS/MEMORY/OBSERVABILITY/capture-guard.jsonl"
+    local log="$CLAUDE_CONFIG_DIR/LIFEOS/MEMORY/OBSERVABILITY/capture-guard.jsonl"
     mkdir -p "$(dirname "$log")" 2>/dev/null || true
     printf '{"ts":"%s","event":"guard-skipped","reason":"%s","out":"%s"}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$reason" "$OUT" >> "$log" 2>/dev/null || true
 }

--- a/LifeOS/install/skills/Interceptor/Tools/CleanupTabs.sh
+++ b/LifeOS/install/skills/Interceptor/Tools/CleanupTabs.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+# Install root. CLAUDE_CONFIG_DIR is the harness's own override for where the
+# config dir lives; fall back to ~/.claude so a default install is unchanged.
+CLAUDE_CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$CLAUDE_CONFIG_DIR}"
 # CleanupTabs.sh — post-run tab hygiene for the pinned Interceptor test context.
 #
 # Closes leftover tabs that Interceptor opened in the TEST profile so the
@@ -28,7 +32,7 @@ SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # than the gate that authorizes it — and on a stock install, where the skill ships
 # only preferences.env.example, no context at all (exit 8 on every run).
 # public issue #1802, @catchingknives
-PREFS="${HOME}/.claude/LIFEOS/USER/CUSTOMIZATIONS/SKILLS/Interceptor/preferences.env"
+PREFS="$CLAUDE_CONFIG_DIR/LIFEOS/USER/CUSTOMIZATIONS/SKILLS/Interceptor/preferences.env"
 [[ -f "$PREFS" ]] || PREFS="$SKILL_DIR/preferences.env"
 
 DRY_RUN=0

--- a/LifeOS/install/skills/Interceptor/Tools/EnsureTestProfile.sh
+++ b/LifeOS/install/skills/Interceptor/Tools/EnsureTestProfile.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+# Install root. CLAUDE_CONFIG_DIR is the harness's own override for where the
+# config dir lives; fall back to ~/.claude so a default install is unchanged.
+CLAUDE_CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$CLAUDE_CONFIG_DIR}"
 # EnsureTestProfile.sh — make the Interceptor test context available, auto-launching
 # the CONFIGURED test profile window if it isn't connected. Sanctioned auto-recovery
 # for the "context not connected" preflight failures (exit 5 / 6) ONLY.
@@ -22,7 +26,7 @@
 set -uo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PREFS="${HOME}/.claude/LIFEOS/USER/CUSTOMIZATIONS/SKILLS/Interceptor/preferences.env"
+PREFS="$CLAUDE_CONFIG_DIR/LIFEOS/USER/CUSTOMIZATIONS/SKILLS/Interceptor/preferences.env"
 # shellcheck disable=SC1090
 [ -f "$PREFS" ] && . "$PREFS"
 

--- a/LifeOS/install/skills/Interceptor/Tools/LaunchTestProfile.sh
+++ b/LifeOS/install/skills/Interceptor/Tools/LaunchTestProfile.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+# Install root. CLAUDE_CONFIG_DIR is the harness's own override for where the
+# config dir lives; fall back to ~/.claude so a default install is unchanged.
+CLAUDE_CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$CLAUDE_CONFIG_DIR}"
 # LaunchTestProfile.sh — open Chrome's dedicated non-default profile in its own window.
 #
 # Why this exists: the operator's Default Chrome profile holds the tabs they're actively
@@ -23,7 +27,7 @@ set -euo pipefail
 # resolves from the single canonical home (preferences.env), not a guessed
 # default. The preflight sources this too; this script must not rely on the
 # preflight having run first.
-USER_PREFS="${HOME}/.claude/LIFEOS/USER/CUSTOMIZATIONS/SKILLS/Interceptor/preferences.env"
+USER_PREFS="$CLAUDE_CONFIG_DIR/LIFEOS/USER/CUSTOMIZATIONS/SKILLS/Interceptor/preferences.env"
 if [ -f "$USER_PREFS" ]; then
     # shellcheck disable=SC1090
     . "$USER_PREFS"

--- a/LifeOS/install/skills/Interceptor/Tools/PreflightIsolation.sh
+++ b/LifeOS/install/skills/Interceptor/Tools/PreflightIsolation.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+# Install root. CLAUDE_CONFIG_DIR is the harness's own override for where the
+# config dir lives; fall back to ~/.claude so a default install is unchanged.
+CLAUDE_CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$CLAUDE_CONFIG_DIR}"
 # PreflightIsolation.sh — hard gate before any browser command lands in Chrome.
 #
 # Guarantees, enforced in code, that an interceptor browser verb cannot route to
@@ -43,7 +47,7 @@ set -euo pipefail
 # Source per-machine USER customizations if present (Chrome profile dir name,
 # pinned context ID, working-profile deny-list). Lives outside the public skill
 # body so the skill stays generic.
-USER_PREFS="${HOME}/.claude/LIFEOS/USER/CUSTOMIZATIONS/SKILLS/Interceptor/preferences.env"
+USER_PREFS="$CLAUDE_CONFIG_DIR/LIFEOS/USER/CUSTOMIZATIONS/SKILLS/Interceptor/preferences.env"
 if [ -f "$USER_PREFS" ]; then
     # shellcheck disable=SC1090
     . "$USER_PREFS"

--- a/LifeOS/install/skills/LifeOS/install/install.sh
+++ b/LifeOS/install/skills/LifeOS/install/install.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+# Install root. CLAUDE_CONFIG_DIR is the harness's own override for where the
+# config dir lives; fall back to ~/.claude so a default install is unchanged.
+CLAUDE_CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$CLAUDE_CONFIG_DIR}"
 # ═══════════════════════════════════════════════════════════════════
 #   LifeOS — One-Line Bootstrap Installer
 #   curl -fsSL https://ourlifeos.ai/install.sh | bash
@@ -192,9 +196,9 @@ success "bun ($(command -v bun), v$(bun --version 2>/dev/null))"
 # ─── Step 2: Detect harness (no clobber) ─────────────────────────
 step "2/6  Detecting your harness"
 if [ -z "$LIFEOS_SKILLS_DIR" ]; then
-  if [ -d "$HOME/.claude" ]; then LIFEOS_SKILLS_DIR="$HOME/.claude/skills"
+  if [ -d "$CLAUDE_CONFIG_DIR" ]; then LIFEOS_SKILLS_DIR="$CLAUDE_CONFIG_DIR/skills"
   elif [ -d "$HOME/.config/claude" ]; then LIFEOS_SKILLS_DIR="$HOME/.config/claude/skills"
-  else LIFEOS_SKILLS_DIR="$HOME/.claude/skills"; fi
+  else LIFEOS_SKILLS_DIR="$CLAUDE_CONFIG_DIR/skills"; fi
 fi
 info "Skills dir: ${BOLD}${LIFEOS_SKILLS_DIR/#$HOME/~}${RESET}"
 TARGET="$LIFEOS_SKILLS_DIR/LifeOS"

--- a/LifeOS/install/skills/LocalIntelligence/Tools/Backfill.ts
+++ b/LifeOS/install/skills/LocalIntelligence/Tools/Backfill.ts
@@ -31,7 +31,7 @@ import { readHometown, NoHometownError } from "./Hometown.ts"
 import { loadUserSources, fetchSourceItems, type UserSource } from "./UserSources.ts"
 import type { Digest, FetchResult, Item, SectionKey } from "./Types.ts"
 
-const DATA_DIR = join(homedir(), ".claude", "LIFEOS", "MEMORY", "DATA", "LocalIntelligence")
+const DATA_DIR = join(process.env.LIFEOS_DIR || join(homedir(), ".claude", "LIFEOS"), "MEMORY", "DATA", "LocalIntelligence")
 const SECTION_KEYS: SectionKey[] = [
   "construction", "crime", "business", "officials",
   "legislation", "elections", "arrests", "news",

--- a/LifeOS/install/skills/LocalIntelligence/Tools/Hometown.ts
+++ b/LifeOS/install/skills/LocalIntelligence/Tools/Hometown.ts
@@ -42,10 +42,7 @@ export class NoHometownError extends Error {
   }
 }
 
-const IDENTITY_DEFAULT = join(
-  homedir(),
-  ".claude",
-  "LIFEOS",
+const IDENTITY_DEFAULT = join(process.env.LIFEOS_DIR || join(homedir(), ".claude", "LIFEOS"),
   "USER",
   "PRINCIPAL",
   "PRINCIPAL_IDENTITY.md"

--- a/LifeOS/install/skills/LocalIntelligence/Tools/Refresh.ts
+++ b/LifeOS/install/skills/LocalIntelligence/Tools/Refresh.ts
@@ -28,9 +28,8 @@ import { fetchCrime } from "./FetchCrime.ts"
 // Serving plane: the Pulse module reads CUSTOMIZATIONS latest.json FIRST
 // (user-scoped primary path) — both latest copies are written on every persist
 // so the module and the history endpoint never diverge again.
-const DATA_DIR = join(homedir(), ".claude", "LIFEOS", "MEMORY", "DATA", "LocalIntelligence")
-const CUSTOMIZATIONS_DIR = join(
-  homedir(), ".claude", "LIFEOS", "USER", "CUSTOMIZATIONS", "SKILLS", "LocalIntelligence"
+const DATA_DIR = join(process.env.LIFEOS_DIR || join(homedir(), ".claude", "LIFEOS"), "MEMORY", "DATA", "LocalIntelligence")
+const CUSTOMIZATIONS_DIR = join(process.env.LIFEOS_DIR || join(homedir(), ".claude", "LIFEOS"), "USER", "CUSTOMIZATIONS", "SKILLS", "LocalIntelligence"
 )
 
 const fetchers: Record<SectionKey, Fetcher> = {

--- a/LifeOS/install/skills/LocalIntelligence/Tools/UserSources.ts
+++ b/LifeOS/install/skills/LocalIntelligence/Tools/UserSources.ts
@@ -26,8 +26,7 @@ import { homedir } from "node:os"
 
 import type { Digest, Item, SectionKey } from "./Types.ts"
 
-const CONFIG_PATH = join(
-  homedir(), ".claude", "LIFEOS", "USER", "CUSTOMIZATIONS", "SKILLS", "LocalIntelligence", "sources.json"
+const CONFIG_PATH = join(process.env.LIFEOS_DIR || join(homedir(), ".claude", "LIFEOS"), "USER", "CUSTOMIZATIONS", "SKILLS", "LocalIntelligence", "sources.json"
 )
 
 const SECTION_KEYS: SectionKey[] = [

--- a/LifeOS/install/skills/ThreatModel/Tools/RiskRegister.ts
+++ b/LifeOS/install/skills/ThreatModel/Tools/RiskRegister.ts
@@ -62,7 +62,7 @@ export function scoreRisk(likelihood: number, impact: number): { score: number; 
 
 export function resolveDataDir(): string {
   const dir = resolve(
-    process.env.THREATMODEL_DATA_DIR ?? join(homedir(), ".claude", "LIFEOS", "USER", "SECURITY", "THREATMODEL"),
+    process.env.THREATMODEL_DATA_DIR ?? join(process.env.LIFEOS_DIR || join(homedir(), ".claude", "LIFEOS"), "USER", "SECURITY", "THREATMODEL"),
   );
   // Structural code/data separation: never allow the register inside a skill tree.
   const probe = existsSync(dir) ? realpathSync(dir) : dir;

--- a/LifeOS/install/skills/Upgrade/Tools/Anthropic.ts
+++ b/LifeOS/install/skills/Upgrade/Tools/Anthropic.ts
@@ -85,7 +85,7 @@ interface State {
 
 // Config
 const HOME = homedir();
-const SKILL_DIR = join(HOME, '.claude', 'skills', 'Upgrade');
+const SKILL_DIR = join(process.env.CLAUDE_CONFIG_DIR || join(HOME, '.claude'), 'skills', 'Upgrade');
 const STATE_DIR = join(SKILL_DIR, 'State');
 const STATE_FILE = join(STATE_DIR, 'last-check.json');
 const SOURCES_FILE = join(SKILL_DIR, 'sources.json');


### PR DESCRIPTION
## Problem

LifeOS assumes it lives at `$HOME/.claude`. The harness does not — it exposes
`CLAUDE_CONFIG_DIR` precisely so the config dir can live elsewhere. Anyone who uses it
(a second install kept off a `~/.claude` that an employer syncs, a multi-profile setup,
a non-default layout) gets ~165 call sites resolving `join(homedir(), ".claude", …)`
against a directory that is not their install.

Two failure classes, and the first is the nasty one:

**1. Silent wrong-tree reads.** `settings.json`, `skills/`, `hooks/`, `agents/`,
`projects/` and `CLAUDE.md` exist in *both* trees. The lookup succeeds — against the
wrong file. Nothing throws. Observed: the Pulse wiki and freshness tabs inventory a
different install's skills and hooks; `GetCounts`, `GenerateTelosSummary` and
`observability` read a `settings.json` that is not the live one; `AgentInvocation` reads
agent frontmatter from an unrelated `agents/`; memory harvesting walks the wrong
`projects/` transcripts.

**2. Install-time baked paths.** The `Install*.ts` tools materialize launchd plists with
literal `$HOME/.claude/...` program args and log paths, and never export `LIFEOS_DIR` or
`CLAUDE_CONFIG_DIR` in `EnvironmentVariables`. So even with the code fixed a daemon
re-derives the wrong root at boot, because the environment it actually runs under is
empty. Worth stressing: fixing the code alone was **not** enough downstream — the plists
had to carry the env too.

The codebase already knows the right pattern; it is just applied unevenly. These are
correct today:

```ts
// PULSE/Conduit/paths.ts
export const CLAUDE_ROOT = process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
// PULSE/checks/notification-governor.ts, poller-meta-monitor.ts
const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
```

while the shared resolver every hook imports is not.

## Fix

**1. `hooks/lib/paths.ts` — the one that matters.** `getClaudeDir()` honored
`CLAUDE_PLUGIN_ROOT` but not `CLAUDE_CONFIG_DIR`, so `getSettingsPath()`,
`getSkillsDir()`, `getHooksDir()` and `getEnvPath()` pointed at `~/.claude` regardless.
One branch fixes every consumer that goes through the resolver.

```diff
 export function getClaudeDir(): string {
   const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;

   if (pluginRoot) {
     return expandPath(pluginRoot);
   }

+  const configDir = process.env.CLAUDE_CONFIG_DIR;
+
+  if (configDir) {
+    return expandPath(configDir);
+  }
+
   return join(homedir(), '.claude');
 }
```

and `getLifeosDir()`'s last resort follows it instead of re-hardcoding:

```diff
-  return join(homedir(), '.claude', 'LIFEOS');
+  return join(getClaudeDir(), 'LIFEOS');
```

**2. 167 direct call sites** across `LIFEOS/**` and `hooks/**` that bypass the resolver,
guarded mechanically:

```ts
join(HOME, ".claude", "LIFEOS", …)  ->  join(process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS"), …)
join(HOME, ".claude", "<seg>", …)   ->  join(process.env.CLAUDE_CONFIG_DIR || join(HOME, ".claude"), "<seg>", …)
```

Collapsing these into `paiPath()` / `getClaudeDir()` imports would be nicer; the inline
guard is the low-risk first step and keeps the diff reviewable line by line. Happy to
follow up with the import version if you prefer it.

**3. Installers and templates.** 16 plist templates parametrized (`{{LIFEOS_DIR}}` /
`__LIFEOS_DIR__` and the config-dir equivalents), both roots exported in
`EnvironmentVariables`, and the 14 substitution sites plus the Pulse/MenuBar shell
materializers taught the new placeholders. Shell scripts (`install.sh`, StatusLine, the
Pulse manage scripts, Interceptor helpers) resolve through `CLAUDE_CONFIG_DIR`.

## Compatibility

Both env vars unset → `getClaudeDir()` returns `~/.claude` and every rewritten site
resolves exactly as before. Byte-identical on a default install, no migration.
`CLAUDE_PLUGIN_ROOT` still wins over `CLAUDE_CONFIG_DIR`, so plugin installs are
untouched.

Verified:

| env | `getClaudeDir()` | `getLifeosDir()` |
|---|---|---|
| *(nothing set)* | `~/.claude` | `~/.claude/LIFEOS` |
| `CLAUDE_CONFIG_DIR=/tmp/alt` | `/tmp/alt` | `/tmp/alt/LIFEOS` |
| `+ CLAUDE_PLUGIN_ROOT=/tmp/plug` | `/tmp/plug` | `/tmp/plug/LIFEOS` |

## Checks run

- 98 changed `.ts` files parse clean
- every changed `.sh` passes `bash -n`
- every changed plist passes `plutil -lint`
- residual sweep: 0 unguarded sites in shell and plists, 2 left in `pulse-old.ts`
  (dead code, deliberately untouched)

## Notes from running this downstream

Applied on a relocated install (config dir outside `~/.claude`) before opening this PR:
Pulse healthy after reload, and every runtime path in the daemon logs now resolves to
the real install root instead of the unrelated tree that happened to sit at `~/.claude`.
