### PR TITLE
fix(prompt-processing): search the real transcript root in findSessionJsonl

### DIFF
--- a/LifeOS/install/hooks/PromptProcessing.hook.ts
+++ b/LifeOS/install/hooks/PromptProcessing.hook.ts
@@ -671,7 +671,7 @@ function storeName(sessionId: string, label: string, source: string): void {
 /** Find Claude Code's session JSONL path for a given session ID. */
 function findSessionJsonl(sessionId: string): string | null {
   try {
-    for (const dir of [paiPath('projects'), paiPath('Projects')]) {
+    for (const dir of [join(process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude'), 'projects')]) {
       if (!existsSync(dir)) continue;
       const r = Bun.spawnSync(['find', dir, '-maxdepth', '2', '-name', `${sessionId}.jsonl`],
         { stdout: 'pipe', stderr: 'pipe', timeout: 2000 });


### PR DESCRIPTION
Fixes #1931.

`findSessionJsonl` searched `paiPath('projects')`, which resolves to `~/.claude/LIFEOS/projects` — a directory that never exists. Claude Code writes transcripts to `<config dir>/projects`. So the function always returned null, `getCustomTitle` always returned null, and the `/rename` custom-title JSONL sync never fired.

One-line fix: search `process.env.CLAUDE_CONFIG_DIR || ~/.claude` + `/projects` (`join`/`homedir` are already imported). Two other stock files resolve the transcript root this way already.