### PR TITLE
Honor CLAUDE_CONFIG_DIR across hooks, tools, and launcher

### DIFF
--- a/LifeOS/Tools/DeployCore.ts
+++ b/LifeOS/Tools/DeployCore.ts
@@ -22,10 +22,11 @@
  *   (dry-run by default — reports the plan per target without writing)
  */
 
-import { existsSync, mkdirSync, readdirSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { copyMissing, detectDevTree } from "./InstallEngine";
+import { atomicWriteText } from "./lib/atomic-write";
 
 // Runtime top-level entries this tool does NOT deploy:
 //  - USER           shipped separately as a scaffold (ScaffoldUser) + symlinked (LinkUser)
@@ -184,7 +185,7 @@ function scaffoldMemory(configRoot: string, apply: boolean): DeployResult {
     if (!apply) {
       r.actions.push(`bun ${generator}`);
     } else {
-      const proc = Bun.spawnSync(["bun", generator], { stdout: "pipe", stderr: "pipe" });
+      const proc = Bun.spawnSync(["bun", generator], { stdout: "pipe", stderr: "pipe", env: { ...process.env, CLAUDE_CONFIG_DIR: configRoot } });
       if (proc.exitCode === 0) r.copied++;
       else r.failures.push(`GenerateKnowledgeSchemaDoc exited ${proc.exitCode}: ${proc.stderr.toString().trim()}`);
     }
@@ -325,6 +326,53 @@ function deployNestedDependencies(payloadInstall: string, configRoot: string, ap
   return r;
 }
 
+/**
+ * (f) system settings layer: install/settings.system.json → configRoot/settings.system.json.
+ *
+ * The gap this fills: settings.json is a GENERATED artifact — the SessionStart MergeSettings
+ * hook rebuilds it every session by merging <configRoot>/settings.system.json (this file) with
+ * the USER overlay, and SettingsBackport + IntegrityCheck read the same path. But no prior Setup
+ * step ever PLACED it — InstallSettings writes the payload's CONTENT into settings.json, never
+ * the source layer itself — so the merge/backport machinery silently had no system source on a
+ * fresh install. Latent on the default ~/.claude; guaranteed to bite a relocated root, which has
+ * no global tree to fall back on. This step deploys the source layer the machinery assumes.
+ *
+ * Relocation: the payload pins `env.LIFEOS_DIR` to "$HOME/.claude/LIFEOS". On a relocated root
+ * that GLOBAL value — re-injected via the regenerated settings.json — would override the
+ * launcher's relocated LIFEOS_DIR and drag LIFEOS-data resolution back to ~/.claude. So we
+ * repoint it at THIS config root on the way in. Default installs keep the shipped string
+ * byte-for-byte. (LIFEOS_CONFIG_DIR is the USER-data location, chosen independently, so it is
+ * left alone.) Additive: never clobbers an existing, possibly user-tuned, system layer.
+ */
+function deploySystemSettings(payloadInstall: string, configRoot: string, apply: boolean): DeployResult {
+  const src = join(payloadInstall, "settings.system.json");
+  const dst = join(configRoot, "settings.system.json");
+  const r: DeployResult = { what: "system-settings", src, dst, present: existsSync(src), copied: 0, actions: [], blockers: [], failures: [] };
+  if (!r.present) {
+    r.blockers.push(`system settings missing: ${src} — point --skill-root at a staged release`);
+    return r;
+  }
+  const relocatedLifeosDir = configRoot === join(process.env.HOME || homedir(), ".claude")
+    ? undefined                                   // default root: ship the payload string as-is
+    : join(configRoot, "LIFEOS");
+  if (existsSync(dst)) return r;                  // additive — never overwrite a populated layer
+  if (!apply) {
+    r.actions.push(relocatedLifeosDir ? `write ${dst} (env.LIFEOS_DIR → ${relocatedLifeosDir})` : `copy ${src} → ${dst}`);
+    return r;
+  }
+  try {
+    const settings = JSON.parse(readFileSync(src, "utf8")) as Record<string, unknown>;
+    if (relocatedLifeosDir && settings.env && typeof settings.env === "object") {
+      (settings.env as Record<string, unknown>).LIFEOS_DIR = relocatedLifeosDir;
+    }
+    atomicWriteText(dst, JSON.stringify(settings, null, 2) + "\n");
+    r.copied = 1;
+  } catch (err) {
+    r.failures.push(`settings.system.json deploy failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  return r;
+}
+
 function main(): void {
   const a = process.argv.slice(2);
   const home = process.env.HOME || homedir();
@@ -349,6 +397,7 @@ function main(): void {
     scaffoldMemory(configRoot, apply),
     deployDependencies(payloadInstall, configRoot, apply),
     deployNestedDependencies(payloadInstall, configRoot, apply),
+    deploySystemSettings(payloadInstall, configRoot, apply),
   ];
 
   // A missing required payload source (blocker) or a copy failure is a hard

--- a/LifeOS/Tools/InstallEngine.ts
+++ b/LifeOS/Tools/InstallEngine.ts
@@ -677,13 +677,34 @@ type MatcherGroup = { matcher?: string; hooks?: HookEntry[]; [k: string]: unknow
 type HooksMap = Record<string, MatcherGroup[]>;
 
 /**
- * Normalize a hook command for dedup: collapse the harness/PAI path-var forms to
- * a single canonical token and squeeze whitespace, so the same hook expressed as
- * `${LIFEOS_DIR}/x`, `$LIFEOS_DIR/x`, or `~/.claude/x` dedupes to one.
+ * Every spelling of the install root, collapsed to one token for dedup. ORDER MATTERS:
+ * the `${CLAUDE_CONFIG_DIR:-…}` default forms must match WHOLE, ahead of the bare
+ * ~/.claude / $HOME/.claude they contain, so an upgrade dedupes a stale `$HOME/.claude/x`
+ * entry against the new templated form of the same hook. LIFEOS_DIR / CLAUDE_PROJECT_DIR /
+ * CLAUDE_PLUGIN_ROOT stay in the set — dropping any would un-dedupe hooks written that way.
+ */
+const ROOT_FORMS: RegExp[] = [
+  /\$\{CLAUDE_CONFIG_DIR:-\$HOME\/\.claude\}/,
+  /\$\{CLAUDE_CONFIG_DIR:-\$\{HOME\}\/\.claude\}/,
+  /\$\{CLAUDE_CONFIG_DIR:-~\/\.claude\}/,
+  /\$\{?CLAUDE_CONFIG_DIR\}?/,
+  /\$\{?LIFEOS_DIR\}?/,
+  /\$\{?CLAUDE_PROJECT_DIR\}?/,
+  /\$\{?CLAUDE_PLUGIN_ROOT\}?/,
+  /~\/\.claude/,
+  /\$HOME\/\.claude/,
+  /\$\{HOME\}\/\.claude/,
+];
+const ROOT_PATTERN = new RegExp(ROOT_FORMS.map((r) => r.source).join("|"), "g");
+
+/**
+ * Normalize a hook command for dedup: collapse any install-root spelling (see ROOT_FORMS)
+ * to `§ROOT§` and squeeze whitespace, so the same hook expressed as `${LIFEOS_DIR}/x`,
+ * `$HOME/.claude/x`, or `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/x` all dedupe to one.
  */
 function normalizeCommand(cmd: string): string {
   return cmd
-    .replace(/\$\{?LIFEOS_DIR\}?|\$\{?CLAUDE_PROJECT_DIR\}?|\$\{?CLAUDE_PLUGIN_ROOT\}?|~\/\.claude|\$HOME\/\.claude|\$\{HOME\}\/\.claude/g, "§ROOT§")
+    .replace(ROOT_PATTERN, "§ROOT§")
     .replace(/\s+/g, " ")
     .trim();
 }

--- a/LifeOS/install/LIFEOS/TOOLS/GenerateKnowledgeSchemaDoc.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/GenerateKnowledgeSchemaDoc.ts
@@ -21,7 +21,13 @@ import {
   RELATION_VOCAB, SOURCE_KINDS, STATUS_VALUES, SCHEMA_VERSION,
 } from "./KnowledgeSchema";
 
-const OUT = pathResolve(homedir(), ".claude/LIFEOS/MEMORY/KNOWLEDGE/_schema.md");
+// Honor CLAUDE_CONFIG_DIR so a relocated install writes the schema under its own
+// config root, not the global ~/.claude. Inlined rather than importing
+// hooks/lib/paths.getClaudeDir(): that helper lives in the HOOKS runtime tree and a
+// LIFEOS/TOOLS script does not reach across into it — sibling TOOLS (Doctor.ts) use
+// this same one-liner, so it is the local convention.
+const CLAUDE_ROOT = process.env.CLAUDE_CONFIG_DIR || pathResolve(homedir(), ".claude");
+const OUT = pathResolve(CLAUDE_ROOT, "LIFEOS/MEMORY/KNOWLEDGE/_schema.md");
 
 /** Absolute path of the generated doc — importers compare against it. */
 export const SCHEMA_DOC_PATH = OUT;

--- a/LifeOS/install/LIFEOS/TOOLS/SettingsBackport.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/SettingsBackport.ts
@@ -51,7 +51,9 @@ import os from "node:os";
 import { mergeSettings, deepEqual, parseJsonFileOrThrow, MERGE_SNAPSHOT_PATH } from "./MergeSettings";
 import { atomicWriteText } from "../PULSE/lib/atomic-write";
 
-const CLAUDE_DIR = path.join(os.homedir(), ".claude");
+// Honor CLAUDE_CONFIG_DIR (matches the install tools and Doctor.ts) so a
+// relocated install backports its OWN settings, not the global ~/.claude.
+const CLAUDE_DIR = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), ".claude");
 const SYSTEM_PATH = path.join(CLAUDE_DIR, "settings.system.json");
 const USER_PATH = path.join(CLAUDE_DIR, "LIFEOS", "USER", "CONFIG", "settings.user.json");
 const GENERATED_PATH = path.join(CLAUDE_DIR, "settings.json");

--- a/LifeOS/install/LIFEOS/TOOLS/lifeos.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/lifeos.ts
@@ -23,17 +23,27 @@
 import { spawn, spawnSync } from "bun";
 import { existsSync, readFileSync, writeFileSync, readdirSync, symlinkSync, unlinkSync, lstatSync } from "fs";
 import { homedir } from "os";
-import { join, basename } from "path";
+import { join, basename, resolve } from "path";
 import { PULSE_BASE } from "../PULSE/endpoint";
 
 // ============================================================================
 // Configuration
 // ============================================================================
 
-const CLAUDE_DIR = join(homedir(), ".claude");
+// The config root this launcher belongs to. It ships at
+// <configRoot>/LIFEOS/TOOLS/lifeos.ts, so it self-locates its own root and
+// exports it as CLAUDE_CONFIG_DIR for the spawned Claude (see launchEnv below) —
+// that is what makes a relocated install actually run inside its own path
+// instead of the global ~/.claude. An explicit CLAUDE_CONFIG_DIR still wins.
+const CLAUDE_DIR = process.env.CLAUDE_CONFIG_DIR || resolve(import.meta.dir, "..", "..");
+// LIFEOS data dir under the resolved root. Computed inline, NOT via the hooks
+// runtime's paths.getLifeosDir(): that helper READS the env vars this launcher is
+// about to SET (LIFEOS_DIR / CLAUDE_CONFIG_DIR), so calling it here would be
+// circular — and it lives in the hooks tree, which a TOOL does not import across into.
+const LIFEOS_DIR = join(CLAUDE_DIR, "LIFEOS");
 const MCP_DIR = join(CLAUDE_DIR, "MCPs");
 const ACTIVE_MCP = join(CLAUDE_DIR, ".mcp.json");
-const BANNER_SCRIPT = join(homedir(), ".claude", "LIFEOS", "TOOLS", "Banner.ts");
+const BANNER_SCRIPT = join(LIFEOS_DIR, "TOOLS", "Banner.ts");
 const VOICE_SERVER = `${PULSE_BASE}/notify/personality`;
 const WALLPAPER_DIR = join(homedir(), "Projects", "Wallpaper");
 // Note: RAW archiving removed - Claude Code handles its own cleanup (30-day retention in projects/)
@@ -434,7 +444,7 @@ function setWallpaper(filename: string): boolean {
  * public PR #1637, @elhoim
  */
 function cmdDoctor(args: string[]) {
-  const doctor = join(CLAUDE_DIR, "LIFEOS", "TOOLS", "Doctor.ts");
+  const doctor = join(LIFEOS_DIR, "TOOLS", "Doctor.ts");
   const result = spawnSync(["bun", doctor, ...args], {
     stdin: "inherit", stdout: "inherit", stderr: "inherit",
   });
@@ -500,7 +510,7 @@ async function cmdLaunch(options: { mcp?: string; resume?: boolean; resumeId?: s
 
   // LifeOS System Prompt — constitutional rules appended to Claude Code's system prompt
   // These rules get highest instruction authority (system prompt layer > CLAUDE.md layer)
-  const systemPromptFile = options.systemPrompt ?? join(CLAUDE_DIR, "LIFEOS", "LIFEOS_SYSTEM_PROMPT.md");
+  const systemPromptFile = options.systemPrompt ?? join(LIFEOS_DIR, "LIFEOS_SYSTEM_PROMPT.md");
   if (existsSync(systemPromptFile)) {
     args.push("--append-system-prompt-file", systemPromptFile);
   }
@@ -561,6 +571,10 @@ async function cmdLaunch(options: { mcp?: string; resume?: boolean; resumeId?: s
   const launchEnv = { ...process.env };
   delete launchEnv.ANTHROPIC_API_KEY;
   launchEnv.CLAUDE_CODE_WORKFLOWS = "1";
+  // Pin Claude Code and every hook to THIS config root, so a relocated install
+  // resolves settings, skills, hooks, and LIFEOS data inside its own path.
+  launchEnv.CLAUDE_CONFIG_DIR = CLAUDE_DIR;
+  launchEnv.LIFEOS_DIR = LIFEOS_DIR;
   const proc = spawn(args, {
     stdio: ["inherit", "inherit", "inherit"],
     env: launchEnv,
@@ -701,7 +715,7 @@ async function cmdPrompt(prompt: string) {
 
   // Same constitutional layer as interactive launches — without this, one-shots
   // ran bare Claude Code (CLAUDE.md only, no output format, no security protocol).
-  const systemPromptFile = join(CLAUDE_DIR, "LIFEOS", "LIFEOS_SYSTEM_PROMPT.md");
+  const systemPromptFile = join(LIFEOS_DIR, "LIFEOS_SYSTEM_PROMPT.md");
   if (existsSync(systemPromptFile)) {
     args.push("--append-system-prompt-file", systemPromptFile);
   }
@@ -711,6 +725,9 @@ async function cmdPrompt(prompt: string) {
   const env: Record<string, string> = { ...process.env } as Record<string, string>;
   delete env.ANTHROPIC_API_KEY;
   env.CLAUDE_CODE_WORKFLOWS = "1";
+  // Pin Claude Code and every hook to THIS config root (see interactive launch).
+  env.CLAUDE_CONFIG_DIR = CLAUDE_DIR;
+  env.LIFEOS_DIR = LIFEOS_DIR;
   const proc = spawn(args, {
     stdio: ["inherit", "inherit", "inherit"],
     env,

--- a/LifeOS/install/hooks/AgentInvocation.hook.ts
+++ b/LifeOS/install/hooks/AgentInvocation.hook.ts
@@ -58,8 +58,7 @@
 
 import { existsSync, mkdirSync, appendFileSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
-import { homedir } from 'os';
-import { paiPath } from './lib/paths';
+import { paiPath, getClaudeDir } from './lib/paths';
 import { getISOTimestamp } from './lib/time';
 import { EFFORT_MODEL, CROSS_VENDOR } from '../LIFEOS/TOOLS/models';
 import { liveModel } from './ModelRungGuard.hook';
@@ -89,7 +88,7 @@ function resolveDispatch(subagentType: string, inputModel?: string): { model: st
   if (CROSS_VENDOR[cvKey]) return { model: CROSS_VENDOR[cvKey], level: 'cross-vendor' };
   if (inputModel) return { model: inputModel, level: levelForModel(inputModel) };
   try {
-    const fm = readFileSync(join(homedir(), '.claude', 'agents', `${subagentType}.md`), 'utf-8').slice(0, 4000);
+    const fm = readFileSync(join(getClaudeDir(), 'agents', `${subagentType}.md`), 'utf-8').slice(0, 4000);
     const m = fm.match(/^model:\s*(\S+)/m);
     if (m) return { model: m[1], level: `${levelForModel(m[1])}-pin` };
   } catch { /* no agent file — built-in type */ }

--- a/LifeOS/install/hooks/AlgorithmNudge.hook.ts
+++ b/LifeOS/install/hooks/AlgorithmNudge.hook.ts
@@ -66,9 +66,9 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync, statSy
 import { join } from 'path';
 import { resolveBun } from './lib/resolve-bin';
 import { deriveAscent, type AscentState } from '../LIFEOS/TOOLS/ascent';
-import { homedir } from "node:os";
+import { getClaudeDir, getLifeosDir } from './lib/paths';
 
-const PAI = join(homedir(), '.claude');
+const PAI = getClaudeDir();
 // Overridable so tests can PRODUCE a state-machine edge instead of hand-writing
 // its precondition, and so test runs stop appending to the production diagnostic
 // log (Forge delta audit H-B, M-E — the log was 7 lines, all of them test noise).
@@ -456,7 +456,7 @@ function loadIndex(): SkillIndex | null {
       // self-heal must leave a trace something can see.
       try {
         appendFileSync(
-          join(homedir(), '.claude/LIFEOS/MEMORY/OBSERVABILITY/hook-selfheal.jsonl'),
+          join(getLifeosDir(), 'MEMORY/OBSERVABILITY/hook-selfheal.jsonl'),
           JSON.stringify({ ts: new Date().toISOString(), hook: 'AlgorithmNudge', action: 'rebuild-index', bun, error: String(e) }) + '\n',
         );
       } catch { /* observability write itself is best-effort */ }

--- a/LifeOS/install/hooks/BashSystemWriteGuard.hook.ts
+++ b/LifeOS/install/hooks/BashSystemWriteGuard.hook.ts
@@ -28,9 +28,10 @@
 import { homedir } from "node:os";
 import { resolve, join } from "node:path";
 import { classifyTarget, loadPatterns, scanForFirstHit } from "./lib/system-file-guard-core";
+import { getClaudeDir } from './lib/paths';
 
 const HOME = process.env.HOME ?? homedir();
-const CLAUDE_ROOT = join(HOME, ".claude");
+const CLAUDE_ROOT = getClaudeDir();
 
 interface HookInput {
   tool_input?: { command?: unknown };

--- a/LifeOS/install/hooks/CheckpointPerISC.hook.ts
+++ b/LifeOS/install/hooks/CheckpointPerISC.hook.ts
@@ -24,6 +24,7 @@ import { readFileSync, existsSync, writeFileSync, statSync, realpathSync, mkdirS
 import { execFileSync } from 'node:child_process';
 import { basename, dirname, join } from 'node:path';
 import { homedir } from 'node:os';
+import { getClaudeDir, getLifeosDir, getSkillsDir } from './lib/paths';
 import { parseFrontmatter, parseCriteriaList, ARTIFACT_FILENAME, LEGACY_ARTIFACT_FILENAME } from './lib/isa-utils';
 import { isForeignToSystemRepo, looksLikePersonalTranscript } from '../LIFEOS/TOOLS/lib/ForeignDataCheck';
 
@@ -31,7 +32,7 @@ import { isForeignToSystemRepo, looksLikePersonalTranscript } from '../LIFEOS/TO
 // '#' comments and blank
 // lines are ignored. Tilde and $HOME prefixes are expanded as a quality-of-
 // life feature so users can write `~/Projects/foo` instead of the long form.
-const ALLOWLIST_PATH = join(homedir(), '.claude', 'checkpoint-repos.txt');
+const ALLOWLIST_PATH = join(getClaudeDir(), 'checkpoint-repos.txt');
 const GIT_TIMEOUT_MS = 5000;
 
 interface CheckpointState {
@@ -154,7 +155,7 @@ function runTouchedPaths(repo: string, startedMs: number): string[] {
   });
 }
 
-const SYSTEM_REPO = join(homedir(), '.claude');
+const SYSTEM_REPO = getClaudeDir();
 
 function isSystemRepo(repo: string): boolean {
   try { return realpathSync(repo) === realpathSync(SYSTEM_REPO); }
@@ -244,9 +245,9 @@ async function main() {
   // dir — skill trees must stay publishable-clean and the sidecar carries
   // absolute paths + SHAs, which trips SkillHygieneGate (found 2026-08-11,
   // interview-evidence upgrade). Everything else keeps the beside-the-ISA path.
-  const skillsPrefix = join(homedir(), '.claude', 'skills') + '/';
+  const skillsPrefix = getSkillsDir() + '/';
   const inSkillTree = slugDir.startsWith(skillsPrefix);
-  const skillStateDir = join(homedir(), '.claude', 'LIFEOS', 'MEMORY', 'STATE', 'checkpoints');
+  const skillStateDir = join(getLifeosDir(), 'MEMORY', 'STATE', 'checkpoints');
   if (inSkillTree) mkdirSync(skillStateDir, { recursive: true });
   const stateFile = inSkillTree
     ? join(skillStateDir, `skill-${slug}.checkpoint-state.json`)

--- a/LifeOS/install/hooks/ConfigEvalFire.hook.ts
+++ b/LifeOS/install/hooks/ConfigEvalFire.hook.ts
@@ -19,10 +19,10 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
 import { spawn } from 'node:child_process';
 import { dirname, resolve } from 'node:path';
-import { homedir } from 'node:os';
 import { isSubagentContext as isSubagent } from './lib/subagent';
+import { getClaudeDir } from './lib/paths';
 
-const CLAUDE_ROOT = resolve(homedir(), '.claude');
+const CLAUDE_ROOT = getClaudeDir();
 const RUNNER = resolve(CLAUDE_ROOT, 'LIFEOS/TOOLS/ConfigEvalOnChange.ts');
 const STATE = resolve(CLAUDE_ROOT, 'LIFEOS/MEMORY/OBSERVABILITY/config-eval-state.json');
 const DEBOUNCE_MINUTES = 5;

--- a/LifeOS/install/hooks/DeployRegistrationGate.hook.ts
+++ b/LifeOS/install/hooks/DeployRegistrationGate.hook.ts
@@ -27,13 +27,12 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
-import { homedir } from "os";
 import { readHookInput, parseTranscriptFromInput } from "./lib/hook-io";
+import { getLifeosDir } from './lib/paths';
 
-const HOME = homedir();
-const PROJECTS_MD = join(HOME, ".claude/LIFEOS/USER/PROJECTS.md");
-const INVENTORY_TS = join(HOME, ".claude/LIFEOS/USER/CUSTOMIZATIONS/ARBOL/Shared/infra-inventory.ts");
-const STATE_DIR = join(HOME, ".claude/LIFEOS/MEMORY/STATE");
+const PROJECTS_MD = join(getLifeosDir(), "USER/PROJECTS.md");
+const INVENTORY_TS = join(getLifeosDir(), "USER/CUSTOMIZATIONS/ARBOL/Shared/infra-inventory.ts");
+const STATE_DIR = join(getLifeosDir(), "MEMORY/STATE");
 const STATE_PATH = join(STATE_DIR, "deploy-registration-gate.json");
 
 // wrangler deploy trigger lines: `  <domain> (custom domain)` — wrangler emits

--- a/LifeOS/install/hooks/DriftReminder.hook.ts
+++ b/LifeOS/install/hooks/DriftReminder.hook.ts
@@ -39,7 +39,7 @@ for (const __k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
 import { existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { firstBannedHit } from "./lib/banned-vocab";
-import { homedir } from "node:os";
+import { getLifeosDir } from './lib/paths';
 
 // Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
 for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
@@ -70,7 +70,7 @@ const DEFAULT_LINE_CAP = 15;
 // The principal asking for depth lifts the cap. His explicit call outranks the
 // default; nothing else does.
 const DEPTH_RE = /\b(extensive|thorough|comprehensive|exhaustive|deep[\s-]?dive|in[\s-]depth|detailed|long[\s-]form|full (?:analysis|report|breakdown|write[\s-]?up)|go deep|be verbose|everything (?:you|we) (?:know|have))\b/i;
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(homedir(), ".claude", "LIFEOS");
+const LIFEOS_DIR = getLifeosDir();
 const LAST_RESPONSE_PATH = join(LIFEOS_DIR, "MEMORY", "STATE", "last-response.txt");
 const STATE_PATH = join(LIFEOS_DIR, "MEMORY", "STATE", "drift-reminder.json");
 const INITIAL_STATE: DriftState = {

--- a/LifeOS/install/hooks/EgressClassGuard.hook.ts
+++ b/LifeOS/install/hooks/EgressClassGuard.hook.ts
@@ -20,11 +20,10 @@
 
 import { readFileSync, appendFileSync, existsSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { homedir } from "node:os";
 import { evaluateEgress } from "./lib/egress-class-core";
+import { getLifeosDir } from './lib/paths';
 
-const HOME = process.env.HOME ?? homedir();
-const LOG_PATH = join(HOME, ".claude/LIFEOS/MEMORY/OBSERVABILITY/egress-decisions.jsonl");
+const LOG_PATH = join(getLifeosDir(), "MEMORY/OBSERVABILITY/egress-decisions.jsonl");
 
 interface HookInput {
   session_id?: string;

--- a/LifeOS/install/hooks/FormatGate.hook.ts
+++ b/LifeOS/install/hooks/FormatGate.hook.ts
@@ -38,7 +38,7 @@
 import { readHookInput, parseTranscriptFromInput } from "./lib/hook-io";
 import { appendFileSync, existsSync, mkdirSync } from "fs";
 import { dirname, join } from "path";
-import { homedir } from "node:os";
+import { getLifeosDir } from './lib/paths';
 
 // Normalize env path vars Claude Code injects without shell expansion (LifeOS#1404)
 for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
@@ -46,7 +46,7 @@ for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
   if (v && /^\$\{?HOME\}?(\/|$)/.test(v)) process.env[k] = v.replace(/^\$\{?HOME\}?/, process.env.HOME ?? "~");
 }
 
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(homedir(), ".claude", "LIFEOS");
+const LIFEOS_DIR = getLifeosDir();
 const OBS_PATH = join(LIFEOS_DIR, "MEMORY", "OBSERVABILITY", "format-gate.jsonl");
 
 export interface FormatViolation {

--- a/LifeOS/install/hooks/HookHealer.hook.ts
+++ b/LifeOS/install/hooks/HookHealer.hook.ts
@@ -36,8 +36,9 @@ import {
 } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
+import { getClaudeDir } from './lib/paths';
 
-const CLAUDE_DIR = join(homedir(), '.claude');
+const CLAUDE_DIR = getClaudeDir();
 const OBS_DIR = join(CLAUDE_DIR, 'LIFEOS', 'MEMORY', 'OBSERVABILITY');
 const LOG_FILE = join(OBS_DIR, 'hook-healer.jsonl');
 const SETTINGS_FILES = ['settings.json', 'settings.local.json'];

--- a/LifeOS/install/hooks/ISACloseGate.hook.ts
+++ b/LifeOS/install/hooks/ISACloseGate.hook.ts
@@ -34,9 +34,9 @@ import { findActiveSessionByUUID } from "./lib/isa-utils";
 import { appendFileSync, mkdirSync, existsSync, readFileSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import { createHash } from "crypto";
-import { homedir } from "node:os";
+import { getLifeosDir } from './lib/paths';
 
-const LIFEOS = process.env.LIFEOS_DIR || join(homedir(), ".claude", "LIFEOS");
+const LIFEOS = getLifeosDir();
 const OBS_PATH = join(LIFEOS, "MEMORY", "OBSERVABILITY", "isa-close-gate.jsonl");
 const STATE_PATH = join(LIFEOS, "MEMORY", "STATE", "isa-close-gate-blocked.json");
 const NUDGE_STATE_DIR = join(LIFEOS, "MEMORY", "STATE", "isa-nudge");

--- a/LifeOS/install/hooks/ISAFoldGate.hook.ts
+++ b/LifeOS/install/hooks/ISAFoldGate.hook.ts
@@ -35,9 +35,9 @@ import { findActiveSessionByUUID } from "./lib/isa-utils";
 import { isaEditedThisTurn, ISA_ADDRESSED_RE } from "./ISACloseGate.hook";
 import { appendFileSync, mkdirSync } from "fs";
 import { dirname, join } from "path";
-import { homedir } from "node:os";
+import { getLifeosDir } from './lib/paths';
 
-const LIFEOS = process.env.LIFEOS_DIR || join(homedir(), ".claude", "LIFEOS");
+const LIFEOS = getLifeosDir();
 const OBS_PATH = join(LIFEOS, "MEMORY", "OBSERVABILITY", "isa-fold-gate.jsonl");
 
 /** Prod-mutating command shapes. Conservative and explicit: each one is a class this

--- a/LifeOS/install/hooks/ISARenderOnStop.hook.ts
+++ b/LifeOS/install/hooks/ISARenderOnStop.hook.ts
@@ -20,11 +20,11 @@
 
 import { readFileSync, existsSync, unlinkSync } from 'fs';
 import { spawn } from 'child_process';
-import { homedir } from 'os';
 import { join, dirname } from 'path';
+import { getLifeosDir } from './lib/paths';
 
-const STATE_DIR = join(homedir(), '.claude/LIFEOS/MEMORY/STATE/isa-render-debounce');
-const ISA_RENDER = join(homedir(), '.claude/LIFEOS/TOOLS/ISARender.ts');
+const STATE_DIR = join(getLifeosDir(), 'MEMORY/STATE/isa-render-debounce');
+const ISA_RENDER = join(getLifeosDir(), 'TOOLS/ISARender.ts');
 
 /**
  * Has this ISA reached completion at least once? This is the real gate the
@@ -109,7 +109,7 @@ try { unlinkSync(stateFile); } catch {}
 if (rendered.length || skipped.length) {
   try {
     const { appendFileSync, mkdirSync } = require('fs');
-    const logDir = join(homedir(), '.claude/LIFEOS/MEMORY/OBSERVABILITY');
+    const logDir = join(getLifeosDir(), 'MEMORY/OBSERVABILITY');
     mkdirSync(logDir, { recursive: true });
     appendFileSync(join(logDir, 'isa-render.jsonl'),
       JSON.stringify({

--- a/LifeOS/install/hooks/ISAStaleWriteGuard.hook.ts
+++ b/LifeOS/install/hooks/ISAStaleWriteGuard.hook.ts
@@ -50,11 +50,11 @@ import {
   writeFileSync,
 } from "node:fs";
 import { basename, join } from "node:path";
-import { homedir } from "node:os";
+import { getLifeosDir } from './lib/paths';
 
 type BlockResult = { block: true; message: string } | null;
 
-const STATE_DIR = join(homedir(), ".claude/LIFEOS/MEMORY/STATE/isa-session-view");
+const STATE_DIR = join(getLifeosDir(), "MEMORY/STATE/isa-session-view");
 const PRUNE_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
 
 /**

--- a/LifeOS/install/hooks/ISASync.hook.ts
+++ b/LifeOS/install/hooks/ISASync.hook.ts
@@ -33,8 +33,8 @@
 
 import { readFileSync, existsSync } from 'fs';
 import { spawn } from 'child_process';
-import { homedir } from 'os';
 import { join } from 'path';
+import { getLifeosDir } from './lib/paths';
 import {
   parseFrontmatter,
   syncToWorkJson,
@@ -155,7 +155,7 @@ async function main(): Promise<string | null> {
   let stripDelta: string | null = null;
   if (input.session_id && fm.slug && !isSubagentContext()) {
     try {
-      const stripDir = join(homedir(), '.claude/LIFEOS/MEMORY/STATE/ascent-strip');
+      const stripDir = join(getLifeosDir(), 'MEMORY/STATE/ascent-strip');
       const stripFile = join(stripDir, `${String(input.session_id).replace(/[^\w-]/g, '')}.json`);
       let prev: { slug?: string; state?: string } = {};
       if (existsSync(stripFile)) {
@@ -183,7 +183,7 @@ async function main(): Promise<string | null> {
   //    constantly remaking the HTML file."
   if (newPhase === 'COMPLETE' && oldPhase !== 'COMPLETE' && fm.slug) {
     try {
-      const isaRender = join(homedir(), '.claude/LIFEOS/TOOLS/ISARender.ts');
+      const isaRender = join(getLifeosDir(), 'TOOLS/ISARender.ts');
       const proc = spawn('bun', [isaRender, isaPath], {
         detached: true,
         stdio: 'ignore',
@@ -200,7 +200,7 @@ async function main(): Promise<string | null> {
   // pre-completion edits never trigger renders even though they show up here.
   if (input.session_id) {
     try {
-      const stateDir = join(homedir(), '.claude/LIFEOS/MEMORY/STATE/isa-render-debounce');
+      const stateDir = join(getLifeosDir(), 'MEMORY/STATE/isa-render-debounce');
       const stateFile = join(stateDir, `${input.session_id}.json`);
       const { mkdirSync, writeFileSync } = require('fs');
       mkdirSync(stateDir, { recursive: true });

--- a/LifeOS/install/hooks/LastResponseCache.hook.ts
+++ b/LifeOS/install/hooks/LastResponseCache.hook.ts
@@ -22,7 +22,7 @@ for (const __k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
 import { readHookInput, parseTranscriptFromInput } from './lib/hook-io';
 import { writeFileSync } from 'fs';
 import { join } from 'path';
-import { homedir } from "node:os";
+import { getLifeosDir } from './lib/paths';
 
 // Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
 for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
@@ -44,7 +44,7 @@ async function main() {
 
   if (lastResponse) {
     try {
-      const paiDir = process.env.LIFEOS_DIR || join(homedir(), '.claude', 'LIFEOS');
+      const paiDir = getLifeosDir();
       const cachePath = join(paiDir, 'MEMORY', 'STATE', 'last-response.txt');
       writeFileSync(cachePath, lastResponse.slice(0, 2000), 'utf-8');
     } catch (err) {

--- a/LifeOS/install/hooks/LoadMemory.hook.ts
+++ b/LifeOS/install/hooks/LoadMemory.hook.ts
@@ -22,11 +22,11 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { resolve as pathResolve } from "node:path";
-import { homedir } from "node:os";
 import { isSubagentContext as isSubagentInvocation } from './lib/subagent';
 import { parseMemoryContent } from "../LIFEOS/TOOLS/MemoryWriter";
+import { getClaudeDir } from './lib/paths';
 
-const CLAUDE_ROOT = pathResolve(homedir(), ".claude");
+const CLAUDE_ROOT = getClaudeDir();
 const PRINCIPAL_MEMORY = pathResolve(CLAUDE_ROOT, "LIFEOS/USER/PRINCIPAL/PRINCIPAL_MEMORY.md");
 const DA_MEMORY = pathResolve(CLAUDE_ROOT, "LIFEOS/USER/DIGITAL_ASSISTANT/DA_MEMORY.md");
 

--- a/LifeOS/install/hooks/MemoryDeltaSurface.hook.ts
+++ b/LifeOS/install/hooks/MemoryDeltaSurface.hook.ts
@@ -32,10 +32,10 @@
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync } from "node:fs";
 import { resolve as pathResolve, dirname } from "node:path";
-import { homedir } from "node:os";
 import { isSubagentContext as isSubagent } from './lib/subagent';
+import { getClaudeDir } from './lib/paths';
 
-const CLAUDE_ROOT = pathResolve(homedir(), ".claude");
+const CLAUDE_ROOT = getClaudeDir();
 const WRITES_LOG = pathResolve(CLAUDE_ROOT, "LIFEOS/MEMORY/OBSERVABILITY/memory-writes.jsonl");
 const CURSOR = pathResolve(CLAUDE_ROOT, "LIFEOS/MEMORY/OBSERVABILITY/memory-delta-cursor.json");
 const HEALTH_LOG = pathResolve(CLAUDE_ROOT, "LIFEOS/MEMORY/OBSERVABILITY/memory-health.jsonl");
@@ -153,7 +153,7 @@ function criticalHealthLine(): string | null {
       .filter((f: any) => f.severity === "critical")
       .map((f: any) => f.message)
       .slice(0, 3);
-    return `🩺 MEMORY HEALTH: CRITICAL — ${blockers.join(" · ") || `${last.counts?.critical ?? "?"} blocker(s)`}. Fix: bun ~/.claude/LIFEOS/TOOLS/MemoryHealthCheck.ts`;
+    return `🩺 MEMORY HEALTH: CRITICAL — ${blockers.join(" · ") || `${last.counts?.critical ?? "?"} blocker(s)`}. Fix: bun ${pathResolve(CLAUDE_ROOT, "LIFEOS/TOOLS/MemoryHealthCheck.ts")}`;
   } catch {
     return null;
   }

--- a/LifeOS/install/hooks/MemoryHealthGate.hook.ts
+++ b/LifeOS/install/hooks/MemoryHealthGate.hook.ts
@@ -16,10 +16,9 @@
 
 import { execFileSync } from "node:child_process";
 import { join } from "node:path";
-import { homedir } from "node:os";
+import { getLifeosDir } from './lib/paths';
 
-const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
-const CHECK = join(HOME, ".claude/LIFEOS/TOOLS/MemoryHealthCheck.ts");
+const CHECK = join(getLifeosDir(), "TOOLS/MemoryHealthCheck.ts");
 
 try {
   const out = execFileSync("bun", [CHECK], {
@@ -29,7 +28,7 @@ try {
   });
   const report = JSON.parse(out);
   if (report.overall === "critical") {
-    console.error(`🚨 Memory health: CRITICAL — ${report.counts.critical} blocker(s). Run: bun ~/.claude/LIFEOS/TOOLS/MemoryHealthCheck.ts`);
+    console.error(`🚨 Memory health: CRITICAL — ${report.counts.critical} blocker(s). Run: bun ${CHECK}`);
   } else if (report.overall === "warn") {
     console.error(`⚠️  Memory health: WARN — ${report.counts.warn} finding(s).`);
   }
@@ -42,7 +41,7 @@ try {
     if (stdout) {
       const report = JSON.parse(stdout);
       if (report.overall === "critical") {
-        console.error(`🚨 Memory health: CRITICAL — ${report.counts.critical} blocker(s). Run: bun ~/.claude/LIFEOS/TOOLS/MemoryHealthCheck.ts`);
+        console.error(`🚨 Memory health: CRITICAL — ${report.counts.critical} blocker(s). Run: bun ${CHECK}`);
       } else if (report.overall === "warn") {
         console.error(`⚠️  Memory health: WARN — ${report.counts.warn} finding(s).`);
       }

--- a/LifeOS/install/hooks/MemoryReviewFire.hook.ts
+++ b/LifeOS/install/hooks/MemoryReviewFire.hook.ts
@@ -41,10 +41,10 @@
 import { appendFileSync, existsSync, mkdirSync, readdirSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { spawn } from "node:child_process";
 import { dirname, join, resolve as pathResolve } from "node:path";
-import { homedir } from "node:os";
 import { isSubagentContext as isSubagent } from './lib/subagent';
+import { getClaudeDir } from './lib/paths';
 
-const CLAUDE_ROOT = pathResolve(homedir(), ".claude");
+const CLAUDE_ROOT = getClaudeDir();
 const STATE_PATH = pathResolve(CLAUDE_ROOT, "LIFEOS/MEMORY/OBSERVABILITY/review-state.json");
 const SESSION_STATE_DIR = pathResolve(CLAUDE_ROOT, "LIFEOS/MEMORY/STATE/memory-review");
 const CONFIG_PATH = pathResolve(CLAUDE_ROOT, "LIFEOS/USER/CONFIG/memory-review.json");

--- a/LifeOS/install/hooks/MemoryTurnStart.hook.ts
+++ b/LifeOS/install/hooks/MemoryTurnStart.hook.ts
@@ -35,8 +35,8 @@ import { clearLedger as clearSystemDelta } from "./SystemChangeSurface.hook";
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { resolve as pathResolve } from "node:path";
-import { homedir } from "node:os";
 import { isSubagentContext as isSubagent } from './lib/subagent';
+import { getClaudeDir } from './lib/paths';
 
 // ── Hot-layer injection gate (2026-07-11, context-window cleanup #1) ─────────
 // The <lifeos-memory> block is ~1.5K tokens; injecting it EVERY prompt duplicated
@@ -45,7 +45,7 @@ import { isSubagentContext as isSubagent } from './lib/subagent';
 // prompts without an injection (compaction backstop — a post-compact window
 // must re-see memory within a bounded number of turns). The 🧠 delta line and
 // the cadence tick remain every-turn: the visible contract is unchanged.
-const CLAUDE_ROOT = pathResolve(homedir(), ".claude");
+const CLAUDE_ROOT = getClaudeDir();
 const STATE_DIR = pathResolve(CLAUDE_ROOT, "LIFEOS/MEMORY/STATE/memory-inject");
 const PRINCIPAL_MEMORY = pathResolve(CLAUDE_ROOT, "LIFEOS/USER/PRINCIPAL/PRINCIPAL_MEMORY.md");
 const DA_MEMORY = pathResolve(CLAUDE_ROOT, "LIFEOS/USER/DIGITAL_ASSISTANT/DA_MEMORY.md");

--- a/LifeOS/install/hooks/ModelRungGuard.hook.ts
+++ b/LifeOS/install/hooks/ModelRungGuard.hook.ts
@@ -37,11 +37,10 @@ for (const __k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
 
 import { appendFileSync, closeSync, existsSync, mkdirSync, openSync, readFileSync, readSync, statSync } from "node:fs";
 import { join } from "node:path";
-import { homedir } from "node:os";
+import { getClaudeDir } from './lib/paths';
 
 const STDIN_TIMEOUT_MS = 300;
-const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
-const CLAUDE_ROOT = join(HOME, ".claude");
+const CLAUDE_ROOT = getClaudeDir();
 const LIFEOS_DIR = process.env.LIFEOS_DIR || join(CLAUDE_ROOT, "LIFEOS");
 const SETTINGS_PATH = join(CLAUDE_ROOT, "settings.json");
 const LOG_PATH = join(LIFEOS_DIR, "MEMORY", "OBSERVABILITY", "model-rung.jsonl");

--- a/LifeOS/install/hooks/PromptProcessing.hook.ts
+++ b/LifeOS/install/hooks/PromptProcessing.hook.ts
@@ -43,11 +43,10 @@ import { inference } from '../LIFEOS/TOOLS/Inference';
 import { getIdentity, getPrincipal } from './lib/identity';
 import { isValidWorkingTitle, getWorkingFallback, trimToValidTitle } from './lib/output-validators';
 import { getSessionOneWord, readTabState, setAscentTab } from './lib/tab-setter';
-import { paiPath } from './lib/paths';
+import { paiPath, getClaudeDir, getLifeosDir } from './lib/paths';
 import { updateSessionNameInWorkJson, upsertSession } from './lib/isa-utils';
 import { isDesktopChannel, logSkippedVoice, getNotificationChannel } from './lib/notification-channel';
 import { PULSE_BASE } from '../LIFEOS/PULSE/endpoint';
-import { homedir } from "node:os";
 
 // Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
 for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
@@ -82,7 +81,7 @@ function appendPromptProcessingTelemetry(entry: Record<string, unknown>): void {
 
 // ── Constants ──
 
-const BASE_DIR = process.env.LIFEOS_DIR || join(homedir(), '.claude', 'LIFEOS');
+const BASE_DIR = getLifeosDir();
 const SESSION_NAMES_PATH = paiPath('MEMORY', 'STATE', 'session-names.json');
 const LOCK_PATH = SESSION_NAMES_PATH + '.lock';
 const MIN_PROMPT_LENGTH = 3;
@@ -859,7 +858,7 @@ function isKnownCommandOrSkill(token: string): boolean {
   const lower = token.toLowerCase();
   try {
     const { readdirSync } = require('fs') as typeof import('fs');
-    const claudeDir = join(homedir(), '.claude');
+    const claudeDir = getClaudeDir();
     for (const f of readdirSync(join(claudeDir, 'commands'))) {
       if (f.toLowerCase() === `${lower}.md`) return true;
     }

--- a/LifeOS/install/hooks/PublicPushGate.hook.ts
+++ b/LifeOS/install/hooks/PublicPushGate.hook.ts
@@ -26,10 +26,11 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, dirname } from "node:path";
+import { getLifeosDir } from './lib/paths';
 
 const HOME = process.env.HOME ?? homedir();
-const PATTERN_FILE = join(HOME, ".claude/LIFEOS/USER/SECURITY/PublicScrubPatterns.txt");
-const CACHE_FILE = join(HOME, ".claude/LIFEOS/MEMORY/STATE/public-push-gate.json");
+const PATTERN_FILE = join(getLifeosDir(), "USER/SECURITY/PublicScrubPatterns.txt");
+const CACHE_FILE = join(getLifeosDir(), "MEMORY/STATE/public-push-gate.json");
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 const HISTORY_SCAN_MAX_COMMITS = 400;
 

--- a/LifeOS/install/hooks/ReminderRouter.hook.ts
+++ b/LifeOS/install/hooks/ReminderRouter.hook.ts
@@ -25,10 +25,9 @@ import { getDAName } from "./lib/identity"
 import { createHash } from "crypto";
 import { join, dirname } from "path";
 import { loadWorkConfig } from "./lib/work-config";
-import { homedir } from "node:os";
+import { getLifeosDir } from './lib/paths';
 
-const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
-const STATE_PATH = join(HOME, ".claude", "LIFEOS", "MEMORY", "STATE", "reminder-router-seen.json");
+const STATE_PATH = join(getLifeosDir(), "MEMORY", "STATE", "reminder-router-seen.json");
 
 interface HookInput {
   session_id?: string;

--- a/LifeOS/install/hooks/Safety.hook.ts
+++ b/LifeOS/install/hooks/Safety.hook.ts
@@ -40,7 +40,7 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
-import { homedir } from "node:os";
+import { getLifeosDir } from './lib/paths';
 import { join } from "node:path";
 import { createHash } from "node:crypto";
 import {
@@ -54,13 +54,7 @@ import { SECRET_VALUE_SHAPES } from "./lib/egress-class-core";
 const STDIN_CAP_BYTES = 2 * 1024 * 1024;
 const CACHE_MAX_BYTES = 10 * 1024 * 1024;
 
-const HOME = homedir();
-const LIFEOS_DIR = process.env.LIFEOS_DIR
-  ? process.env.LIFEOS_DIR.replace(/^~(?=\/|$)/, HOME).replace(
-      /^\$\{?HOME\}?(?=\/|$)/,
-      HOME,
-    )
-  : join(HOME, ".claude", "LIFEOS");
+const LIFEOS_DIR = getLifeosDir();
 const STATE_DIR = join(LIFEOS_DIR, "MEMORY", "STATE");
 const OBS_DIR = join(LIFEOS_DIR, "MEMORY", "OBSERVABILITY");
 const CACHE_PATH = join(STATE_DIR, "permission-cache.json");

--- a/LifeOS/install/hooks/SatisfactionCapture.hook.ts
+++ b/LifeOS/install/hooks/SatisfactionCapture.hook.ts
@@ -45,7 +45,7 @@ import { getISOTimestamp, getPSTComponents } from './lib/time';
 import { captureFailure } from '../LIFEOS/TOOLS/FailureCapture';
 import { addUpgrade } from '../LIFEOS/TOOLS/Upgrades';
 import { addRatingPulse } from './lib/isa-utils';
-import { homedir } from "node:os";
+import { getLifeosDir } from './lib/paths';
 
 // Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
 for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
@@ -77,7 +77,7 @@ interface RatingEntry {
 
 // ── Constants ──
 
-const BASE_DIR = process.env.LIFEOS_DIR || join(homedir(), '.claude', 'LIFEOS');
+const BASE_DIR = getLifeosDir();
 const SIGNALS_DIR = join(BASE_DIR, 'MEMORY', 'LEARNING', 'SIGNALS');
 const RATINGS_FILE = join(SIGNALS_DIR, 'ratings.jsonl');
 const LAST_RESPONSE_CACHE = join(BASE_DIR, 'MEMORY', 'STATE', 'last-response.txt');

--- a/LifeOS/install/hooks/SessionCleanup.hook.ts
+++ b/LifeOS/install/hooks/SessionCleanup.hook.ts
@@ -46,7 +46,7 @@ import { join } from 'path';
 import { getISOTimestamp } from './lib/time';
 import { setTabState, cleanupKittySession } from './lib/tab-setter';
 import { readRegistry, writeRegistry, findArtifactPath, findActiveSessionByUUID, applyAscent } from './lib/isa-utils';
-import { homedir } from "node:os";
+import { getLifeosDir } from './lib/paths';
 
 // Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
 for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
@@ -55,7 +55,7 @@ for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
 }
 
 
-const BASE_DIR = process.env.LIFEOS_DIR || join(homedir(), '.claude', 'LIFEOS');
+const BASE_DIR = getLifeosDir();
 const MEMORY_DIR = join(BASE_DIR, 'MEMORY');
 const STATE_DIR = join(MEMORY_DIR, 'STATE');
 const WORK_DIR = join(MEMORY_DIR, 'WORK');

--- a/LifeOS/install/hooks/SystemChangeSurface.hook.ts
+++ b/LifeOS/install/hooks/SystemChangeSurface.hook.ts
@@ -42,7 +42,7 @@
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { resolve as pathResolve, dirname } from "node:path";
-import { homedir } from "node:os";
+import { getClaudeDir } from './lib/paths';
 /** The line is for the principal's primary session. Subagents write plenty of
  *  system files (a delegate editing a skill, a fork editing an ISA) and would
  *  each emit their own line into their own context, which helps nobody. */
@@ -54,7 +54,7 @@ import {
   type ChangeEntry,
 } from "./lib/system-surfaces";
 
-const CLAUDE_ROOT = pathResolve(process.env.HOME ?? homedir(), ".claude");
+const CLAUDE_ROOT = getClaudeDir();
 const LEDGER_DIR = pathResolve(CLAUDE_ROOT, "LIFEOS/MEMORY/STATE");
 
 interface LedgerEntry extends ChangeEntry {

--- a/LifeOS/install/hooks/SystemFileGuard.hook.ts
+++ b/LifeOS/install/hooks/SystemFileGuard.hook.ts
@@ -22,12 +22,11 @@
 
 import { readFileSync, appendFileSync, existsSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { homedir } from "node:os";
 import { evaluateWrite, extractNewContent } from "./lib/system-file-guard-core";
 import { parseHookStdin, asWriteToolInput, isString } from "./lib/hook-input";
+import { getLifeosDir } from './lib/paths';
 
-const HOME = process.env.HOME ?? homedir();
-const LOG_PATH = join(HOME, ".claude/LIFEOS/MEMORY/OBSERVABILITY/system-file-guard.jsonl");
+const LOG_PATH = join(getLifeosDir(), "MEMORY/OBSERVABILITY/system-file-guard.jsonl");
 
 interface HookInput {
   session_id?: string;

--- a/LifeOS/install/hooks/TimeContext.hook.ts
+++ b/LifeOS/install/hooks/TimeContext.hook.ts
@@ -16,12 +16,12 @@
  * without the line — a timestamp is nice-to-have, never worth blocking.
  */
 import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
+import { getSettingsPath } from './lib/paths';
 
 try {
   let TZ = "UTC";
   try {
-    const s = JSON.parse(readFileSync(`${homedir()}/.claude/settings.json`, "utf8"));
+    const s = JSON.parse(readFileSync(getSettingsPath(), "utf8"));
     if (s?.principal?.timezone) TZ = s.principal.timezone;
   } catch {
     // keep UTC

--- a/LifeOS/install/hooks/VerificationGate.hook.ts
+++ b/LifeOS/install/hooks/VerificationGate.hook.ts
@@ -55,9 +55,9 @@ import {
 import { appendFileSync, mkdirSync, existsSync, readFileSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import { createHash } from "crypto";
-import { homedir } from "node:os";
+import { getLifeosDir } from './lib/paths';
 
-const LIFEOS = process.env.LIFEOS_DIR || join(homedir(), ".claude", "LIFEOS");
+const LIFEOS = getLifeosDir();
 const OBS_PATH = join(LIFEOS, "MEMORY", "OBSERVABILITY", "verification-gate.jsonl");
 const STATE_PATH = join(LIFEOS, "MEMORY", "STATE", "verification-gate-blocked.json");
 

--- a/LifeOS/install/hooks/VersionDrift.hook.ts
+++ b/LifeOS/install/hooks/VersionDrift.hook.ts
@@ -19,10 +19,10 @@
  */
 import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
-import { homedir } from "node:os";
 import { join, dirname } from "node:path";
+import { getClaudeDir } from './lib/paths';
 
-const CLAUDE_DIR = join(homedir(), ".claude");
+const CLAUDE_DIR = getClaudeDir();
 const VERSION_FILE = join(CLAUDE_DIR, "LIFEOS", "VERSION");
 const STATE_FILE = join(CLAUDE_DIR, "LIFEOS", "MEMORY", "STATE", "version-drift-nag.json");
 

--- a/LifeOS/install/hooks/WorkCompletionLearning.hook.ts
+++ b/LifeOS/install/hooks/WorkCompletionLearning.hook.ts
@@ -62,7 +62,7 @@ import { join } from 'path';
 import { getISOTimestamp, getPSTDate } from './lib/time';
 import { getLearningCategory } from './lib/learning-utils';
 import { findArtifactPath, findActiveSessionByUUID } from './lib/isa-utils';
-import { homedir } from "node:os";
+import { getLifeosDir } from './lib/paths';
 
 // Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
 for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
@@ -71,7 +71,7 @@ for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
 }
 
 
-const BASE_DIR = process.env.LIFEOS_DIR || join(homedir(), '.claude', 'LIFEOS');
+const BASE_DIR = getLifeosDir();
 const MEMORY_DIR = join(BASE_DIR, 'MEMORY');
 const WORK_DIR = join(MEMORY_DIR, 'WORK');
 const LEARNING_DIR = join(MEMORY_DIR, 'LEARNING');

--- a/LifeOS/install/hooks/WritingGate.hook.ts
+++ b/LifeOS/install/hooks/WritingGate.hook.ts
@@ -37,7 +37,7 @@ import { readHookInput, parseTranscriptFromInput } from "./lib/hook-io";
 import { appendFileSync, mkdirSync, existsSync, readFileSync } from "fs";
 import { createHash } from "crypto";
 import { dirname, join } from "path";
-import { homedir } from "node:os";
+import { getLifeosDir, getEnvPath } from './lib/paths';
 
 // Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
 for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
@@ -46,7 +46,7 @@ for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
 }
 
 
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(homedir(), ".claude", "LIFEOS");
+const LIFEOS_DIR = getLifeosDir();
 const OBS_PATH = join(LIFEOS_DIR, "MEMORY", "OBSERVABILITY", "writing-gate.jsonl");
 const RUNS_PATH = join(LIFEOS_DIR, "MEMORY", "OBSERVABILITY", "pangram-runs.jsonl");
 const RUN_WINDOW_MS = 30 * 60 * 1000; // a run counts as "this turn" within 30 min
@@ -127,7 +127,7 @@ function freshRuns(): RunRec[] {
 function detectorAvailable(): boolean {
   if (process.env.PANGRAM_API_KEY) return true;
   try {
-    const env = readFileSync(join(homedir(), ".claude", ".env"), "utf8");
+    const env = readFileSync(getEnvPath(), "utf8");
     return env.split("\n").some((l) => {
       if (!l.startsWith("PANGRAM_API_KEY=")) return false;
       return l.slice("PANGRAM_API_KEY=".length).replace(/^["']|["']$/g, "").trim().length > 0;

--- a/LifeOS/install/hooks/handlers/UpdateCounts.ts
+++ b/LifeOS/install/hooks/handlers/UpdateCounts.ts
@@ -21,8 +21,7 @@
 import { readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { execSync } from 'child_process';
-import { getLifeosDir } from '../lib/paths';
-import { homedir } from "node:os";
+import { getLifeosDir, getClaudeDir } from '../lib/paths';
 
 /**
  * Refresh usage cache from Anthropic OAuth API.
@@ -40,7 +39,7 @@ async function refreshUsageCache(paiDir: string): Promise<void> {
         { encoding: 'utf-8', timeout: 3000 }
       ).trim();
     } else {
-      const credPath = join(homedir(), '.claude', '.credentials.json');
+      const credPath = join(getClaudeDir(), '.credentials.json');
       credJson = readFileSync(credPath, 'utf-8').trim();
     }
 

--- a/LifeOS/install/hooks/hooks.json
+++ b/LifeOS/install/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/ContextReduction.hook.sh"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/ContextReduction.hook.sh"
           }
         ]
       },
@@ -28,7 +28,7 @@
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/AgentInvocation.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/AgentInvocation.hook.ts"
           }
         ]
       },
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/TabState.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/TabState.hook.ts"
           }
         ]
       },
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/PreToolGuard.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/PreToolGuard.hook.ts"
           }
         ]
       }
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/AgentInvocation.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/AgentInvocation.hook.ts"
           }
         ]
       },
@@ -66,7 +66,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/Safety.hook.ts",
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/Safety.hook.ts",
             "timeout": 5
           }
         ]
@@ -76,7 +76,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/Safety.hook.ts",
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/Safety.hook.ts",
             "timeout": 5
           }
         ]
@@ -86,7 +86,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/Safety.hook.ts",
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/Safety.hook.ts",
             "timeout": 5
           }
         ]
@@ -96,7 +96,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/Safety.hook.ts",
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/Safety.hook.ts",
             "timeout": 5
           }
         ]
@@ -106,7 +106,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/TabState.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/TabState.hook.ts"
           }
         ]
       },
@@ -115,7 +115,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/ISAStaleWriteGuard.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/ISAStaleWriteGuard.hook.ts"
           }
         ]
       },
@@ -124,34 +124,34 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/ISASync.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/ISASync.hook.ts"
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/ISAStaleWriteGuard.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/ISAStaleWriteGuard.hook.ts"
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/CheckpointPerISC.hook.ts",
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/CheckpointPerISC.hook.ts",
             "timeout": 30
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/ConfigEvalFire.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/ConfigEvalFire.hook.ts"
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/AtlasEventCapture.hook.ts",
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/AtlasEventCapture.hook.ts",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/KnowledgeWriteGuard.hook.ts",
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/KnowledgeWriteGuard.hook.ts",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/ComplexityRatchet.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/ComplexityRatchet.hook.ts"
           }
         ]
       },
@@ -160,34 +160,34 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/ISASync.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/ISASync.hook.ts"
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/ISAStaleWriteGuard.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/ISAStaleWriteGuard.hook.ts"
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/CheckpointPerISC.hook.ts",
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/CheckpointPerISC.hook.ts",
             "timeout": 30
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/ConfigEvalFire.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/ConfigEvalFire.hook.ts"
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/AtlasEventCapture.hook.ts",
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/AtlasEventCapture.hook.ts",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/KnowledgeWriteGuard.hook.ts",
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/KnowledgeWriteGuard.hook.ts",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/ComplexityRatchet.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/ComplexityRatchet.hook.ts"
           }
         ]
       },
@@ -196,34 +196,34 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/ISASync.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/ISASync.hook.ts"
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/ISAStaleWriteGuard.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/ISAStaleWriteGuard.hook.ts"
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/CheckpointPerISC.hook.ts",
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/CheckpointPerISC.hook.ts",
             "timeout": 30
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/ConfigEvalFire.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/ConfigEvalFire.hook.ts"
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/AtlasEventCapture.hook.ts",
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/AtlasEventCapture.hook.ts",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/KnowledgeWriteGuard.hook.ts",
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/KnowledgeWriteGuard.hook.ts",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/ComplexityRatchet.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/ComplexityRatchet.hook.ts"
           }
         ]
       },
@@ -231,7 +231,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/EventLogger.hook.ts",
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/EventLogger.hook.ts",
             "timeout": 5,
             "async": true
           }
@@ -242,11 +242,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/PostToolObserver.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/PostToolObserver.hook.ts"
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/LoopDetector.hook.ts",
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/LoopDetector.hook.ts",
             "timeout": 5
           }
         ]
@@ -256,7 +256,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/AtlasEventCapture.hook.ts",
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/AtlasEventCapture.hook.ts",
             "timeout": 5
           }
         ]
@@ -267,27 +267,27 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/WorkCompletionLearning.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/WorkCompletionLearning.hook.ts"
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/SessionCleanup.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/SessionCleanup.hook.ts"
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/UpdateCounts.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/UpdateCounts.hook.ts"
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/MemoryHealthGate.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/MemoryHealthGate.hook.ts"
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/DocIntegrity.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/DocIntegrity.hook.ts"
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/IntegrityCheck.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/IntegrityCheck.hook.ts"
           }
         ]
       }
@@ -297,7 +297,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/PromptProcessing.hook.ts",
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/PromptProcessing.hook.ts",
             "timeout": 30,
             "async": true
           }
@@ -307,7 +307,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/SatisfactionCapture.hook.ts",
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/SatisfactionCapture.hook.ts",
             "timeout": 20,
             "async": true
           }
@@ -317,7 +317,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/ReminderRouter.hook.ts",
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/ReminderRouter.hook.ts",
             "timeout": 5,
             "async": true
           }
@@ -327,7 +327,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/VersionDrift.hook.ts",
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/VersionDrift.hook.ts",
             "timeout": 10,
             "async": true
           }
@@ -337,7 +337,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/MemoryTurnStart.hook.ts",
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/MemoryTurnStart.hook.ts",
             "timeout": 8
           }
         ]
@@ -347,7 +347,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/DriftReminder.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/DriftReminder.hook.ts"
           }
         ]
       },
@@ -356,7 +356,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/AlgorithmNudge.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/AlgorithmNudge.hook.ts"
           }
         ]
       },
@@ -364,7 +364,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/TimeContext.hook.ts",
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/TimeContext.hook.ts",
             "timeout": 5,
             "async": true
           }
@@ -374,7 +374,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/ModelRungGuard.hook.ts",
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/ModelRungGuard.hook.ts",
             "timeout": 5,
             "async": true
           }
@@ -386,7 +386,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/EventLogger.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/EventLogger.hook.ts"
           }
         ]
       },
@@ -394,7 +394,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/AlgorithmNudge.hook.ts",
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/AlgorithmNudge.hook.ts",
             "timeout": 5
           }
         ]
@@ -403,7 +403,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/LoopDetector.hook.ts",
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/LoopDetector.hook.ts",
             "timeout": 5
           }
         ]
@@ -414,7 +414,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/TaskGovernance.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/TaskGovernance.hook.ts"
           }
         ]
       }
@@ -424,7 +424,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/EventLogger.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/EventLogger.hook.ts"
           }
         ]
       }
@@ -434,26 +434,26 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun $HOME/.claude/hooks/HookHealer.hook.ts",
+            "command": "bun ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/HookHealer.hook.ts",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/KittyEnvPersist.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/KittyEnvPersist.hook.ts"
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/LoadContext.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/LoadContext.hook.ts"
           },
           {
             "type": "command",
-            "command": "bun $HOME/.claude/LIFEOS/TOOLS/FreshnessCache.ts --quiet",
+            "command": "bun ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/LIFEOS/TOOLS/FreshnessCache.ts --quiet",
             "timeout": 5,
             "async": true
           },
           {
             "type": "command",
-            "command": "bun $HOME/.claude/LIFEOS/TOOLS/SettingsBackport.ts; bun $HOME/.claude/LIFEOS/TOOLS/MergeSettings.ts --system $HOME/.claude/settings.system.json --user $HOME/.claude/LIFEOS/USER/CONFIG/settings.user.json --output $HOME/.claude/settings.json",
+            "command": "bun ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/LIFEOS/TOOLS/SettingsBackport.ts; bun ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/LIFEOS/TOOLS/MergeSettings.ts --system ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.system.json --user ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/LIFEOS/USER/CONFIG/settings.user.json --output ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json",
             "timeout": 15,
             "async": true
           }
@@ -465,31 +465,31 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/LastResponseCache.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/LastResponseCache.hook.ts"
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/TabState.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/TabState.hook.ts"
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/VoiceCompletion.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/VoiceCompletion.hook.ts"
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/ISARenderOnStop.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/ISARenderOnStop.hook.ts"
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/SpendAuditor.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/SpendAuditor.hook.ts"
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/StopGates.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/StopGates.hook.ts"
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/MemoryReviewFire.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/MemoryReviewFire.hook.ts"
           }
         ]
       },
@@ -497,7 +497,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/MemoryHealthGate.hook.ts",
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/MemoryHealthGate.hook.ts",
             "timeout": 15,
             "async": true
           }
@@ -509,7 +509,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/EventLogger.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/EventLogger.hook.ts"
           }
         ]
       }
@@ -520,7 +520,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/Safety.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/Safety.hook.ts"
           }
         ]
       },
@@ -529,7 +529,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/Safety.hook.ts"
+            "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/Safety.hook.ts"
           }
         ]
       }

--- a/LifeOS/install/hooks/lib/identity.ts
+++ b/LifeOS/install/hooks/lib/identity.ts
@@ -22,11 +22,9 @@ import {
   type LifeosDa,
   type LifeosPrincipal,
 } from '../../LIFEOS/TOOLS/LifeosConfig';
-import { homedir } from "node:os";
+import { getSettingsPath, getLifeosDir } from './paths';
 
-// HOME ?? USERPROFILE: Windows defines only the latter (public issue #1694, @dissembler21-png)
-const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
-const SETTINGS_PATH = join(HOME, '.claude/settings.json');
+const SETTINGS_PATH = getSettingsPath();
 
 // Identity-file paths derive from LifeosConfig's userDir. On fresh installs where
 // LIFEOS_CONFIG.toml hasn't been created yet, fall back to the conventional
@@ -36,7 +34,7 @@ function paiUserDir(): string {
   try {
     return loadLifeosConfig().paths.userDir;
   } catch {
-    return join(HOME, '.claude/LIFEOS/USER');
+    return join(getLifeosDir(), 'USER');
   }
 }
 const DA_IDENTITY_PATH = join(paiUserDir(), 'DIGITAL_ASSISTANT/DA_IDENTITY.md');

--- a/LifeOS/install/hooks/lib/notifications.ts
+++ b/LifeOS/install/hooks/lib/notifications.ts
@@ -7,10 +7,9 @@
 
 import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { join } from 'path';
-import { homedir } from "node:os";
+import { getLifeosDir } from './paths';
 
-const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
-const PULSE_TOML_PATH = join(HOME, '.claude/LIFEOS/PULSE/PULSE.toml');
+const PULSE_TOML_PATH = join(getLifeosDir(), 'PULSE/PULSE.toml');
 
 // ============================================================================
 // Session Timing

--- a/LifeOS/install/hooks/lib/paths.ts
+++ b/LifeOS/install/hooks/lib/paths.ts
@@ -31,7 +31,8 @@ export function expandPath(path: string): string {
  * Priority:
  *   1. CLAUDE_PLUGIN_ROOT (plugin install) → <root>/PAI
  *   2. LIFEOS_DIR env var (expanded)
- *   3. ~/.claude/LIFEOS  (live default — byte-identical to pre-plugin behavior)
+ *   3. <getClaudeDir()>/LIFEOS — honors CLAUDE_CONFIG_DIR, else ~/.claude/LIFEOS
+ *      (live default — byte-identical to pre-plugin behavior)
  *
  * The CLAUDE_PLUGIN_ROOT guard MUST precede the LIFEOS_DIR check: in a packed
  * plugin, bin/pai exports LIFEOS_DIR equal to CLAUDE_PLUGIN_ROOT (the flattened
@@ -51,22 +52,35 @@ export function getLifeosDir(): string {
     return expandPath(envLifeosDir);
   }
 
-  return join(homedir(), '.claude', 'LIFEOS');
+  return join(getClaudeDir(), 'LIFEOS');
 }
 
 /**
  * Get the Claude Code home directory.
  *
- * Plugin install: CLAUDE_PLUGIN_ROOT is the flattened plugin root that plays the
- * live ~/.claude role (skills/ and hooks/ sit directly under it, matching live
- * .claude/skills and .claude/hooks). Live default: ~/.claude — byte-identical to
- * pre-plugin behavior, since CLAUDE_PLUGIN_ROOT is unset on a normal install.
+ * Priority:
+ *   1. CLAUDE_PLUGIN_ROOT (plugin install) — the flattened plugin root that
+ *      plays the live ~/.claude role (skills/ and hooks/ sit directly under it,
+ *      matching live .claude/skills and .claude/hooks).
+ *   2. CLAUDE_CONFIG_DIR (relocated config root) — the same relocation the
+ *      install tools and every other runtime module already honor (Doctor.ts,
+ *      PULSE Conduit/paths.ts). Without it the hooks pin to ~/.claude even under
+ *      a relocated install, so their commands resolve to the global dir (none of
+ *      the copied scripts) and MergeSettings rewrites the global settings.json.
+ *   3. ~/.claude — live default, byte-identical to pre-plugin behavior since
+ *      neither env var is set on a normal install.
  */
 export function getClaudeDir(): string {
   const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
 
   if (pluginRoot) {
     return expandPath(pluginRoot);
+  }
+
+  const configDir = process.env.CLAUDE_CONFIG_DIR;
+
+  if (configDir) {
+    return expandPath(configDir);
   }
 
   return join(homedir(), '.claude');

--- a/LifeOS/install/hooks/lib/safety-classifier.ts
+++ b/LifeOS/install/hooks/lib/safety-classifier.ts
@@ -1,5 +1,6 @@
 import { homedir } from "node:os";
 import { resolve } from "node:path";
+import { getClaudeDir } from "./paths";
 
 export type Decision = "allow" | "neutral";
 
@@ -32,7 +33,7 @@ export interface ToolCall {
 const HOME = homedir();
 
 export const TRUSTED_PREFIXES: readonly string[] = [
-  resolve(HOME, ".claude"),
+  getClaudeDir(),
   resolve(HOME, "Projects"),
   resolve(HOME, "LocalProjects"),
   resolve(HOME, "Downloads"),

--- a/LifeOS/install/hooks/lib/system-file-guard-core.ts
+++ b/LifeOS/install/hooks/lib/system-file-guard-core.ts
@@ -12,12 +12,11 @@
 
 import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
-import { homedir } from "node:os";
 import { createHash } from "node:crypto";
 import { isContained, isPatternAllowlisted, relativeToClaudeRoot } from "./containment-zones";
+import { getClaudeDir } from "./paths";
 
-const HOME = process.env.HOME ?? homedir();
-const CLAUDE_ROOT = join(HOME, ".claude");
+const CLAUDE_ROOT = getClaudeDir();
 const DEFAULT_DENY_LIST_PATH = join(CLAUDE_ROOT, "LIFEOS/USER/SECURITY/DENY_LIST.txt");
 // USER/SECURITY, not skills/_LIFEOS: on a public install, running the shipped
 // DeriveDenyHashes used to CREATE <your-release-skill>/, whose existence is exactly

--- a/LifeOS/install/hooks/lib/work-config.ts
+++ b/LifeOS/install/hooks/lib/work-config.ts
@@ -34,7 +34,7 @@ for (const __k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { atomicWriteText } from "../../LIFEOS/PULSE/lib/atomic-write";
-import { homedir } from "node:os";
+import { getLifeosDir } from "./paths";
 
 // Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
 for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
@@ -45,8 +45,7 @@ for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
 
 declare const Bun: { spawnSync: (cmd: string[], opts?: any) => any };
 
-const HOME = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
-const LIFEOS_DIR = process.env.LIFEOS_DIR || join(HOME, ".claude", "LIFEOS");
+const LIFEOS_DIR = getLifeosDir();
 const REPO_JSON_PATH = join(LIFEOS_DIR, "USER", "WORK", "work_repo.json");
 const COLUMNS_YAML_PATH = join(LIFEOS_DIR, "USER", "WORK", "config.yaml");
 


### PR DESCRIPTION
LifeOS hooks and install tools hardcoded `~/.claude`, so an install under a relocated config root (`--config-root` / `CLAUDE_CONFIG_DIR`) copied files into its own root but resolved them against the global `~/.claude`.

Worse, a SessionStart `MergeSettings` hook would rewrite the GLOBAL `settings.json` from inside a relocated install.

This routes all 36 hooks and the install tooling through the resolved config root, has the `lifeos` launcher export `CLAUDE_CONFIG_DIR` so a relocated install actually runs in its own path, and closes two latent gaps: `settings.system.json` was never deployed, and the upgrade merge did not dedup the new templated command form. Default installs are byte-identical.

---

- 543f20e **fix: honor CLAUDE_CONFIG_DIR across hooks, tools, and launcher**
  - Route every hook, install tool, and the launcher through the resolved config root.
  - Deploy the missing `settings.system.json` (repointed on relocation) and dedup the upgrade path.