### PR TITLE
chore(github): add the bug-report issue form proposed in #1847 (five fields, negative control required)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,67 @@
+name: Bug report
+description: A defect with a version, a location, a repro on a clean tree, and proof the check would have gone red.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Five fields make a report cheap to accept. The first four say what is broken and where. The fifth, the negative control, is what turns a patch review into a bug reproduction: it states the defect without reference to any fix, so a maintainer can see the failure before reading a line of proposed code.
+
+        Redact before you paste. DA output carries your home path, your name, and sometimes your own data. `/Users/you/.claude/...` reads fine.
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: LifeOS version, plus the component version when the defect lives in one.
+      placeholder: LifeOS 7.40.4 / Cortex
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: What is broken
+      description: One paragraph on the behaviour, not the remedy.
+    validations:
+      required: true
+  - type: input
+    id: location
+    attributes:
+      label: Where (file:line)
+      description: The line the defect lives on. Add the reader and the writer when the two disagree.
+      placeholder: LIFEOS/TOOLS/CortexHealth.ts:206
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Repro on a clean tree
+      description: Commands someone can run against a fresh install of the version above, and what they will see. No local patches, no personal config.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: negative-control
+    attributes:
+      label: Negative control
+      description: >
+        How you proved the check would have gone red. Run the probe against the unpatched version and paste the failing output, phrased without reference to any fix, e.g. "on unpatched 7.40.4 the retriever returns 5 ranked results and writes 0 evidence rows". A probe that has never been red is an assertion wearing the clothes of a verification.
+    validations:
+      required: true
+  - type: textarea
+    id: fix
+    attributes:
+      label: Suggested fix
+      description: Optional. A diff, or the shape of one. Say plainly if it is untested.
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched open and closed issues for this defect.
+          required: true
+        - label: The repro runs against a clean tree of the version above, not against my modified install.
+          required: true
+        - label: "I removed personal data from the pasted output — real names, absolute home paths, tokens, my own content."
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question, idea, or release feedback
+    url: https://github.com/danielmiessler/LifeOS/discussions
+    about: Discussions is the place for questions, feature ideas, and "should I upgrade?". Defects belong in issues.


### PR DESCRIPTION
Adds the bug-report issue form proposed in [#1847](https://github.com/danielmiessler/LifeOS/discussions/1847#discussioncomment-18072384), unchanged from the text posted there on Aug 18. Opening it as a PR now because the thread has kept asking process questions the template answers — most recently @Drizzt321 asking whether a PR should be accompanied by an issue.

Context: @garthsch asked whether feedback needed a standard format; @danielmiessler answered that the recent wave *is* the format — version + `file:line` + a repro against a clean tree + a suggested fix — and said it would be encoded as an issue template.

**Five fields.** The four above, plus one the last batch showed makes a report cheap to accept: the **negative control**, i.e. how the reporter proved the check would have gone red. It states the defect without reference to any fix, so a maintainer reproduces a bug instead of reviewing a patch. That is also the cheapest filter against generated-code submissions.

**Three pre-submit boxes.** Searched prior issues; repro runs on a clean tree, not a modified install; personal data removed from pasted output. The third exists because DA-written reports tend to arrive carrying the reporter's home path and real name.

**`config.yml`** keeps blank issues enabled and points questions, ideas and "should I upgrade?" at Discussions.

Deliberately left out: a feature-request form, and any label or triage policy — those are maintainer calls, not mine.

Both files parse (`js-yaml`). Required fields: version, summary, location, repro, negative-control; suggested fix optional.

Happy to have this closed if the shape isn't right, or reworked in whatever direction you prefer.
