### PR TITLE
fix(security): DeriveDenyHashes skip predicate stale after #1689 relocation

### DIFF
--- a/LifeOS/install/LIFEOS/TOOLS/DeriveDenyHashes.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/DeriveDenyHashes.ts
@@ -213,8 +213,13 @@ function main(): void {
   // of exiting 1 on every derivedsync run (public issue #1488). The consumer
   // (hooks/lib/system-file-guard-core.ts) already fails open on a missing
   // DENY_HASHES.json, so nothing is lost.
-  if (!existsSync(join(CLAUDE, "skills", "_LIFEOS"))) {
-    console.log("[DeriveDenyHashes] skills/_LIFEOS absent (public install) — skipping hash write");
+  // Fix 2026-08-23: since #1689 the filter's home is USER/SECURITY and the
+  // consumer ships in hooks/lib — a public install WITH that consumer present
+  // both has a home for the filter and a guard reading it, so only skip when
+  // the consumer is missing too (predicate was stale, pre-relocation).
+  const consumerPresent = existsSync(join(CLAUDE, "hooks", "lib", "system-file-guard-core.ts"));
+  if (!existsSync(join(CLAUDE, "skills", "_LIFEOS")) && !consumerPresent) {
+    console.log("[DeriveDenyHashes] skills/_LIFEOS absent and no hash consumer installed — skipping hash write");
     return;
   }
 

--- a/LifeOS/install/LIFEOS/TOOLS/DeriveDenyHashes.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/DeriveDenyHashes.ts
@@ -28,7 +28,7 @@
  * token, so filtering here keeps the scan precise. Tune ALLOWLIST/STOPWORDS with
  * --show-tokens.
  */
-import { readFileSync, writeFileSync, existsSync, appendFileSync, readdirSync, mkdirSync, lstatSync, realpathSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, appendFileSync, readdirSync, mkdirSync, realpathSync, renameSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, dirname, sep } from "node:path";
 import { createHash, randomBytes } from "node:crypto";
@@ -244,14 +244,20 @@ function main(): void {
   // outside the tree. Resolve both sides and refuse anything not contained.
   const userRoot = realpathSync(join(CLAUDE, "LIFEOS", "USER"));
   const outDir = realpathSync(dirname(OUT_PATH));
-  let outIsSymlink = false;
-  try { outIsSymlink = lstatSync(OUT_PATH).isSymbolicLink(); } catch { /* absent is fine */ }
-  if ((outDir !== userRoot && !outDir.startsWith(userRoot + sep)) || outIsSymlink) {
-    console.error(`[DeriveDenyHashes] refusing write: ${OUT_PATH} resolves outside the USER root or is a symlink`);
+  if (outDir !== userRoot && !outDir.startsWith(userRoot + sep)) {
+    console.error(`[DeriveDenyHashes] refusing write: ${OUT_PATH} resolves outside the USER root`);
     process.exit(1);
   }
-  writeFileSync(OUT_PATH, JSON.stringify(payload, null, 0) + "\n");
-  console.log(`[DeriveDenyHashes] wrote ${hashes.length} salted hashes -> ${OUT_PATH} (no plaintext)`);
+  // Write temp-then-rename ON THE RESOLVED DIR: rename replaces the directory
+  // entry, so a statically crafted DENY_HASHES.json that is a symlink or hard
+  // link to a file elsewhere is replaced, never followed/truncated. Threat
+  // model boundary: an attacker mutating the tree concurrently mid-run already
+  // has code execution as this user and is out of scope.
+  const finalPath = join(outDir, "DENY_HASHES.json");
+  const tmpPath = join(outDir, `.DENY_HASHES.json.tmp-${process.pid}`);
+  writeFileSync(tmpPath, JSON.stringify(payload, null, 0) + "\n");
+  renameSync(tmpPath, finalPath);
+  console.log(`[DeriveDenyHashes] wrote ${hashes.length} salted hashes -> ${finalPath} (no plaintext)`);
 }
 
 if (import.meta.main) main();

--- a/LifeOS/install/LIFEOS/TOOLS/DeriveDenyHashes.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/DeriveDenyHashes.ts
@@ -28,9 +28,9 @@
  * token, so filtering here keeps the scan precise. Tune ALLOWLIST/STOPWORDS with
  * --show-tokens.
  */
-import { readFileSync, writeFileSync, existsSync, appendFileSync, readdirSync, mkdirSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, appendFileSync, readdirSync, mkdirSync, lstatSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
-import { join, dirname } from "node:path";
+import { join, dirname, sep } from "node:path";
 import { createHash, randomBytes } from "node:crypto";
 
 const HOME = process.env.HOME || homedir();
@@ -238,6 +238,18 @@ function main(): void {
   // Create the output dir first — absent on fresh installs, and a throw here
   // aborts the whole DerivedSync pass (public PR #1652, @elhoim).
   mkdirSync(dirname(OUT_PATH), { recursive: true });
+  // The USER root is legitimately a symlink (XDG mount, SystemUserBoundary.md),
+  // but nothing below it may be: a restored or untrusted USER tree carrying
+  // SECURITY/ or DENY_HASHES.json as a symlink would redirect this write
+  // outside the tree. Resolve both sides and refuse anything not contained.
+  const userRoot = realpathSync(join(CLAUDE, "LIFEOS", "USER"));
+  const outDir = realpathSync(dirname(OUT_PATH));
+  let outIsSymlink = false;
+  try { outIsSymlink = lstatSync(OUT_PATH).isSymbolicLink(); } catch { /* absent is fine */ }
+  if ((outDir !== userRoot && !outDir.startsWith(userRoot + sep)) || outIsSymlink) {
+    console.error(`[DeriveDenyHashes] refusing write: ${OUT_PATH} resolves outside the USER root or is a symlink`);
+    process.exit(1);
+  }
   writeFileSync(OUT_PATH, JSON.stringify(payload, null, 0) + "\n");
   console.log(`[DeriveDenyHashes] wrote ${hashes.length} salted hashes -> ${OUT_PATH} (no plaintext)`);
 }


### PR DESCRIPTION
## What

Since #1689 moved the deny-hash filter's home to `USER/SECURITY` and its consumer (`hooks/lib/system-file-guard-core.ts`) ships in `hooks/lib`, a public install with the consumer present has both a home for `DENY_HASHES.json` and a guard reading it — yet the write was still gated on `skills/_LIFEOS` existing (the pre-relocation dev-tree marker). Result: public installs silently never get the deny-hash filter even though the guard consuming it is installed and fails open.

**Commit 1** updates the skip predicate: only skip when the consumer is missing too.

**Commits 2–3** harden the write that the relaxed predicate newly enables on public installs. The USER root is legitimately a symlink (XDG mount, per SystemUserBoundary.md), but a statically crafted USER tree (restored backup, cloned repo) could carry `SECURITY/` as a symlink, or `DENY_HASHES.json` as a symlink or hard link, redirecting or truncating a file outside the tree. The tool now resolves the output dir, refuses a destination outside the resolved USER root, and writes temp-then-rename on the resolved dir so a crafted final component is replaced, never followed. Stated threat-model boundary: concurrent mid-run mutation of the tree means the attacker already has code execution as the user, and is out of scope.

## Testing

- Scratch-tree harness: legitimate XDG layout (`LIFEOS/USER` itself a symlink) writes normally; `SECURITY/` symlinked out of tree is refused; `DENY_HASHES.json` hard-linked to a victim file leaves the victim untouched while the output replaces the directory entry.
- Patched tool parses clean under bun.

Developed with AI assistance (Claude), reviewed and tested by the author.
