### PR TITLE
fix(inference): pin verbose off so --output-format json stays a single object

### DIFF
--- a/LifeOS/install/LIFEOS/TOOLS/Inference.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/Inference.ts
@@ -260,6 +260,9 @@ async function inferenceAttempt(options: InferenceOptions, modelOverride?: strin
       '--effort', config.effort,  // Opus 4.8 respects effort strictly; tune intelligence vs. token spend per level
       ...(hasImages ? ['--allowedTools', 'Read'] : ['--tools', '']),
       '--output-format', 'json',
+      // Verbose on turns the JSON envelope into an array (anthropics/claude-code#84784),
+      // and --setting-sources '' doesn't suppress it. Force it off.
+      '--settings', '{"verbose":false}',
       '--exclude-dynamic-system-prompt-sections',  // v3.23 C2: cache-friendly prompt prefix (claude-code v2.1.98+)
       '--setting-sources', '',
       ...systemPromptArgs,


### PR DESCRIPTION
With verbose view mode on (`"verbose": true` in settings.json, `/config verbose=true`, or `--verbose`), `claude --print --output-format json` returns a JSON array of session messages instead of the documented single result object (anthropics/claude-code#84784).

`inferenceAttempt()` reads `envelope.result` off the parsed value, so on those installs every call fails with `Claude JSON envelope missing result field`, taking down every `Inference.ts` consumer at once.

`--setting-sources ''` is already passed and does not suppress it (measured on CLI 2.1.245). Command-line settings outrank the user settings file, so this pins `verbose: false` for the child process. Three lines.

Reproduce:

    claude -p hi --output-format json | head -c 1             # {
    claude -p hi --output-format json --verbose | head -c 1   # [

Managed settings outrank `--settings`, so an MDM-forced verbose install would still see an array. A shape-tolerant parse closes that if that's a better way to go. 