### PR TITLE
fix(deriver): word-boundary matching in violatesPrivacy — short People slugs block every hypothesis

### DIFF
--- a/LifeOS/install/LIFEOS/TOOLS/LearningPatternSynthesis.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/LearningPatternSynthesis.ts
@@ -442,12 +442,24 @@ function listPeopleSlugs(): Set<string> {
 }
 
 function violatesPrivacy(text: string, peopleSlugs: Set<string>): boolean {
+  // Word-boundary matching, not substring. KNOWLEDGE/People can legitimately
+  // contain very short slugs (an initial, a nickname); with `includes()`, a
+  // single-letter slug matches almost any text, so every candidate hypothesis
+  // is privacy-blocked and the deriver silently never emits — the failure mode
+  // is a clean `emitted=0`, indistinguishable from "nothing to report".
+  // Boundary matching preserves the guard's intent: claims that actually name
+  // a person still block.
   const norm = text.toLowerCase();
   for (const slug of peopleSlugs) {
-    // Slug typically `firstname-lastname`; check for both joined and space-separated.
-    const flat = slug.replace(/-/g, "");
-    const spaced = slug.replace(/-/g, " ");
-    if (norm.includes(spaced) || norm.includes(flat)) return true;
+    // Slug may be `firstname-lastname` or `firstname_lastname`; check the
+    // separator-normalized and joined forms.
+    const spaced = slug.replace(/[-_]/g, " ").trim();
+    const flat = slug.replace(/[-_]/g, "");
+    for (const needle of new Set([spaced, flat])) {
+      if (!needle) continue;
+      const esc = needle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      if (new RegExp(`\\b${esc}\\b`, "i").test(norm)) return true;
+    }
   }
   return false;
 }


### PR DESCRIPTION
## Symptom

The proactive deriver (`--hypothesize`) can silently emit **zero hypotheses forever**. The run log shows healthy clusters that all die at the privacy gate:

```
clusters: 8
privacy-block: <every single cluster>
dry-run: would emit 0 hypotheses
```

The failure mode is a clean `emitted=0`, indistinguishable from "nothing to report" — so nobody notices the loop is dead.

## Cause

`violatesPrivacy()` uses substring matching (`norm.includes(...)`) against `KNOWLEDGE/People` slugs. People notes can legitimately have very short slugs (an initial, a nickname — e.g. `e.md`). A single-letter slug then matches **any text containing that letter**, so every candidate hypothesis is blocked.

Underscore-separated slugs (`Firstname_Lastname.md`) are also never matched, because only `-` is normalized.

## Fix

Word-boundary regex matching instead of `includes()`, with both `-` and `_` separator normalization. The guard's intent is preserved: claims that actually name a person still block.

| Text | Slug | Before | After |
|---|---|---|---|
| "Recurring incomplete work pattern…" | `e` | ❌ blocked | ✅ passes |
| "E said she will visit" | `e` | blocked | ✅ still blocked (boundary hit) |
| "meeting with mary about seo" | `mary` | blocked | ✅ still blocked |
| "firstname lastname approved" | `firstname_lastname` | ⚠️ passed (underscore never matched) | ✅ blocked |

Tested against a 12-case matrix (short slugs, underscore slugs, real-name mentions, cluster-name false-positives): every real name still blocks, no cluster name falsely blocks.
