### PR TITLE
fix(hooks): detect subagents from hook stdin (agent_id / agent_type, SessionStart source=fork), drop the fork feature-flag test

### DIFF
--- a/LifeOS/install/hooks/ConfigEvalFire.hook.ts
+++ b/LifeOS/install/hooks/ConfigEvalFire.hook.ts
@@ -41,15 +41,17 @@ function isSentinel(path: string): boolean {
   return /(^|\/)CLAUDE\.md$/.test(path);
 }
 
-function readInput(): { filePath: string | null } {
+// `input` is the whole parsed payload — the subagent guard reads its agent stamp,
+// which is the only marker a forked subagent sets (see lib/subagent.ts).
+function readInput(): { filePath: string | null; input: unknown } {
   try {
     const raw = readFileSync(0, 'utf8');
-    if (!raw.trim()) return { filePath: null };
+    if (!raw.trim()) return { filePath: null, input: null };
     const j = JSON.parse(raw);
     const fp = j?.tool_input?.file_path;
-    return { filePath: typeof fp === 'string' ? fp : null };
+    return { filePath: typeof fp === 'string' ? fp : null, input: j };
   } catch {
-    return { filePath: null };
+    return { filePath: null, input: null };
   }
 }
 
@@ -76,9 +78,9 @@ function saveLastFire(iso: string): void {
 
 function main(): void {
   try {
-    if (isSubagent()) process.exit(0);
+    const { filePath, input } = readInput();
+    if (isSubagent(input)) process.exit(0);
 
-    const { filePath } = readInput();
     if (!filePath || !isSentinel(filePath)) process.exit(0);
     if (minutesSince(loadLastFire()) < DEBOUNCE_MINUTES) process.exit(0);
     if (!existsSync(RUNNER)) process.exit(0);

--- a/LifeOS/install/hooks/ISASync.hook.ts
+++ b/LifeOS/install/hooks/ISASync.hook.ts
@@ -153,7 +153,7 @@ async function main(): Promise<string | null> {
   // without a phase edit. Per-session dedupe file; subagents never emit (their
   // ISA edits would strip-spam their own contexts, which helps nobody).
   let stripDelta: string | null = null;
-  if (input.session_id && fm.slug && !isSubagentContext()) {
+  if (input.session_id && fm.slug && !isSubagentContext(input)) {
     try {
       const stripDir = join(homedir(), '.claude/LIFEOS/MEMORY/STATE/ascent-strip');
       const stripFile = join(stripDir, `${String(input.session_id).replace(/[^\w-]/g, '')}.json`);

--- a/LifeOS/install/hooks/KittyEnvPersist.hook.ts
+++ b/LifeOS/install/hooks/KittyEnvPersist.hook.ts
@@ -20,21 +20,24 @@ import { isSubagentContext } from './lib/subagent';
 
 const paiDir = getLifeosDir();
 
-// Skip for subagents
-if (isSubagentContext()) process.exit(0);
-
 // Read session_id + source from stdin (SessionStart hook input)
-// source ∈ {"startup", "resume", "compact", "clear"}; absent on older CC versions.
+// source ∈ {"startup", "resume", "compact", "clear", "fork"}; absent on older CC versions.
 let sessionId = '';
 let source = '';
+let parsed: unknown = null;
 try {
   const raw = readFileSync(0, 'utf-8');
   if (raw) {
-    const parsed = JSON.parse(raw);
-    sessionId = String(parsed.session_id || '');
-    source = String(parsed.source || '');
+    const json = JSON.parse(raw);
+    parsed = json;
+    sessionId = String(json.session_id || '');
+    source = String(json.source || '');
   }
 } catch { /* best-effort */ }
+
+// Skip for subagents — a fork announces itself as `source: "fork"` on stdin and
+// nowhere in the env, so this reads the payload above (see lib/subagent.ts).
+if (isSubagentContext(parsed)) process.exit(0);
 
 // Persist Kitty environment for hooks that run later without terminal context
 const kittyListenOn = process.env.KITTY_LISTEN_ON;

--- a/LifeOS/install/hooks/LoadContext.hook.ts
+++ b/LifeOS/install/hooks/LoadContext.hook.ts
@@ -462,8 +462,16 @@ async function checkActiveProgress(paiDir: string): Promise<string | null> {
 
 async function main() {
   try {
+    // A fork carries no distinguishing env var — its stamp (`source: "fork"`)
+    // arrives on stdin, so read it before the guard (see lib/subagent.ts).
+    let hookInput: unknown = null;
+    try {
+      const raw = readFileSync(0, 'utf-8');
+      if (raw.trim()) hookInput = JSON.parse(raw);
+    } catch { /* best-effort: env-only guard below */ }
+
     // Subagents don't need dynamic context injection
-    if (isSubagentContext()) {
+    if (isSubagentContext(hookInput)) {
       console.error('🤖 Subagent session - skipping context loading');
       process.exit(0);
     }

--- a/LifeOS/install/hooks/MemoryReviewFire.hook.ts
+++ b/LifeOS/install/hooks/MemoryReviewFire.hook.ts
@@ -200,18 +200,21 @@ function logFire(payload: Record<string, unknown>): void {
  * fired. Read it so the reviewer analyzes THIS session's transcript instead
  * of guessing via globally-newest-mtime, which grabs a concurrent session's
  * transcript whenever two sessions overlap (public issue #1495, @christauff).
+ * `input` is the whole payload — the subagent guard reads its agent stamp,
+ * the only marker a forked subagent sets (see lib/subagent.ts).
  */
-function readHookInput(): { sessionId: string | null; transcriptPath: string | null } {
+function readHookInput(): { sessionId: string | null; transcriptPath: string | null; input: unknown } {
   try {
     const raw = readFileSync(0, "utf8");
-    if (!raw.trim()) return { sessionId: null, transcriptPath: null };
+    if (!raw.trim()) return { sessionId: null, transcriptPath: null, input: null };
     const j = JSON.parse(raw);
     return {
       sessionId: typeof j.session_id === "string" ? j.session_id : null,
       transcriptPath: typeof j.transcript_path === "string" ? j.transcript_path : null,
+      input: j,
     };
   } catch {
-    return { sessionId: null, transcriptPath: null };
+    return { sessionId: null, transcriptPath: null, input: null };
   }
 }
 
@@ -240,9 +243,9 @@ function spawnReviewer(turnsReviewed: number, transcriptPath: string | null): { 
 
 function main(): void {
   try {
-    if (isSubagent()) process.exit(0);
+    const { sessionId, transcriptPath, input } = readHookInput();
+    if (isSubagent(input)) process.exit(0);
 
-    const { sessionId, transcriptPath } = readHookInput();
     const nowMs = Date.now();
     const now = new Date(nowMs).toISOString();
     const config = loadConfig();

--- a/LifeOS/install/hooks/MemoryTurnStart.hook.ts
+++ b/LifeOS/install/hooks/MemoryTurnStart.hook.ts
@@ -88,16 +88,20 @@ async function readStdin(): Promise<string> {
   });
 }
 
-if (isSubagent()) process.exit(0);
-
 (async () => {
   let sessionId = "unknown";
   let prompt = "";
+  let input: any = null;
   try {
-    const input = JSON.parse(await readStdin());
+    input = JSON.parse(await readStdin());
     sessionId = input.session_id || "unknown";
     prompt = typeof input.prompt === "string" ? input.prompt : "";
   } catch {}
+
+  // The skip lives here, after stdin, because a fork is only distinguishable by
+  // the agent stamp on the payload — its env is its parent's (see lib/subagent.ts).
+  // Unparseable stdin still proceeds: the guard falls back to the env union.
+  if (isSubagent(input)) process.exit(0);
 
   // Turn boundary for the ⚙️ SYSTEM surface. It lives here because this is the
   // ONE UserPromptSubmit composer, so it needs no new settings.json entry — and

--- a/LifeOS/install/hooks/SystemChangeSurface.hook.ts
+++ b/LifeOS/install/hooks/SystemChangeSurface.hook.ts
@@ -71,6 +71,9 @@ export interface HookInput {
   session_id?: string;
   tool_name?: string;
   tool_input?: { file_path?: string };
+  /** Subagent stamp on hook input — a forked subagent carries "fork". */
+  agent_id?: string;
+  agent_type?: string;
 }
 
 const WRITE_TOOLS = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
@@ -113,7 +116,7 @@ function writeLedger(path: string, ledger: Ledger): void {
 
 export function run(input: HookInput): string | null {
   try {
-    if (isSubagent()) return null;
+    if (isSubagent(input)) return null;
     const tool = input.tool_name ?? "";
     if (!WRITE_TOOLS.has(tool)) return null;
     const filePath = input.tool_input?.file_path;

--- a/LifeOS/install/hooks/lib/hook-io.ts
+++ b/LifeOS/install/hooks/lib/hook-io.ts
@@ -30,6 +30,12 @@ export interface HookInput {
    * VerificationGate.hook.ts for canonical usage.
    */
   stop_hook_active?: boolean;
+  /** Present only on subagent hook input — the delegate's id. */
+  agent_id?: string;
+  /** Present only on subagent hook input; a forked subagent carries "fork". */
+  agent_type?: string;
+  /** SessionStart only: startup | resume | clear | compact | fork. */
+  source?: string;
 }
 
 /**

--- a/LifeOS/install/hooks/lib/subagent.ts
+++ b/LifeOS/install/hooks/lib/subagent.ts
@@ -17,20 +17,41 @@
  * surface line) into a delegate, while a false positive would suppress context
  * in a main session. Verified 2026-07-28 in a main session — every marker below
  * is unset, so the union cannot false-positive there.
+ *
+ * Env markers cannot see a FORK: a fork's environment is byte-identical to its
+ * parent's, and CLAUDE_CODE_FORK_SUBAGENT is the feature-ENABLE flag every modern
+ * interactive session carries, so testing it read every main session as a subagent
+ * (#1864, #1911; that row is removed here, matching PR #1942). The authoritative
+ * marker is the hook's stdin stamp — `agent_id`/`agent_type` (a fork arrives as
+ * `agent_type: "fork"`), and SessionStart's `source: "fork"`. Consumers holding
+ * parsed stdin pass it in; the env union stays the fallback, and #1831 stays shut.
  */
 
-/** True when this process is a subagent/delegate rather than the main session. */
-export function isSubagentContext(): boolean {
+/** True when hook stdin carries the harness's subagent stamp (fork included). */
+export function isSubagentHookInput(input: unknown): boolean {
+  if (typeof input !== 'object' || input === null) return false;
+  const stamp = input as Record<string, unknown>;
+  const named = (v: unknown): boolean => typeof v === 'string' && v.length > 0;
+  return Boolean(
+    named(stamp.agent_id) ||
+      named(stamp.agent_type) ||
+      (stamp.hook_event_name === 'SessionStart' && stamp.source === 'fork'),
+  );
+}
+
+/**
+ * True when this process is a subagent/delegate rather than the main session.
+ * Pass the hook's parsed stdin when it is already in hand — it is the only
+ * signal a fork sets.
+ */
+export function isSubagentContext(input?: unknown): boolean {
   const projectDir = process.env.CLAUDE_PROJECT_DIR || '';
   return Boolean(
     projectDir.includes('/.claude/Agents/') ||
       process.env.CLAUDE_AGENT_TYPE ||
       process.env.CLAUDE_CODE_SUBAGENT_NAME ||
       process.env.CLAUDE_CODE_SUBAGENT_TYPE ||
-      // Forked subagents set ONLY the fork marker — none of the above.
-      // Without it, 8 hook consumers re-inject main-session context into
-      // forks that inherited it via cache. (public issue #1831, @DRAZY)
-      process.env.CLAUDE_CODE_FORK_SUBAGENT === '1' ||
-      process.env.CLAUDE_AGENT_SDK === '1',
+      process.env.CLAUDE_AGENT_SDK === '1' ||
+      isSubagentHookInput(input),
   );
 }


### PR DESCRIPTION
## Summary

`isSubagentContext()` keys on environment variables. That cannot work for forked subagents, and the workaround it shipped with (`CLAUDE_CODE_FORK_SUBAGENT === '1'`) turned every main session into a "subagent" and silently disabled nine hooks (#1864, #1911, PR #1942).

This PR removes the fork-flag row (same hunk as #1942) **and** replaces it with the signal that actually distinguishes a fork: the hook's stdin JSON. Consumers that already parse stdin pass it to the guard; the two SessionStart consumers that did not read stdin now do, best-effort.

## Why an env var can never mark a fork

Measured on Claude Code 2.1.241 by spawning a fork and dumping its environment from inside: **a fork's environment is byte-identical to its parent's** — same `CLAUDE_CODE_SESSION_ID`, same `CLAUDE_PID`, no `CLAUDE_AGENT_TYPE` / `CLAUDE_CODE_SUBAGENT_NAME` / `CLAUDE_CODE_SUBAGENT_TYPE`, and `CLAUDE_CODE_FORK_SUBAGENT=1` in both. Nothing in `process.env` separates them, so with the flag row removed (#1942) the original #1831 leak (forks re-injecting main-session context) is open again.

## What does mark a fork

The [hooks reference](https://code.claude.com/docs/en/hooks) documents `agent_id` and `agent_type` as common input fields "for subagent hooks", and lists `fork` as a `SessionStart` matcher (i.e. `source: "fork"` on that event's input). Observed on the same 2.1.241 fork: its PostToolUse input carries `agent_type: "fork"` plus an `agent_id`; an ordinary delegate carries `agent_type: "general-purpose"`; main-session input carries neither.

## Change

`lib/subagent.ts`

- `isSubagentContext(input?: unknown)` — optional parsed-stdin argument; result is the existing env union **OR** the stdin stamp. Every zero-arg call site keeps compiling and behaves as before, minus the false positive.
- New `isSubagentHookInput(input)` — true when `agent_id` or `agent_type` is a non-empty string, or `hook_event_name === "SessionStart"` with `source === "fork"`. Pure, zero-dep, never throws.
- Fork-flag row removed (identical to #1942).

Consumers now pass their parsed stdin: `ISASync`, `SystemChangeSurface` (`HookInput` gains optional `agent_id`/`agent_type`), `ConfigEvalFire`, `MemoryReviewFire`, `MemoryTurnStart`, `KittyEnvPersist` (guard moved after its existing stdin read; `source` comment now includes `fork`), `LoadContext` (adds a best-effort stdin read). `LoadMemory` and `MemoryDeltaSurface` are unchanged: their guarded paths are standalone probes, and their real caller `MemoryTurnStart` is now guarded on stdin.

`lib/hook-io.ts` — `HookInput` documents the optional `agent_id`, `agent_type`, `source` fields.

No new dependencies; hooks stay importable before `bun install`.

## Verification

All runs with `CLAUDE_CODE_FORK_SUBAGENT=1` in the environment (what `settings.system.json` and Claude Code ≥ 2.1.232 both set), against a throwaway HOME, using stdin shapes copied from real captured hook input:

- Guard unit cases (18): main-session input with the flag set → `false` for PostToolUse / Stop / SessionStart-startup; fork PostToolUse (`agent_type: "fork"`) and SessionStart `source: "fork"` → `true`; ordinary delegate stamp → `true`; each surviving env marker alone → `true`; null / string / array / empty-string / non-string / `source: "fork"` on a non-SessionStart event → `false`, none throw.
- Hook-level: `MemoryReviewFire` writes its per-session state on a main Stop and writes nothing on a fork-stamped Stop; `LoadContext` runs on `source: "startup"` and prints its skip line on `source: "fork"`; `KittyEnvPersist` same split; `SystemChangeSurface.run()` returns its surface line for a main write and `null` for a fork-stamped one.
- Each edited hook transpiles (`bun build --target=bun --no-bundle`).

Relationship to open work: stacks on #1942 (the removal hunk is the same; merging either first leaves a trivial conflict on that one hunk). Closes the re-opened #1831 concern and the "what is the reliable fork marker" follow-up noted on #1864 / #1911.
