### PR TITLE
fix(SessionCleanup): derive ISA phase from claim state — a session ending is not a claim closing

### DIFF
--- a/LifeOS/install/hooks/SessionCleanup.hook.ts
+++ b/LifeOS/install/hooks/SessionCleanup.hook.ts
@@ -86,12 +86,31 @@ function clearSessionWork(sessionId?: string): void {
       // findArtifactPath prefers ISA.md and falls back to legacy PRD.md.
       if (isaPath && existsSync(isaPath)) {
         let isaContent = readFileSync(isaPath, 'utf-8');
-        isaContent = isaContent.replace(/^phase:.*$/m, 'phase: complete');
+
+        // A session ending is not a claim closing. Derive the phase from claim
+        // state so work in flight keeps a phase the continuity surfaces can see.
+        const openClaims = (isaContent.match(/^- \[ \]/gm) || []).length;
+        const closedClaims = (isaContent.match(/^- \[x\]/gm) || []).length;
+        const phase = openClaims > 0
+          ? (closedClaims > 0 ? 'climbing' : 'scoping')
+          : 'complete';
+
+        isaContent = isaContent.replace(/^phase:.*$/m, `phase: ${phase}`);
         isaContent = isaContent.replace(/^updated:.*$/m, `updated: ${getISOTimestamp()}`);
-        isaContent = isaContent.replace(/^status: ACTIVE$/m, 'status: COMPLETED');
-        isaContent = isaContent.replace(/^completed_at: null$/m, `completed_at: "${getISOTimestamp()}"`);
+        if (openClaims > 0) {
+          // progress must not go stale while the ISA stays open
+          isaContent = isaContent.replace(
+            /^progress:.*$/m, `progress: ${closedClaims}/${closedClaims + openClaims}`);
+        } else {
+          isaContent = isaContent.replace(/^status: ACTIVE$/m, 'status: COMPLETED');
+          isaContent = isaContent.replace(/^completed_at: null$/m, `completed_at: "${getISOTimestamp()}"`);
+        }
         writeFileSync(isaPath, isaContent, 'utf-8');
         marked = true;
+        if (openClaims > 0) {
+          console.error(`[SessionCleanup] ${isaPath}: left phase: ${phase} — ` +
+            `${openClaims} claim(s) still open. A session ending does not close claims.`);
+        }
       }
 
       // Legacy fallback: update META.yaml if it exists


### PR DESCRIPTION
Fixes #1977.

## What this changes

`clearSessionWork()` rewrote `phase:` to `complete` whenever a session ended, with no inspection of claim state. Any session that ended with work in flight marked its ISA finished, and because the continuity surfaces filter on phase, that work then did not resurface at the next session start.

This derives the phase from the claims instead:

```ts
const openClaims   = (isaContent.match(/^- \[ \]/gm) || []).length;
const closedClaims = (isaContent.match(/^- \[x\]/gm) || []).length;
const phase = openClaims > 0
  ? (closedClaims > 0 ? 'climbing' : 'scoping')
  : 'complete';
```

Three further consequences fall out of the same condition:

- `status: COMPLETED` and `completed_at` are written **only** when `openClaims === 0`. Previously an ISA could carry a completion timestamp with every claim still open.
- `progress:` is refreshed while the ISA stays open, so it cannot go stale. On this install one ISA read `progress: 5/16` against 28 real claims.
- The hook logs to stderr when it leaves an ISA open, so the state is visible rather than assumed.

## Why this shape

`scoping` / `climbing` / `complete` is the vocabulary the shipped ISA documentation already uses — 33, 10 and 36 occurrences in `LIFEOS/DOCUMENTATION/ISA/`. Worth noting that no shipped hook or tool currently writes `scoping` or `climbing`; only `complete`, `plan` and `execute` appear in shipped code. So this is the first place the mid-flight vocabulary is actually written, which is why the bug existed at all: the hook only ever had one phase to write.

The check is deliberately a condition inside a procedure that already runs, rather than a new gate. It costs nothing on any session that ends with its claims closed.

## Verification

- The phase derivation was tested against four cases: all claims open, some closed, all closed, and no claims at all.
- **Mutation-tested.** Reverting the logic to the unconditional `'complete'` form is caught by the test, so the check is not vacuous.
- The file builds clean under `bun build`.
- Applied on a live install: re-sweeping every `phase: complete` ISA for unchecked claims returns zero, where it returned five before the patch.

## Not claimed

No estimate of how many installs are affected. The write is unconditional, so any install ending a session mid-work should reproduce it, but that is reasoning rather than measurement.
