### PR TITLE
fix(migrate-approve): interpolate the project slug, not the literal placeholder

### DIFF
--- a/LifeOS/install/LIFEOS/TOOLS/MigrateApprove.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/MigrateApprove.ts
@@ -85,8 +85,11 @@ function resolveTargetPath(target: string): string {
     return join(LIFEOS_DIR, target.startsWith("USER/") ? target : target);
   }
   if (target === "memory/feedback") {
-    // Feedback memories live outside LifeOS dir in projects/${HARNESS_USER_DIR}/memory/
-    return join(HOME, ".claude", "projects", "${HARNESS_USER_DIR}", "memory");
+    // Feedback memories live outside the LifeOS dir under projects/<cwd-slug>/memory/.
+    // The slug is derived the same way SessionHarvester.ts does (CLAUDE_DIR path
+    // slugified), never the literal "${HARNESS_USER_DIR}" placeholder.
+    const cwdSlug = join(HOME, ".claude").replace(/[\/.]/g, "-");
+    return join(HOME, ".claude", "projects", cwdSlug, "memory");
   }
   return join(LIFEOS_DIR, target);
 }


### PR DESCRIPTION
Refs #1932. Opened as **draft** — the fix direction is right but the intended slug source needs a maintainer call (see below).

The `memory/feedback` branch returned `join(HOME, '.claude', 'projects', '${HARNESS_USER_DIR}', 'memory')` — the `${...}` sits in a plain double-quoted string and is never interpolated, so the path names a directory literally called `${HARNESS_USER_DIR}` and can never match a real session dir.

This patch derives the slug the way `SessionHarvester.ts` does (`CLAUDE_DIR` path slugified). **Open question:** `SessionHarvester` slugifies `~/.claude` itself; if the feedback path should key off a different cwd, the slug source should change accordingly. Happy to adjust once you confirm the intended value — the issue (#1932) has the full context.