### PR TITLE
feat(lifeos): make the launch directory configurable via a [launch] config block

### DIFF
--- a/LifeOS/install/LIFEOS/DOCUMENTATION/Config/ConfigSystem.md
+++ b/LifeOS/install/LIFEOS/DOCUMENTATION/Config/ConfigSystem.md
@@ -61,6 +61,52 @@ LifeOS configuration follows the **system/user separation** contract (`LIFEOS/DO
 3. **Skills** — private `_*` skills that need credentials/integration data read `LIFEOS_CONFIG.toml` via `LifeosConfig.load()` (e.g. a home-automation skill reads its Homebridge token; the network skill reads UniFi creds).
 4. **CLAUDE.md `@`-imports** — at session start, CC loads files referenced by top-level `@`-imports in `CLAUDE.md` (ARCHITECTURE_SUMMARY, PRINCIPAL_TELOS, PRINCIPAL_IDENTITY, DA_IDENTITY, PROJECTS, OPERATIONAL_RULES). CC does NOT follow transitive `@`-imports from inside imported files, so identity files must be listed in `CLAUDE.md` directly.
 
+## The `[launch]` block — where a session starts
+
+`LIFEOS_CONFIG.toml` carries an optional `[launch]` table that decides which directory `lifeos` puts a session in. Historically the launcher hardcoded `process.chdir(CLAUDE_DIR)`, so every session landed in `~/.claude` regardless of where the terminal was — which meant the Bash tool, `EventLogger`'s git snapshot, `ForgeProgress`'s `codex exec --cd`, `SecretScan`'s default target, and Serena's project matching all operated on the LifeOS install rather than the project actually being worked in.
+
+**The governing property: the default reproduces stock behaviour byte for byte.** No config file, no `[launch]` block, or an absent `cwd_mode` all resolve to "cd to the config root". Nobody's behaviour changes until they opt in.
+
+### Modes
+
+| `cwd_mode` | Behaviour |
+|---|---|
+| `config-root` | cd to `default_dir`. STOCK, and the default when the key is absent. |
+| `stay` | Stay in the launch directory, always. |
+| `stay-if-permitted` | Stay when the launch directory is under a permitted root, otherwise cd to `default_dir`. |
+
+`default_dir` defaults to the config root (`~/.claude`). It is the configured landing directory: set it to anything else and both `config-root` mode and the `--home` flag follow it.
+
+### Precedence
+
+`--local` → `--home` → `LIFEOS_CWD_MODE` env var → `[launch].cwd_mode` → built-in `config-root`. `--local` forces staying in the current directory; `--home` forces `default_dir`. An empty `LIFEOS_CWD_MODE` counts as unset; an unrecognised one is a hard error rather than a silent fallback.
+
+### Permitted roots
+
+`permitted_roots` is consulted only in `stay-if-permitted` mode, and accepts literal paths and `@`-sentinels:
+
+| Sentinel | Expands to |
+|---|---|
+| `@config-root` | the config root (`~/.claude`) |
+| `@config-paths` | `[paths].user_dir` and `[paths].projects_dir` |
+| `@settings-allow` | roots parsed from the MERGED `settings.json` `permissions.allow` `Edit()` rules |
+
+`@settings-allow` matches an `Edit(<path>/**)` rule whose `<path>` is ROOTED — it begins with `~/` or `/`. Rules carrying a wildcard anywhere other than the trailing `/**` are SKIPPED, because a leading `**/` form is a pattern rather than a rooted path and treating it as a root would add a meaningless entry; relative rules are skipped for the same reason. The merged `settings.json` is the right input rather than `settings.user.json`, since the effective permission set is what the user actually experiences.
+
+**"Known root" semantics.** Matching is lexical and prefix-based against the VISIBLE path (`$PWD`, not `process.cwd()`), with the trailing separator re-appended — so `~/Projects` matches `~/Projects/thing` but NOT `~/Projects-old`. A directory equal to a root exactly counts as under it. There is no globbing, and no realpath on either side: resolving would make a symlinked project directory stop matching the root the user actually typed. An ABSENT `permitted_roots` falls back to `["@config-root", "@config-paths"]`; an EMPTY one (`[]`) means nothing is permitted, so `stay-if-permitted` always lands on `default_dir`.
+
+### Validation
+
+The whole block is validated at config LOAD, regardless of which mode is active, so a typo in `permitted_roots` surfaces at the next launch rather than three weeks later when the mode changes. Accepted path forms are `~/...`, absolute `/...`, and `${VAR}/...` or `$VAR/...` drawn from a bounded allowlist (`HOME`, `LIFEOS_DIR`, `PROJECTS_DIR`). Rejected, each naming the offending key: any `..` segment, a relative path, anything containing `*`, an unknown `@sentinel`, and an allowlisted variable that is unset or empty. That last one is a hard error because naive expansion of an unset `${LIFEOS_DIR}` would yield `""`, turning `${LIFEOS_DIR}/x` into `/x` — a root-level prefix matching nearly everything.
+
+`@` is RESERVED as a prefix: a literal path beginning with `@` is not supported. An unknown sentinel is a hard error listing the valid set, never a silent skip — a dropped typo would narrow the permitted set invisibly and quietly change where sessions land.
+
+Existence is deliberately NOT checked at load. The split is that config load validates SYNTAX (pure string work) while `chdir` validates REALITY (does this directory exist right now, can we enter it) — so a `default_dir` on an automounted or network path does not fail validation at a moment when it is legitimately absent.
+
+### The main-checkout guard
+
+The worktree guard is keyed on the DESTINATION rather than on `--local`: the hazard is a property of where the session lands, not of why. Keyed on the flag, it would silently stop protecting anyone who set `cwd_mode` to a staying mode — exactly the population that most needs it. `LIFEOS_ALLOW_ROOT=1` still overrides.
+
 ## Editing
 
 - **Identity / voice / principal name / per-machine integrations** → edit `LIFEOS/USER/CONFIG/settings.user.json` (USER overlay) or `LIFEOS_CONFIG.toml`. Takes effect next SessionStart.

--- a/LifeOS/install/LIFEOS/TOOLS/LifeosConfig.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/LifeosConfig.ts
@@ -17,13 +17,16 @@
  * See: LIFEOS/DOCUMENTATION/SystemUserBoundary.md § "The four allowed access patterns".
  */
 
-import { existsSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { resolve } from "node:path";
 import { homedir } from "node:os";
 
 // Expand leading `~` (and `~/`) to the user's home directory. node:fs APIs do
 // not expand tildes, so any path returned from this loader must be absolute.
-function expandHome(p: string): string {
+//
+// Exported because [launch] carries paths with the same semantics as [paths],
+// and a second implementation would drift.
+export function expandHome(p: string): string {
   if (!p) return p;
   if (p === "~") return DEFAULT_HOME;
   if (p.startsWith("~/")) return resolve(DEFAULT_HOME, p.slice(2));
@@ -81,16 +84,32 @@ export interface LifeosPaths {
   projectsDir: string;
 }
 
+// Where a `lifeos` session starts.
+//   config-root        cd to defaultDir (STOCK behaviour, and the default)
+//   stay               stay in the launch directory, always
+//   stay-if-permitted  stay when under a permitted root, else defaultDir
+export type CwdMode = "config-root" | "stay" | "stay-if-permitted";
+
+export interface LifeosLaunch {
+  cwdMode: CwdMode;
+  defaultDir: string;
+  // Absolute, trailing-slash stripped, @-sentinels ALREADY EXPANDED. Expanding
+  // at load is what lets the launcher's resolver stay pure.
+  permittedRoots: string[];
+}
+
 export interface LifeosConfig {
   principal: LifeosPrincipal;
   da: LifeosDa;
   integrations: LifeosIntegrations;
   paths: LifeosPaths;
+  launch: LifeosLaunch;
 }
 
 // ─────────── Resolution ───────────
 
 const DEFAULT_HOME = process.env.HOME || homedir();
+const DEFAULT_CONFIG_ROOT = resolve(DEFAULT_HOME, ".claude");
 const DEFAULT_CONFIG_PATH = resolve(DEFAULT_HOME, ".claude/LIFEOS/USER/CONFIG/LIFEOS_CONFIG.toml");
 
 let cache: { config: LifeosConfig; mtime: number; path: string } | null = null;
@@ -143,6 +162,37 @@ export function paiUserDir(): string {
   }
 }
 
+/**
+ * The [launch] block, with the built-in defaults when there is no config file
+ * at all. Mirrors paiUserDir()'s shape: a fresh install that has not scaffolded
+ * LIFEOS_CONFIG.toml yet must still launch, and the defaults reproduce stock
+ * behaviour exactly.
+ *
+ * A config file that EXISTS but carries a malformed [launch] block still
+ * throws. Only ABSENCE is tolerated here, never a typo.
+ */
+export function loadLifeosLaunch(): LifeosLaunch {
+  const path = process.env.LIFEOS_CONFIG_PATH ?? DEFAULT_CONFIG_PATH;
+  if (!existsSync(path)) {
+    return defaultLaunchConfig();
+  }
+  return loadLifeosConfig().launch;
+}
+
+/** Built-in [launch] defaults: cd to the config root, exactly as stock does. */
+export function defaultLaunchConfig(): LifeosLaunch {
+  return normalizeLaunchBlock(undefined, defaultSentinelContext([]), process.env);
+}
+
+function defaultSentinelContext(settingsAllow: string[]): LaunchSentinelContext {
+  return {
+    configRoot: DEFAULT_CONFIG_ROOT,
+    userDir: resolve(DEFAULT_HOME, ".claude/LIFEOS/USER"),
+    projectsDir: resolve(DEFAULT_HOME, "Projects"),
+    settingsAllow,
+  };
+}
+
 // ─────────── Validation ───────────
 
 function validateAndNormalize(raw: unknown, path: string): LifeosConfig {
@@ -167,6 +217,33 @@ function validateAndNormalize(raw: unknown, path: string): LifeosConfig {
   if (!daVoices.main || typeof (daVoices.main.voice_id ?? daVoices.main.voiceId) !== "string") {
     throw new Error(`LifeosConfig: [da.voices.main] requires a voice_id — see ${path}`);
   }
+
+  const paths: LifeosPaths = {
+    userDir: expandHome(
+      root.paths?.userDir ?? root.paths?.user_dir ?? resolve(DEFAULT_HOME, ".claude/LIFEOS/USER"),
+    ),
+    projectsDir: expandHome(
+      root.paths?.projectsDir ?? root.paths?.projects_dir ?? resolve(DEFAULT_HOME, "Projects"),
+    ),
+  };
+
+  // settings.json is only read when @settings-allow is actually referenced --
+  // the stock default set does not include it, so the common path pays nothing.
+  const rawRoots =
+    root.launch?.permitted_roots ?? root.launch?.permittedRoots ?? DEFAULT_PERMITTED_ROOTS;
+  const settingsAllow =
+    Array.isArray(rawRoots) && rawRoots.includes("@settings-allow") ? readSettingsAllow() : [];
+
+  const launch = normalizeLaunchBlock(
+    root.launch,
+    {
+      configRoot: DEFAULT_CONFIG_ROOT,
+      userDir: paths.userDir,
+      projectsDir: paths.projectsDir,
+      settingsAllow,
+    },
+    process.env,
+  );
 
   return {
     principal: {
@@ -200,14 +277,8 @@ function validateAndNormalize(raw: unknown, path: string): LifeosConfig {
         : undefined,
       cloudflare: root.integrations?.cloudflare,
     },
-    paths: {
-      userDir: expandHome(
-        root.paths?.userDir ?? root.paths?.user_dir ?? resolve(DEFAULT_HOME, ".claude/LIFEOS/USER"),
-      ),
-      projectsDir: expandHome(
-        root.paths?.projectsDir ?? root.paths?.projects_dir ?? resolve(DEFAULT_HOME, "Projects"),
-      ),
-    },
+    paths,
+    launch,
   };
 }
 
@@ -222,6 +293,243 @@ function normalizeVoice(v: any): LifeosVoiceSettings {
     useSpeakerBoost: v.use_speaker_boost ?? v.useSpeakerBoost,
     volume: v.volume,
   };
+}
+
+// ----------- [launch] validation -----------
+//
+// The whole block is validated at LOAD, regardless of which mode is active, so
+// a typo in permitted_roots surfaces at the next launch rather than weeks later
+// when the mode changes. This file validates SYNTAX, naming the offending key;
+// the launcher's chdir() validates REALITY. Existence stays out of load-time
+// validation so a default_dir on an automounted or network path does not fail
+// while it is legitimately absent.
+
+const CWD_MODES: readonly string[] = ["config-root", "stay", "stay-if-permitted"];
+
+// Environment variables a [launch] path may reference. All three are set by
+// settings.system.json's env block; an open allowlist would let a launch path
+// depend on whatever happened to be exported.
+const LAUNCH_ENV_ALLOWLIST: readonly string[] = ["HOME", "LIFEOS_DIR", "PROJECTS_DIR"];
+
+const LAUNCH_SENTINELS: readonly string[] = ["@config-root", "@config-paths", "@settings-allow"];
+
+// Matches the default in the shipped TOML template. Sentinels, not paths --
+// they expand through the same code path a user-written entry does.
+const DEFAULT_PERMITTED_ROOTS: readonly string[] = ["@config-root", "@config-paths"];
+
+export interface LaunchSentinelContext {
+  configRoot: string;
+  userDir: string;
+  projectsDir: string;
+  /** Raw `permissions.allow` entries from the MERGED settings.json. */
+  settingsAllow: string[];
+}
+
+// Trailing "/" is stripped on load and re-appended for prefix comparison, so
+// "~/Projects" and "~/Projects/" are the same entry. "/" itself is preserved --
+// normalising it to "" would turn the root into a prefix that matches nothing.
+function stripTrailingSlash(p: string): string {
+  if (p === "/") {
+    return p;
+  }
+  return p.replace(/\/+$/, "") || "/";
+}
+
+function expandLaunchVars(
+  value: string,
+  key: string,
+  env: Record<string, string | undefined>,
+): string {
+  return value.replace(
+    /\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g,
+    (_match, braced: string | undefined, bare: string | undefined) => {
+      const name = braced ?? bare ?? "";
+      if (!LAUNCH_ENV_ALLOWLIST.includes(name)) {
+        throw new Error(
+          `LifeosConfig: [launch].${key} references $${name}, which is not an allowed variable ` +
+            `(allowed: ${LAUNCH_ENV_ALLOWLIST.join(", ")})`,
+        );
+      }
+      const resolved = env[name];
+      if (!resolved) {
+        // Naive expansion of an unset var yields "", turning "${LIFEOS_DIR}/x"
+        // into "/x" -- a root-level prefix that matches nearly everything.
+        // Never empty-expand; fail loudly instead.
+        throw new Error(
+          `LifeosConfig: [launch].${key} references $${name}, which is unset or empty -- ` +
+            `refusing to expand it to "" (that would yield a root-level path)`,
+        );
+      }
+      return resolved;
+    },
+  );
+}
+
+/**
+ * Normalize one [launch] path to an absolute, trailing-slash-free path.
+ *
+ * Pure: `env` arrives as an argument rather than being read from process.env.
+ * `key` exists only to name the offending entry in errors.
+ */
+export function normalizeLaunchPath(
+  value: unknown,
+  key: string,
+  env: Record<string, string | undefined>,
+): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`LifeosConfig: [launch].${key} must be a non-empty string`);
+  }
+  if (value.includes("*")) {
+    throw new Error(
+      `LifeosConfig: [launch].${key} contains "*" (got "${value}") -- globbing is not supported`,
+    );
+  }
+
+  const expanded = expandLaunchVars(value, key, env);
+
+  // Checked BEFORE expandHome: expandHome uses resolve(), which silently
+  // COLLAPSES ".." segments, leaving nothing to detect afterwards.
+  if (expanded.split("/").includes("..")) {
+    throw new Error(
+      `LifeosConfig: [launch].${key} contains a ".." segment (got "${value}") -- not allowed`,
+    );
+  }
+
+  const absolute = expandHome(expanded);
+  if (!absolute.startsWith("/")) {
+    throw new Error(
+      `LifeosConfig: [launch].${key} is a relative path (got "${value}") -- relative to what? ` +
+        `Use "/...", "~/...", or \${HOME}/\${LIFEOS_DIR}/\${PROJECTS_DIR}`,
+    );
+  }
+  return stripTrailingSlash(absolute);
+}
+
+// Roots implied by settings.json `permissions.allow`. Matches an Edit rule whose
+// path is ROOTED -- it begins with "~/" or "/" -- so Edit(/tmp/**) counts as
+// well as the "~/" forms.
+//
+// A rule with a wildcard anywhere other than the trailing "/**" is SKIPPED: a
+// leading "**/" is a pattern, not a rooted path. Relative rules are skipped for
+// the same reason.
+//
+// The input is the MERGED settings.json rather than settings.user.json, since
+// the effective permission set is what the user experiences.
+export function parseSettingsAllowRoots(allow: readonly string[]): string[] {
+  const roots: string[] = [];
+  for (const rule of allow) {
+    if (typeof rule !== "string") {
+      continue;
+    }
+    const match = /^Edit\((.+)\/\*\*\)$/.exec(rule);
+    if (!match) {
+      continue;
+    }
+    const path = match[1];
+    if (path.includes("*")) {
+      continue;
+    }
+    if (!path.startsWith("~/") && !path.startsWith("/")) {
+      continue;
+    }
+    roots.push(stripTrailingSlash(expandHome(path)));
+  }
+  return roots;
+}
+
+/**
+ * Expand one @-sentinel to the set of roots it stands for.
+ *
+ * "@" is RESERVED as a prefix: a literal path beginning with "@" is not
+ * supported. An unknown sentinel is a HARD ERROR rather than a skip -- a
+ * silently-dropped typo would narrow the permitted set invisibly and change
+ * where sessions land.
+ */
+export function expandLaunchSentinel(sentinel: string, ctx: LaunchSentinelContext): string[] {
+  switch (sentinel) {
+    case "@config-root":
+      return [stripTrailingSlash(ctx.configRoot)];
+    case "@config-paths":
+      return [stripTrailingSlash(ctx.userDir), stripTrailingSlash(ctx.projectsDir)];
+    case "@settings-allow":
+      return parseSettingsAllowRoots(ctx.settingsAllow);
+    default:
+      throw new Error(
+        `LifeosConfig: [launch].permitted_roots has unknown sentinel "${sentinel}" -- ` +
+          `valid sentinels are ${LAUNCH_SENTINELS.join(", ")}`,
+      );
+  }
+}
+
+/**
+ * Validate and normalize the raw [launch] table. Pure with respect to the
+ * filesystem: everything it needs arrives through `ctx` and `env`.
+ *
+ * An absent block, or an absent cwd_mode, yields stock behaviour: cd to the
+ * config root.
+ */
+export function normalizeLaunchBlock(
+  raw: unknown,
+  ctx: LaunchSentinelContext,
+  env: Record<string, string | undefined>,
+): LifeosLaunch {
+  const block = (raw ?? {}) as Record<string, any>;
+
+  const rawMode = block.cwd_mode ?? block.cwdMode;
+  let cwdMode: CwdMode = "config-root";
+  if (rawMode !== undefined) {
+    if (typeof rawMode !== "string" || !CWD_MODES.includes(rawMode)) {
+      throw new Error(
+        `LifeosConfig: [launch].cwd_mode is "${rawMode}" -- valid modes are ${CWD_MODES.join(", ")}`,
+      );
+    }
+    cwdMode = rawMode as CwdMode;
+  }
+
+  const rawDefaultDir = block.default_dir ?? block.defaultDir;
+  const defaultDir =
+    rawDefaultDir === undefined
+      ? stripTrailingSlash(ctx.configRoot)
+      : normalizeLaunchPath(rawDefaultDir, "default_dir", env);
+
+  const rawRoots = block.permitted_roots ?? block.permittedRoots ?? DEFAULT_PERMITTED_ROOTS;
+  if (!Array.isArray(rawRoots)) {
+    throw new Error(`LifeosConfig: [launch].permitted_roots must be an array of strings`);
+  }
+
+  const permittedRoots: string[] = [];
+  for (const entry of rawRoots) {
+    if (typeof entry !== "string") {
+      throw new Error(`LifeosConfig: [launch].permitted_roots entries must be strings`);
+    }
+    if (entry.startsWith("@")) {
+      permittedRoots.push(...expandLaunchSentinel(entry, ctx));
+    } else {
+      permittedRoots.push(normalizeLaunchPath(entry, "permitted_roots", env));
+    }
+  }
+
+  return { cwdMode, defaultDir, permittedRoots: [...new Set(permittedRoots)] };
+}
+
+// Absent or malformed settings are treated as an empty allow list rather than an
+// error: a Core-only install may legitimately not have the file, and
+// @settings-allow is opt-in.
+function readSettingsAllow(): string[] {
+  const settingsPath = resolve(DEFAULT_CONFIG_ROOT, "settings.json");
+  try {
+    if (!existsSync(settingsPath)) {
+      return [];
+    }
+    const parsed = JSON.parse(readFileSync(settingsPath, "utf-8")) as any;
+    const allow = parsed?.permissions?.allow;
+    if (!Array.isArray(allow)) {
+      return [];
+    }
+    return allow.filter((rule: unknown): rule is string => typeof rule === "string");
+  } catch {
+    return [];
+  }
 }
 
 // ─────────── CLI entry ───────────

--- a/LifeOS/install/LIFEOS/TOOLS/lifeos.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/lifeos.ts
@@ -25,6 +25,7 @@ import { existsSync, readFileSync, writeFileSync, readdirSync, symlinkSync, unli
 import { homedir } from "os";
 import { join, basename } from "path";
 import { PULSE_BASE } from "../PULSE/endpoint";
+import { loadLifeosLaunch, type LifeosLaunch } from "./LifeosConfig";
 
 // ============================================================================
 // Configuration
@@ -104,6 +105,112 @@ export function inMainCheckoutWithWorktrees(): boolean {
 function error(message: string): never {
   console.error(`❌ ${message}`);
   process.exit(1);
+}
+
+// ============================================================================
+// Launch directory
+// ============================================================================
+
+// The path the user SEES. process.cwd() reconstructs the canonical physical
+// path -- the kernel holds the cwd as a directory reference, not a string -- so
+// a symlinked route is lost there. $PWD carries it, and process.chdir() never
+// touches $PWD.
+//
+// PWD is not realpath-validated: `lifeos` is a shell alias, so bash sets it
+// immediately before exec. The fallback covers the direct `bun .../lifeos.ts`
+// invocation INSTALL.md documents, where PWD may be absent.
+export function visibleCwd(): string {
+  return process.env.PWD ?? process.cwd();
+}
+
+function isUnderPermittedRoot(cwd: string, roots: string[]): boolean {
+  for (const root of roots) {
+    if (cwd === root) {
+      return true;
+    }
+    // Re-append the separator stripped at load, so "~/Projects" does not match
+    // "~/Projects-old".
+    const prefix = root.endsWith("/") ? root : `${root}/`;
+    if (cwd.startsWith(prefix)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Absolute directory the session should start in.
+ *
+ * Pure -- no filesystem, no process state; everything arrives as an argument,
+ * so the whole decision table is exercisable as string logic with no fixtures
+ * (public issue #1526: a knob that looks live but is not).
+ *
+ * Precedence: --local -> --home -> LIFEOS_CWD_MODE -> [launch].cwd_mode ->
+ * built-in "config-root".
+ */
+export function resolveLaunchDir(input: {
+  flags: { local?: boolean; home?: boolean };
+  cwd: string;
+  config: LifeosLaunch;
+  env: Record<string, string | undefined>;
+}): string {
+  if (input.flags.local) {
+    return input.cwd;
+  }
+  if (input.flags.home) {
+    return input.config.defaultDir;
+  }
+
+  // `||` not `??`: an empty LIFEOS_CWD_MODE counts as unset.
+  const mode = input.env.LIFEOS_CWD_MODE || input.config.cwdMode;
+  switch (mode) {
+    case "stay":
+      return input.cwd;
+    case "stay-if-permitted":
+      // Lexical match against the VISIBLE path: no realpath on either side.
+      // Resolving would make a symlinked project directory stop matching the
+      // root the user typed.
+      return isUnderPermittedRoot(input.cwd, input.config.permittedRoots)
+        ? input.cwd
+        : input.config.defaultDir;
+    case "config-root":
+      return input.config.defaultDir;
+    default:
+      // config.cwdMode is validated at config load, so only the env var can
+      // land here.
+      throw new Error(
+        `lifeos: LIFEOS_CWD_MODE is "${mode}" -- valid modes are config-root, stay, stay-if-permitted`,
+      );
+  }
+}
+
+/**
+ * The destination-keyed half of the main-checkout guard (public PR #1579,
+ * @asdf8675309): does this launch land in the current directory, and has the
+ * user not overridden the check?
+ *
+ * Split out from inMainCheckoutWithWorktrees() so the decision is testable
+ * without a git fixture, and so short-circuiting keeps the two git subprocesses
+ * off the common path.
+ */
+export function mainCheckoutGuardApplies(
+  launchDir: string,
+  cwd: string,
+  env: Record<string, string | undefined>,
+  defaultDir: string,
+): boolean {
+  // The configured default destination is ALWAYS exempt, even when it equals
+  // the cwd. Without this a stock install can lock itself out: default_dir is
+  // ~/.claude, that directory is commonly a git repo, and the tooling creates
+  // .claude/worktrees there as a side effect of agent isolation, so every
+  // launch from it would error out.
+  //
+  // The guard means "you asked to STAY somewhere that is probably the wrong
+  // branch". Arriving at default_dir is not that.
+  if (launchDir === defaultDir) {
+    return false;
+  }
+  return launchDir === cwd && env.LIFEOS_ALLOW_ROOT !== "1";
 }
 
 // A Core-only install declines the hooks tree, so ../../hooks/lib/identity may
@@ -489,7 +596,7 @@ function cmdWallpaper(args: string[]) {
 // Commands
 // ============================================================================
 
-async function cmdLaunch(options: { mcp?: string; resume?: boolean; resumeId?: string; local?: boolean; systemPrompt?: string; passthrough?: string[] }) {
+async function cmdLaunch(options: { mcp?: string; resume?: boolean; resumeId?: string; local?: boolean; home?: boolean; systemPrompt?: string; passthrough?: string[] }) {
   // CLAUDE.md is now static — no build step needed.
   // Algorithm spec is loaded on-demand when Algorithm mode triggers.
   // (InstantiatePAI.ts is retired — kept for reference only)
@@ -524,22 +631,35 @@ async function cmdLaunch(options: { mcp?: string; resume?: boolean; resumeId?: s
     }
   }
 
-  // Guard (public PR #1579, @asdf8675309): --local launches Claude in the
-  // CURRENT directory. If that's a repo's main checkout (not a worktree) and
-  // the repo uses .claude/worktrees, the whole session would run on whatever
-  // stale branch the root is parked on. Refuse unless explicitly overridden.
-  if (options.local && process.env.LIFEOS_ALLOW_ROOT !== "1" && inMainCheckoutWithWorktrees()) {
+  const launchConfig = loadLifeosLaunch();
+  const launchDir = resolveLaunchDir({
+    flags: { local: options.local, home: options.home },
+    cwd: visibleCwd(),
+    config: launchConfig,
+    env: process.env,
+  });
+
+  // Guard (public PR #1579, @asdf8675309), keyed on the DESTINATION rather than
+  // on --local: the hazard is where the session LANDS, not why. If that
+  // destination is a repo's main checkout (not a worktree) and the repo uses
+  // .claude/worktrees, the session runs on whatever stale branch the root is
+  // parked on. Keyed on the flag, the guard would stop protecting anyone who
+  // sets cwd_mode to a staying mode.
+  if (
+    mainCheckoutGuardApplies(launchDir, visibleCwd(), process.env, launchConfig.defaultDir) &&
+    inMainCheckoutWithWorktrees()
+  ) {
     error(
       "You're in the main checkout root, not a worktree.\n" +
-        "   A --local session here runs on whatever branch the root is parked on.\n" +
+        "   A session here runs on whatever branch the root is parked on.\n" +
         "   cd into a worktree first, or set LIFEOS_ALLOW_ROOT=1 to override.",
     );
   }
 
-  // Change to LifeOS directory unless --local flag is set
-  if (!options.local) {
-    process.chdir(CLAUDE_DIR);
-  }
+  // Existence stays out of the resolver: chdir is atomic (no TOCTOU) and
+  // distinguishes ENOENT / ENOTDIR / EACCES where a boolean cannot. Let the raw
+  // error surface.
+  process.chdir(launchDir);
 
   // Flags this CLI doesn't model (e.g. --fork-session) reach `claude` verbatim
   // after a bare `--`. Without it the parser's default branch swallowed every
@@ -712,7 +832,32 @@ async function cmdPrompt(prompt: string) {
     args.push("--append-system-prompt-file", systemPromptFile);
   }
 
-  process.chdir(CLAUDE_DIR);
+  // The launch directory is a property of the invocation, not of whether the
+  // session is interactive, so a one-shot honours cwd_mode too. cmdPrompt takes
+  // only the prompt, so the flag set is empty and the config does the work.
+  const launchConfig = loadLifeosLaunch();
+  const launchDir = resolveLaunchDir({
+    flags: {},
+    cwd: visibleCwd(),
+    config: launchConfig,
+    env: process.env,
+  });
+
+  // Same destination-keyed guard as cmdLaunch: a one-shot on a stale
+  // main-checkout branch is the same failure with less warning, since there is
+  // no session to notice it in.
+  if (
+    mainCheckoutGuardApplies(launchDir, visibleCwd(), process.env, launchConfig.defaultDir) &&
+    inMainCheckoutWithWorktrees()
+  ) {
+    error(
+      "You're in the main checkout root, not a worktree.\n" +
+        "   A session here runs on whatever branch the root is parked on.\n" +
+        "   cd into a worktree first, or set LIFEOS_ALLOW_ROOT=1 to override.",
+    );
+  }
+
+  process.chdir(launchDir);
 
   const env: Record<string, string> = { ...process.env } as Record<string, string>;
   env.PWD = process.cwd();
@@ -738,6 +883,7 @@ USAGE:
   lifeos -r, --resume [id]  Resume a session (interactive picker, or a specific session ID)
   lifeos -s, --system-prompt  System prompt file to append (default: LIFEOS_SYSTEM_PROMPT.md)
   lifeos -l, --local       Stay in current directory (don't cd to ~/.claude)
+  lifeos --home            Go to the configured default_dir regardless of cwd
   lifeos -- <flags...>     Forward everything after -- straight to \`claude\`
 
 COMMANDS:
@@ -800,7 +946,7 @@ async function main() {
   // and the default branch below would otherwise silently drop it all over again
   // (public issue #1690, @catchingknives).
   const KNOWN_FLAGS = new Set([
-    "-m", "--mcp", "-r", "--resume", "-s", "--system-prompt", "-l", "--local",
+    "-m", "--mcp", "-r", "--resume", "-s", "--system-prompt", "-l", "--local", "--home",
     "-v", "--version", "-h", "--help", "-p", "-w", "--wallpaper", "--",
   ]);
   if (args[0].startsWith("-") && !KNOWN_FLAGS.has(args[0])) {
@@ -813,6 +959,7 @@ async function main() {
   let resume = false;
   let resumeId: string | undefined;
   let local = false;
+  let home = false;
   let systemPrompt: string | undefined;
   let command: string | undefined;
   let subCommand: string | undefined;
@@ -853,6 +1000,10 @@ async function main() {
       case "-l":
       case "--local":
         local = true;
+        break;
+      // No short form: -h is taken by --help.
+      case "--home":
+        home = true;
         break;
       case "-v":
       case "--version":
@@ -942,11 +1093,22 @@ async function main() {
       break;
     default:
       // Launch with options
-      await cmdLaunch({ mcp, resume, resumeId, local, systemPrompt, passthrough });
+      await cmdLaunch({ mcp, resume, resumeId, local, home, systemPrompt, passthrough });
   }
 }
 
-main().catch((e) => {
-  console.error(e);
-  process.exit(1);
-});
+// Guarded so the pure helpers above can be imported without launching a
+// session -- the same pattern LifeosConfig.ts uses.
+if (import.meta.main) {
+  main().catch((e) => {
+    // Config validation throws carry actionable messages naming the offending
+    // key, and console.error(e) on an Error prints the stack instead, burying
+    // them. Route Errors through the same formatter every other user-facing
+    // failure uses; keep the raw dump for non-Error throws.
+    if (e instanceof Error && e.message) {
+      error(e.message);
+    }
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/LifeOS/install/LIFEOS/TOOLS/lifeos.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/lifeos.ts
@@ -559,6 +559,12 @@ async function cmdLaunch(options: { mcp?: string; resume?: boolean; resumeId?: s
   // interactive session uses OAuth (`claude /login`) instead of API-key billing.
   // Mirrors the protection in cmdPrompt() — same hazard, same fix.
   const launchEnv = { ...process.env };
+  // chdir() moves the process but never touches PWD, a shell convention rather
+  // than kernel state -- so without this the child inherits a PWD naming the
+  // launch-time directory while its actual cwd is elsewhere. Bash recomputes an
+  // inherited PWD that is not a valid alias for its real directory, which is
+  // why it has been invisible.
+  launchEnv.PWD = process.cwd();
   delete launchEnv.ANTHROPIC_API_KEY;
   launchEnv.CLAUDE_CODE_WORKFLOWS = "1";
   const proc = spawn(args, {
@@ -709,6 +715,7 @@ async function cmdPrompt(prompt: string) {
   process.chdir(CLAUDE_DIR);
 
   const env: Record<string, string> = { ...process.env } as Record<string, string>;
+  env.PWD = process.cwd();
   delete env.ANTHROPIC_API_KEY;
   env.CLAUDE_CODE_WORKFLOWS = "1";
   const proc = spawn(args, {

--- a/LifeOS/install/USER/CONFIG/LIFEOS_CONFIG.toml
+++ b/LifeOS/install/USER/CONFIG/LIFEOS_CONFIG.toml
@@ -40,3 +40,29 @@ token_env_var = "CLOUDFLARE_API_TOKEN"
 [paths]
 user_dir = "~/.claude/LIFEOS/USER"
 projects_dir = "~/Projects"
+
+[launch]
+# Where a `lifeos` session starts. These values are the built-in defaults and
+# reproduce stock behaviour exactly: every session cd's to the config root. An
+# older config with no [launch] block behaves identically.
+#
+#   "config-root"        cd to default_dir (this default)
+#   "stay"               stay in the launch directory, always
+#   "stay-if-permitted"  stay when under a permitted root, else default_dir
+cwd_mode = "config-root"
+
+# Where config-root mode lands, and where --home forces a session regardless
+# of the current directory.
+default_dir = "~/.claude"
+
+# Only consulted in stay-if-permitted mode. Accepts literal paths ("~/...",
+# "/...", "${HOME}/...") and @-sentinels:
+#
+#   @config-root     the config root (~/.claude)
+#   @config-paths    [paths].user_dir and [paths].projects_dir, above
+#   @settings-allow  roots parsed from settings.json permissions.allow Edit() rules
+#
+# Matching is lexical and prefix-based against the visible path, so "~/Projects"
+# matches "~/Projects/thing" but not "~/Projects-old". No globbing. An unknown
+# sentinel is an error, not a silent skip. See DOCUMENTATION/Config/ConfigSystem.md.
+permitted_roots = ["@config-root", "@config-paths"]


### PR DESCRIPTION
## Description

### The problem

`lifeos.ts` hardcodes `process.chdir(CLAUDE_DIR)`, so every session starts in `~/.claude` regardless of where the terminal was. That means the Bash tool, `EventLogger`'s git snapshot, `ForgeProgress`'s `codex exec --cd`, `SecretScan`'s default target, and Serena's project matching all operate on the LifeOS install instead of the project the human is working in. The workaround today is `--local` on every invocation, or a local patch to the launcher.

### The default reproduces today's behaviour byte for byte

An install that does not opt in behaves exactly as v7.40.4 does now. All four of these resolve to `~/.claude`, the current hardcoded `CLAUDE_DIR`:

| Situation | Resolves to |
|---|---|
| no `LIFEOS_CONFIG.toml` on disk at all | `~/.claude` |
| TOML present, no `[launch]` block | `~/.claude` |
| `[launch]` present, `cwd_mode` absent | `~/.claude` |
| `[launch]` present, `cwd_mode = "config-root"` | `~/.claude` |

The built-in defaults are `cwdMode: "config-root"` and `defaultDir: <config root>`. `default_dir` is not a new place to land; it is a name for the place the launcher already lands, made overridable.

The template ships the block live, with those defaults written out rather than commented. That matches how the rest of the file ships (`[principal]`, `[da]`, `[paths]` all carry real values), it makes the knob discoverable, and it means the parse and validation path runs on every install so a regression there fails loudly instead of silently falling back to defaults. An older config with no `[launch]` block behaves identically.

### What this adds

A `[launch]` table in `LIFEOS_CONFIG.toml`:

```toml
[launch]
cwd_mode        = "stay-if-permitted"
default_dir     = "~/.claude"
permitted_roots = ["@config-root", "@config-paths"]
```

| `cwd_mode` | Behaviour |
|---|---|
| `config-root` | cd to `default_dir`. Stock, and the default when the key is absent. |
| `stay` | Stay in the launch directory, always. |
| `stay-if-permitted` | Stay when the launch directory is under a permitted root, otherwise cd to `default_dir`. |

Precedence: `--local` -> `--home` -> `LIFEOS_CWD_MODE` -> `[launch].cwd_mode` -> built-in `config-root`. The env var name follows the existing `LIFEOS_ALLOW_ROOT` convention in the same file. An empty `LIFEOS_CWD_MODE` counts as unset; an unrecognised one is a hard error rather than a silent fallback to stock.

`--home` is new and forces `default_dir` regardless of cwd. No short form, since `-h` is taken by `--help`. It is registered in `KNOWN_FLAGS`, without which the passthrough branch would swallow it and forward it to `claude` verbatim - the failure mode of issue #1690 (@catchingknives).

`permitted_roots` is consulted only in `stay-if-permitted` mode, and takes literal paths plus `@`-sentinels:

| Sentinel | Expands to |
|---|---|
| `@config-root` | the config root (`~/.claude`) |
| `@config-paths` | `[paths].user_dir` and `[paths].projects_dir` |
| `@settings-allow` | roots parsed from the merged `settings.json` `permissions.allow` `Edit()` rules |

Matching is lexical and prefix-based against the visible path, with the trailing separator re-appended, so `~/Projects` matches `~/Projects/thing` but not `~/Projects-old`. No globbing, and no realpath on either side: resolving would make a symlinked project directory stop matching the root the user typed. `@` is reserved as a prefix, so a literal path starting with `@` is not supported.

### Design notes

**`resolveLaunchDir()` is pure.** Everything arrives as an argument, so the whole decision table is exercisable as string logic with no fixtures - the concern issue #1526 raised about `memoryDir`, where a knob looked live but was not.

**Validation happens at config load, regardless of the active mode.** A typo in `permitted_roots` surfaces at the next launch rather than weeks later when the mode changes, and each message names the offending key. Rejected: any `..` segment, a relative path, anything containing `*`, an unknown `@sentinel`, and an allowlisted variable that is unset or empty. That last one is a hard error because naive expansion of an unset `${LIFEOS_DIR}` yields `""`, turning `${LIFEOS_DIR}/x` into `/x`, a root-level prefix matching nearly everything.

**Existence is not checked at load.** Config load validates syntax, `chdir` validates reality. `chdir` is atomic, one syscall instead of two, and distinguishes `ENOENT` / `ENOTDIR` / `EACCES` where a boolean cannot. It also means a `default_dir` on an automounted or network path does not fail validation while it is legitimately absent.

**`CLAUDE_DIR` is unchanged.** It appears eight times and seven of those locate the install itself: `Doctor.ts`, `LIFEOS_SYSTEM_PROMPT.md`, `MCP_DIR`, `ACTIVE_MCP`, `BANNER_SCRIPT`. Only one use is the launch destination. Conflating the two would mean setting `default_dir` accidentally relocates where the launcher looks for its own system prompt.

**`expandHome` is exported** from `LifeosConfig.ts` rather than reimplemented. It already normalises `~` for `[paths]`, `[launch]` carries paths with the same semantics, and a second implementation would drift.

**`main()` now sits behind `import.meta.main`,** the pattern `LifeosConfig.ts` already uses, so the pure helpers can be imported without launching a session. Its catch routes `Error`s through the existing `error()` formatter and keeps the raw dump for non-`Error` throws: `console.error(e)` prints the stack, burying the validation messages that name the offending key.

### The main-checkout guard, extended rather than worked around

PR #1579 (@asdf8675309) refuses to launch when `--local` would put a session in a repo's main checkout root while that repo uses `.claude/worktrees`, because the session would run on whatever stale branch the root is parked on.

This change re-keys that guard on the destination instead of on the flag. The hazard is where the session lands, not why. Keyed on `--local`, the guard would stop protecting anyone who sets `cwd_mode` to a staying mode - the population that most needs it.

Re-keying alone introduces one new failure, and the fix is part of this PR: the configured default destination is always exempt. Without that exemption the guard fires whenever the destination equals the cwd for any reason, including simply arriving at `default_dir`. That is reachable on a stock install with zero customization: `default_dir` defaults to `~/.claude`, that directory is commonly a git repo, and the tooling creates `.claude/worktrees` there as a side effect of agent isolation. Populate it once and a stock user standing in `~/.claude` under stock `config-root` mode is refused by the tool's own defaults.

The guard means "you asked to stay somewhere that is probably the wrong branch". Arriving at `default_dir` is not that. `LIFEOS_ALLOW_ROOT=1` still overrides everything.

The message drops "A --local session" for "A session", since the guard no longer implies that flag.

### The `PWD` commit

The first commit stands alone and can be taken or dropped independently.

`lifeos.ts` calls `process.chdir()` and then spawns, but never updates `PWD` in the child's environment, so the child receives a `PWD` naming the launch-time directory while its actual cwd is the config root. It is invisible today because bash self-heals: an inherited `PWD` that is a valid alias for the current directory is kept, one that is not is silently recomputed from `getcwd()`, and most tooling calls `getcwd()` anyway.

It is a minor pre-existing inconsistency rather than a live bug, fixed here because the feature depends on it. `getcwd()` always returns the resolved physical path - the kernel holds the cwd as a directory reference, not a string - so a symlinked route survives into the child only if `PWD` carries it. Both sites use `process.cwd()` rather than a captured variable, so they stay correct regardless of the destination.

The same distinction is why `visibleCwd()` reads `process.env.PWD ?? process.cwd()`. The fallback covers the direct `bun .../lifeos.ts` invocation `INSTALL.md` documents, where `PWD` may be absent. There is no realpath validation of `PWD`: `lifeos` is a shell alias, so bash sets it immediately before exec and there is no intermediate process to make it stale.

### Both launch paths

`cmdPrompt` (the one-shot `lifeos -p "..."` path) gets the same treatment as `cmdLaunch`. The launch directory is a property of the invocation, not of whether the session is interactive, so honouring `cwd_mode` in one path and not the other would be a bug rather than a scoping decision. Scripted callers are covered by the governing property: nothing changes for anyone who has not opted in, and a caller who has opted in is already in the directory they want.

`cmdPrompt` takes only `(prompt: string)` today, so it resolves with an empty flag set and config-driven modes do the work. Threading `--local` / `--home` through to it is an additive follow-up.

There is precedent for treating the two paths symmetrically, for the principle rather than for this decision specifically: the comment at the `launchEnv` site already says "Mirrors the protection in cmdPrompt() - same hazard, same fix" about stripping `ANTHROPIC_API_KEY` before spawn.

### Files changed

| File | Change |
|---|---|
| `LIFEOS/TOOLS/LifeosConfig.ts` | `expandHome` exported; `CwdMode` / `LifeosLaunch` types; `launch` on `LifeosConfig`; `loadLifeosLaunch()`; `[launch]` parse, validation, sentinel expansion |
| `LIFEOS/TOOLS/lifeos.ts` | `visibleCwd()`, pure `resolveLaunchDir()`, `mainCheckoutGuardApplies()`, `--home` plus `KNOWN_FLAGS` and help row, both chdir sites, both `PWD` assignments, `import.meta.main` guard and error formatting |
| `LIFEOS/DOCUMENTATION/Config/ConfigSystem.md` | a `[launch]` section covering modes, precedence, sentinels, "known root" semantics, validation, and the guard |
| `USER/CONFIG/LIFEOS_CONFIG.toml` | the `[launch]` block, shipped live with the stock defaults |

### Verification

Verified by hand on a live 7.40.4 install across ten launch scenarios: permitted roots, non-permitted directories, `--home`, `--local`, and `lifeos -p`. `lifeos -p "run pwd"` from a project directory reported that directory rather than the config root, confirming the one-shot path honours `cwd_mode`.

The guard was tested in all four directions against a real worktree created and removed for the purpose: main checkout with worktrees while staying refuses; the same with `LIFEOS_ALLOW_ROOT=1` launches; inside a worktree launches; and a launch whose destination is `default_dir` is exempt.

The decision table was also driven through the pure resolver locally, covering: no config present, `cwd_mode` absent, each flag against each mode, `~/Projects-old` against a `~/Projects` root, cwd equal to a root exactly, each sentinel, an unknown sentinel, each rejected path form, env-versus-TOML precedence, and every direction of the guard including both default-dir exemption cases.

No test file is included. The repository ships none, and adding the first one seemed like a separate conversation to have with you rather than something to bundle into a feature. The resolver being pure is what makes that table cheap to run, and I am happy to add the file here or in a follow-up if you want it.