### PR TITLE
Make the TELOS dashboard work out of the box

### DIFF
--- a/LifeOS/install/LIFEOS/PULSE/Observability/observability.ts
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/observability.ts
@@ -2267,15 +2267,28 @@ function parseCurrencyCell(cell: string): number {
   return plain ? parseFloat(plain[0]) : 0
 }
 
-function parseGoals(content: string): { id: string, text: string }[] {
+function parseGoals(content: string): { id: string, text: string, progress?: number }[] {
+  // Explicit-ID goals come in two shapes: bullet form (- **G0**: …) and
+  // heading form (### G0: …) — unified-TELOS installs often write headings.
   const withIds = content.split("\n")
-    .filter(l => /^[-*]\s*\*{0,2}G\d+\*{0,2}:/.test(l))
+    .filter(l => /^(?:[-*]\s*|#{2,4}\s+)\*{0,2}G\d+\*{0,2}:/.test(l))
     .map(l => {
       const m = l.match(/\*{0,2}(G\d+)\*{0,2}:\s*(.+)/)
       return m ? { id: m[1], text: m[2].trim() } : null
     })
-    .filter(Boolean) as { id: string, text: string }[]
-  if (withIds.length > 0) return withIds
+    .filter(Boolean) as { id: string, text: string, progress?: number }[]
+  if (withIds.length > 0) {
+    // Hand-set progress: a `- Progress: N%` bullet inside the goal's H3 block —
+    // the contract the /life goals card hint promises. Percent only,
+    // deliberately no milestone machinery.
+    const progressById = new Map<string, number>()
+    for (const block of content.split(/^### /m).slice(1)) {
+      const head = block.match(/^\*{0,2}(G\d+)\*{0,2}:/)
+      const prog = block.match(/^[-*]\s*\*{0,2}Progress\*{0,2}:\s*(\d{1,3})\s*%/im)
+      if (head && prog) progressById.set(head[1], Math.min(100, parseInt(prog[1], 10)))
+    }
+    return withIds.map(g => progressById.has(g.id) ? { ...g, progress: progressById.get(g.id) } : g)
+  }
   // ID-less prose fallback (unified TELOS, 2026-06-09 contract: explicit IDs
   // win, prose paragraphs get positional IDs — same rule as
   // GenerateTelosSummary.paragraphItems). Without this, /api/life/home renders
@@ -2305,6 +2318,31 @@ function parseSections(content: string): { heading: string, body: string }[] {
     if (body) sections.push({ heading, body })
   }
   if (sections.length > 0) return sections
+
+  // Unified-TELOS section bodies carry their entries as H3s (### M1: …) with
+  // a trailing "### <Topic> notes" block; treat ID-form H3s as the entries and
+  // fold everything after a notes heading away, instead of falling through to
+  // the paragraph fallback (which shreds Summary/References lines into fake
+  // entries into fake missions on /life).
+  const h3Entries: { heading: string, body: string }[] = []
+  const h3Parts = content.split(/^### /m)
+  for (const part of h3Parts.slice(1)) {
+    const newline = part.indexOf("\n")
+    const heading = (newline === -1 ? part : part.slice(0, newline)).trim()
+    // Field labels are structure, not content: drop the **Summary:** prefix and
+    // **References:** lines so consumers (e.g. /life card subtitles) get prose.
+    const body = (newline === -1 ? "" : part.slice(newline + 1))
+      .replace(/^\s*\*\*Summary:\*\*\s*/im, "")
+      .replace(/^\s*\*\*References:\*\*[^\n]*$/gim, "")
+      .trim()
+    if (/^[A-Z]{1,4}\d+[a-z]?\s*:/.test(heading)) h3Entries.push({ heading, body })
+  }
+  if (h3Entries.length > 0) return h3Entries
+
+  // Bullet-form sections carry the same trailing notes block (### Wisdom notes)
+  // — meta-commentary, not an entry. Cut it before the bullet/paragraph pass.
+  const notesIdx = content.search(/^###\s+.*\bnotes\s*$/im)
+  if (notesIdx >= 0) content = content.slice(0, notesIdx)
 
   const lines = content.split("\n")
   let currentBullet: { heading: string, body: string } | null = null
@@ -2440,7 +2478,7 @@ function handleLifeHome(): Response {
     const { updated, updatedBy, domains } = parseCurrentDomains(current)
     const actions = parseNumberedList(current, "Next likely actions")
     const goals = parseGoals(goalsRaw).slice(0, 3)
-    const sparkNames = sparksRaw.split("\n").filter(l => l.startsWith("### ")).map(l => l.replace(/^###\s*/, ""))
+    const sparkNames = parseSparkBullets(sparksRaw)
     const randomSpark = sparkNames.length > 0 ? sparkNames[Math.floor(Math.random() * sparkNames.length)] : null
     const timelineBlocks = timelineRaw.split("\n").filter(l => l.startsWith("### ")).length
 
@@ -2997,8 +3035,12 @@ async function handleLifeGrowth(): Promise<Response> {
 function handleLifeWork(): Response {
   try {
     const projectsContent = readMd(PROJECTS_FILE)
+    // Scope the table scan to the "## Active projects" section when present —
+    // other tables in the registry (authored tools, aliases) otherwise leak
+    // their header rows in as projects ("Tool | Path" rendered as a project).
+    const activeScope = projectsContent.split(/^## /m).find((s) => /^(active )?projects( table)?\s*$/i.test(s.split("\n", 1)[0] ?? "")) ?? projectsContent
     // Parse project table rows
-    let projectLines = projectsContent.split("\n")
+    let projectLines = activeScope.split("\n")
       .filter(l => l.startsWith("|") && !l.includes("---") && !l.includes("Project"))
       .map(l => {
         const cols = l.split("|").map(c => c.trim()).filter(Boolean)
@@ -3104,7 +3146,7 @@ function handleLifeGoals(): Response {
       traumas: parseSections(traumas),
       status: parseSections(status),
       telosProjects: parseSections(telosProjects),
-      sparks: sparks.split("\n").filter(l => l.startsWith("### ")).map(l => l.replace(/^###\s*/, "")),
+      sparks: parseSparkBullets(sparks),
       timeline2036Blocks: timeline2036.split("\n").filter(l => l.startsWith("### ")).length,
       timeline2036Raw: timeline2036,
       telosMasterRaw: telosMaster,
@@ -3469,6 +3511,15 @@ function telosSectionOrFile(sections: Record<string, string>, sectionKey: string
   return sections[sectionKey] || readMd(join(TELOS_DIR, legacyFile))
 }
 
+// Sparks are bold-lead bullets ("- **Gardening** — ...") in TELOS.md § Sparks.
+// The legacy SPARKS.md used H3s as category headers, so H3-parsing surfaced
+// categories instead of sparks.
+function parseSparkBullets(raw: string): string[] {
+  return raw.split("\n")
+    .filter(l => /^[-*]\s+\*\*/.test(l))
+    .map(l => l.replace(/^[-*]\s+/, "").replace(/\*\*/g, "").trim())
+}
+
 function parseTelosUnified(): Record<string, string> {
   const telosPath = join(TELOS_DIR, "TELOS.md")
   const content = readMd(telosPath)
@@ -3613,14 +3664,19 @@ function buildPreferencesFromTelos(): {
   const books = parseBullets(readMd(join(TELOS_DIR, "BOOKS.md"))).slice(0, 8)
   const movies = parseBullets(readMd(join(TELOS_DIR, "MOVIES.md"))).slice(0, 8)
   const authors = parseBullets(readMd(join(TELOS_DIR, "AUTHORS.md"))).slice(0, 8)
-  if (books.length === 0 && movies.length === 0 && authors.length === 0) return null
+  const hobbies = parseBullets(readMd(join(TELOS_DIR, "HOBBIES.md"))).slice(0, 8)
+  // Aphorisms live in the unified TELOS.md § Wisdom when present; the
+  // legacy WISDOM.md file remains the fallback.
+  const wisdomRaw = parseTelosUnified()["wisdom"] || readMd(join(TELOS_DIR, "WISDOM.md"))
+  const aphorisms = parseBullets(wisdomRaw).filter((a) => !/^\(sample\)/i.test(a)).slice(0, 8)
+  if (books.length === 0 && movies.length === 0 && authors.length === 0 && hobbies.length === 0 && aphorisms.length === 0) return null
   return {
     books,
     films: movies,
     anime: [],
     characters: [],
-    aphorisms: [],
-    hobbies: [],
+    aphorisms,
+    hobbies,
     literature: authors,
   }
 }
@@ -4062,7 +4118,8 @@ function cleanWorkTitle(raw: string): string {
 }
 
 function agentFromLabels(labels: string[] | undefined): string {
-  const l = (labels ?? []).find((x) => x.startsWith("agent:"))
+  // Label case follows the repo taxonomy ("Agent:Ada"), so match case-insensitively.
+  const l = (labels ?? []).find((x) => x.toLowerCase().startsWith("agent:"))
   if (!l) return ""
   const name = l.slice("agent:".length)
   return name.charAt(0).toUpperCase() + name.slice(1)
@@ -4227,7 +4284,11 @@ async function handleTelosOverview(): Promise<Response> {
           addresses: refsByPrefix(g.references, "P"),
           kpi: pickBulletValue(g.body, "KPI") ?? "",
           target: pickBulletValue(g.body, "Target") ?? "",
-          pct: 0,
+          // Same hand-set `- Progress: N%` bullet parseGoals reads for /life.
+          pct: (() => {
+            const m = (pickBulletValue(g.body, "Progress") ?? "").match(/(\d{1,3})\s*%/)
+            return m ? Math.min(100, parseInt(m[1], 10)) : 0
+          })(),
           delta: null,
           dims: [],
           metrics: [],

--- a/LifeOS/install/LIFEOS/PULSE/Observability/observability.ts
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/observability.ts
@@ -4125,6 +4125,20 @@ function agentFromLabels(labels: string[] | undefined): string {
   return name.charAt(0).toUpperCase() + name.slice(1)
 }
 
+// Optional per-item metadata labels from the work repo taxonomy:
+// "Strategy:S4" links the item to a TELOS strategy, "Feeds:money" names a
+// life dimension it feeds, "Property:acme" groups items into a project row.
+function labelValue(labels: string[] | undefined, prefix: string): string {
+  const l = (labels ?? []).find((x) => x.toLowerCase().startsWith(prefix.toLowerCase()))
+  return l ? l.slice(prefix.length) : ""
+}
+
+function labelValues(labels: string[] | undefined, prefix: string): string[] {
+  return (labels ?? [])
+    .filter((x) => x.toLowerCase().startsWith(prefix.toLowerCase()))
+    .map((x) => x.slice(prefix.length))
+}
+
 function etaFromAge(ageHours: number | undefined): string {
   if (typeof ageHours !== "number") return ""
   return ageHours < 48 ? `${Math.round(ageHours)}h` : `${Math.round(ageHours / 24)}d`
@@ -4138,23 +4152,35 @@ function buildProjectsFromStatus(inFlight: WorkApiItem[]): OverviewProject[] | n
   const projects: OverviewProject[] = []
 
   if (inFlight.length > 0) {
-    projects.push({
-      id: "WORK",
-      title: "Work in flight",
-      strategy: "",
-      dims: [],
-      // Any thread older than a week without closing gets an amber row and
-      // ambers the card — staleness is visible, not judged.
-      status: inFlight.some((w) => (w.ageHours ?? 0) > 168) ? "amber" : "green",
-      work: inFlight.map((w) => ({
-        id: w.slug || String(w.number ?? ""),
-        title: cleanWorkTitle(w.title ?? ""),
-        strategy: "",
-        eta: etaFromAge(w.ageHours),
-        status: (w.ageHours ?? 0) > 168 ? "amber" : "green",
-        owner: agentFromLabels(w.labels),
-      })),
-    })
+    // One project row per Property:* label (acme, internal…); items
+    // without one share a generic "Work in flight" row.
+    const byProperty = new Map<string, WorkApiItem[]>()
+    for (const w of inFlight) {
+      const prop = labelValue(w.labels, "Property:").toLowerCase()
+      const key = prop || "work"
+      byProperty.set(key, [...(byProperty.get(key) ?? []), w])
+    }
+    for (const [prop, items] of byProperty) {
+      const strategies = [...new Set(items.map((w) => labelValue(w.labels, "Strategy:")).filter(Boolean))]
+      const dims = [...new Set(items.flatMap((w) => labelValues(w.labels, "Feeds:").map((d) => d.toLowerCase())))]
+      projects.push({
+        id: prop.toUpperCase(),
+        title: prop === "work" ? "Work in flight" : prop.charAt(0).toUpperCase() + prop.slice(1),
+        strategy: strategies[0] ?? "",
+        dims,
+        // Any thread older than a week without closing gets an amber row and
+        // ambers the card — staleness is visible, not judged.
+        status: items.some((w) => (w.ageHours ?? 0) > 168) ? "amber" : "green",
+        work: items.map((w) => ({
+          id: w.slug || String(w.number ?? ""),
+          title: cleanWorkTitle(w.title ?? ""),
+          strategy: labelValue(w.labels, "Strategy:"),
+          eta: etaFromAge(w.ageHours),
+          status: (w.ageHours ?? 0) > 168 ? "amber" : "green",
+          owner: agentFromLabels(w.labels),
+        })),
+      })
+    }
   }
 
   for (const [name, s] of apps) {

--- a/LifeOS/install/LIFEOS/PULSE/Observability/src/app/life/page.tsx
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/src/app/life/page.tsx
@@ -69,7 +69,7 @@ interface UserIndex {
 }
 
 interface GoalsData {
-  goals?: Array<{ id: string; text: string }>;
+  goals?: Array<{ id: string; text: string; progress?: number }>;
   mission?: Array<{ heading: string; body: string }>;
   problems?: Array<{ heading: string; body: string }>;
   status?: Array<{ heading: string; body: string }>;
@@ -418,13 +418,27 @@ function ActiveGoals({ goals }: { goals: GoalsData | null }) {
             <div key={g.id} className="flex items-center gap-4">
               <span className="text-xs mono text-ink-3 w-8 shrink-0">{g.id}</span>
               <span className="text-sm flex-1 truncate text-ink-1" title={g.text}>{g.text}</span>
-              <Pill dim="relationships" className="shrink-0">active</Pill>
+              {typeof g.progress === "number" ? (
+                <div className="flex items-center gap-2 shrink-0">
+                  <div className="w-24 h-1.5 rounded-full bg-line-1 overflow-hidden">
+                    <div
+                      className="h-full rounded-full"
+                      style={{ width: `${g.progress}%`, background: DIMENSION_COLOR.relationships }}
+                    />
+                  </div>
+                  <span className="text-xs mono text-ink-3 w-9 text-right">{g.progress}%</span>
+                </div>
+              ) : (
+                <Pill dim="relationships" className="shrink-0">active</Pill>
+              )}
             </div>
           ))}
         </div>
-        <div className="mt-4 pt-4 text-xs text-ink-3 italic border-t border-line-1">
-          Progress tracking appears once each goal has a `progress` field in Telos/Goals.md
-        </div>
+        {items.every(g => typeof g.progress !== "number") && (
+          <div className="mt-4 pt-4 text-xs text-ink-3 italic border-t border-line-1">
+            Progress tracking appears once a goal carries a `- Progress: N%` line in TELOS.md § Goals
+          </div>
+        )}
       </Panel>
     </section>
   );
@@ -461,7 +475,7 @@ function NextActionsSpark({ home }: { home: HomeData | null }) {
         {spark ? (
           <p className="text-base font-serif italic leading-relaxed text-ink-1">{spark}</p>
         ) : (
-          <p className="text-xs text-ink-3 italic">Sparks surfaces random entries from Telos/Sparks.md</p>
+          <p className="text-xs text-ink-3 italic">Spark surfaces a random entry from TELOS.md § Sparks</p>
         )}
       </Panel>
     </section>

--- a/LifeOS/install/LIFEOS/PULSE/Observability/src/app/life/page.tsx
+++ b/LifeOS/install/LIFEOS/PULSE/Observability/src/app/life/page.tsx
@@ -475,7 +475,7 @@ function NextActionsSpark({ home }: { home: HomeData | null }) {
         {spark ? (
           <p className="text-base font-serif italic leading-relaxed text-ink-1">{spark}</p>
         ) : (
-          <p className="text-xs text-ink-3 italic">Spark surfaces a random entry from TELOS.md § Sparks</p>
+          <p className="text-xs text-ink-3 italic">Spark surfaces a random entry from SPARKS.md (or a Sparks section in TELOS.md)</p>
         )}
       </Panel>
     </section>

--- a/LifeOS/install/USER/TELOS/SPARKS.md
+++ b/LifeOS/install/USER/TELOS/SPARKS.md
@@ -1,0 +1,26 @@
+# Sparks (fuel, not outcomes)
+
+> Goals are outcomes; sparks are fuel — the things that refuel you whether or not
+> they produce anything. If a whole month passes with none of them touched, that's
+> drift into all-work mode, and the right nudge is not another work session.
+>
+> Shape notes: category headings are H3s — the morning voice brief picks one to ask
+> you about. Sparks are bold-lead bullets — the /life Spark card surfaces one at random.
+
+### Body & outdoors
+
+- **(sample) A sport or movement practice** — one line on why it refuels you.
+
+- **(sample) Being outdoors** — movement, weather, horizon; the base layer under everything physical.
+
+### Craft & aesthetics
+
+- **(sample) A creative pursuit** — music, drawing, cooking, photography — made for its own sake.
+
+- **(sample) Great design** — well-made products, spaces, objects that light something up.
+
+### Mind & people
+
+- **(sample) Learning something new** — new ideas, new domains, new ways of seeing.
+
+- **(sample) Long conversations with good people** — the multiplier on every other spark.

--- a/LifeOS/install/USER/TELOS/TELOS.md
+++ b/LifeOS/install/USER/TELOS/TELOS.md
@@ -7,54 +7,103 @@ convention: pai-freshness-v1
 
 # TELOS — Your Name
 
-> 🎯 SAMPLE TEMPLATE — this is the single source of truth for your TELOS (your mission, goals, problems, and the rest). Every entry below is a placeholder showing the SHAPE of the data. Run `/interview` (or just talk to your DA) to replace these samples with your real life context. Pulse reads this file to render your rings, freshness, and TELOS overview — it comes alive once you fill it in.
+> 🎯 SAMPLE TEMPLATE — this is the single source of truth for your TELOS (your mission, goals, problems, and the rest). Every entry below is a placeholder showing the SHAPE of the data — the exact markdown forms the Pulse parsers read to render /life and /telos. Keep the shapes, replace the words: run `/interview` (or just talk to your DA) to fill in your real life context.
 
 ## Current State (where you are now)
+<!-- updated: 2026-01-01 by:bootstrap-template -->
 
-- Health: (sample) TBD — describe your current health, energy, sleep.
-- Finances: (sample) TBD — describe your current financial state.
-- Relationships: (sample) TBD — describe your current relationships.
+**Focus:** (sample) The one thing most of your attention is on right now
+
+**Energy:** (sample) Good (7/10)
+
+**Mood:** (sample) Good, building momentum
+
+**Next likely actions:**
+
+1. (sample) The next concrete step you'd take this week
+2. (sample) A second step, with its deadline if it has one
+
+### Health
+
+(sample) A few sentences on your current health, energy, sleep — honest, not aspirational.
+
+### Finances
+
+(sample) Your current financial state: income, runway, the number that matters most.
+
+### Relationships
+
+(sample) Where your key relationships stand right now.
 
 ## Ideal State (where you want to be)
 
-- Health: (sample) TBD — the health you're aiming for.
-- Finances: (sample) TBD — the financial state you're aiming for.
-- Creative: (sample) TBD — the creative life you're aiming for.
+### Health
+
+(sample) The health you're aiming for, concrete enough to verify.
+
+**North-star aspiration:** (sample) One sentence naming what this dimension is ultimately for.
+
+### Finances
+
+(sample) The financial state you're aiming for.
+
+**North-star aspiration:** (sample) One sentence naming what money is for in your life.
+
+### Creative
+
+(sample) The creative life you're aiming for.
+
+**North-star aspiration:** (sample) One sentence on why the creative work matters.
 
 ## Mission
 
-- **M0:** (sample) The one-sentence reason you do what you do.
+### M0: (sample) The one-sentence reason you do what you do
+
+**Summary:** (sample) A short paragraph expanding the mission — what it looks like when lived.
 
 ## Problems (the problems in the world you're trying to solve)
 
-- **P0:** (sample) A problem you care about solving.
-- **P1:** (sample) A second problem worth your time.
+- **P0**: (sample) A problem you care about solving.
+- **P1**: (sample) A second problem worth your time.
 
-## GOALS (measurable milestones toward the problems)
+## Goals (measurable milestones toward the problems)
 
-- **G0:** (sample) Ship X by date Y — measurable: <criterion>.
-- **G1:** (sample) Reach <number> of <thing> this year.
+### G0: (sample) Ship X by date Y — measurable: <criterion>
+
+- KPI: (sample) The number you track
+- Target: (sample) The number that means done
+- Progress: 0%
+
+### G1: (sample) Reach <number> of <thing> this year
+
+- Progress: 0%
 
 ## Challenges (things stopping you from hitting your goals)
 
-- **C0:** (sample) A recurring obstacle you face.
-- **C1:** (sample) A second challenge to work on.
+- **C0**: (sample) A recurring obstacle you face.
+- **C1**: (sample) A second challenge to work on.
 
 ## Strategies (how you'll overcome the challenges)
 
-- **S0:** (sample) A concrete strategy you're committing to.
+- **S0**: (sample) A concrete strategy you're committing to.
 
 ## Projects (what you're working on to pursue the strategies)
 
-- **PR0:** (sample) A current project, with its status.
+- **PR0**: (sample) A current project, with its status.
 
 ## Narratives (talking points for talks, panels, posts)
 
-- **N0:** (sample) A story or claim you want to be known for.
+- **N0**: (sample) A story or claim you want to be known for.
 
 ## Wisdom (favorite lessons and aphorisms)
 
 - (sample) A lesson you've learned that guides you.
 
+## Sparks (fuel, not outcomes)
+
+- **(sample) A hobby or practice** — one line on why it refuels you.
+
+- **(sample) A second spark** — goals are outcomes; sparks are the things that refuel you whether or not they produce anything.
+
 ---
-*This file is the canonical TELOS. The DA and Pulse read it directly; the split files in this folder (MISSION.md, GOALS.md, …) are legacy samples that will be superseded as you fill in your real TELOS via the interview.*
+*This file is the canonical TELOS. The DA and Pulse read it directly; the split files in this folder (MISSION.md, GOALS.md, …) are legacy samples that will be superseded as you fill in your real TELOS via the interview. Shape notes: goals are H3 blocks so their `- Progress: N%` bullet can render as a bar; Energy wants an "(N/10)" rating; the `<!-- updated -->` marker feeds the freshness display; sparks are bold-lead bullets.*

--- a/LifeOS/install/USER/TELOS/TELOS.md
+++ b/LifeOS/install/USER/TELOS/TELOS.md
@@ -99,11 +99,5 @@ convention: pai-freshness-v1
 
 - (sample) A lesson you've learned that guides you.
 
-## Sparks (fuel, not outcomes)
-
-- **(sample) A hobby or practice** — one line on why it refuels you.
-
-- **(sample) A second spark** — goals are outcomes; sparks are the things that refuel you whether or not they produce anything.
-
 ---
-*This file is the canonical TELOS. The DA and Pulse read it directly; the split files in this folder (MISSION.md, GOALS.md, …) are legacy samples that will be superseded as you fill in your real TELOS via the interview. Shape notes: goals are H3 blocks so their `- Progress: N%` bullet can render as a bar; Energy wants an "(N/10)" rating; the `<!-- updated -->` marker feeds the freshness display; sparks are bold-lead bullets.*
+*This file is the canonical TELOS. The DA and Pulse read it directly; the split files in this folder (MISSION.md, GOALS.md, …) are legacy samples that will be superseded as you fill in your real TELOS via the interview. Shape notes: goals are H3 blocks so their `- Progress: N%` bullet can render as a bar; Energy wants an "(N/10)" rating; the `<!-- updated -->` marker feeds the freshness display. Sparks live in `SPARKS.md` beside this file (bold-lead bullets under H3 category headings — the Spark card and the morning voice brief both read it); a `## Sparks` section here would take precedence over that file if you prefer one document.*


### PR DESCRIPTION
# Make the TELOS dashboard work out of the box

A fresh install ships a TELOS template whose examples don't match what the dashboard can actually read, so /life and /telos look empty or broken until you dig into the parser source to learn the expected format. This PR fixes both sides: the parsers understand more, and the template's examples now show exactly the format that works.

## What a fresh install gets

- **Goal progress bars.** The goals card has always said "Progress tracking appears once each goal has a progress field," but no code ever read such a field. Now you write `- Progress: 40%` under a goal and get a bar on /life, /telos, and the goal's detail page. Just a hand-typed percent, nothing more to maintain.
- **The Spark card shows actual sparks.** It used to show the section headings (like "Sensory / aesthetic") instead of the entries under them. Sparks are now read from bold bullets: `- **Gardening** — why it refuels you.` The template now also ships a `SPARKS.md` with sample categories (H3 headings) and sparks (bold bullets) — the shape the morning voice brief (`checks/life-morning-brief.ts`, which picks a random H3 from `SPARKS.md`) and the Spark card both read, so both work on a fresh install. A `## Sparks` section in the unified TELOS.md still takes precedence for single-file setups.
- **Sections written in the unified TELOS.md render correctly.** Entries like `### M1: ...` are recognized, the Summary and References labels no longer leak into card text, and a trailing notes block no longer shows up as fake extra entries.
- **The preferences card fills itself** from the Wisdom section and a hobbies file, skipping "(sample)" placeholders.
- **Two small bug fixes.** The owner column in work views never filled in because of a capitalization mismatch, and the /life projects card picked up rows from unrelated tables in PROJECTS.md.
- **The work card shows which project each thread belongs to** (second commit). Items carrying a `Property:` label get one row per project, with the strategy tag and life-area tags read from the item's labels. Boards that don't use those labels look exactly as before.
- **A template that teaches the right format.** The samples in `USER/TELOS/TELOS.md` are rewritten to the exact shapes the parsers read. Replace the words with your own, keep the layout, and the dashboard works on day one. The footer notes the few formats that matter.

## Three behaviors change on purpose

- Sparks are read from bold bullets instead of headings. If you used headings as individual sparks, move those names into bullets.
- The /life projects card reads only the projects section of PROJECTS.md when one exists, instead of scanning every table in the file.
- The work card on /telos groups threads by their `Property:` label when present, instead of always showing one flat "Work in flight" row.

Everything else keeps working as before: legacy per-topic files and bullet-style sections parse the same as they always did.

## Tested

All parser changes run live on the install they came from, and the rewritten template was fed through this branch's own parser functions: every sample renders — goals with bars, sparks, state fields, next actions, and dimensions.

