### PR TITLE
MemoryRetriever: never return a bare heading as a retrieval excerpt

### DIFF
--- a/LifeOS/install/LIFEOS/TOOLS/MemoryRetriever.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/MemoryRetriever.ts
@@ -436,10 +436,23 @@ function extractExcerpt(note: KnowledgeNote, queryTerms: string[]): string {
   const paragraphs = body.split(/\n\n+/).filter((p) => p.trim().length > 30);
   if (paragraphs.length === 0) return body.substring(0, MAX_EXCERPT_CHARS);
 
-  let bestParagraph = paragraphs[0];
+  // A heading-only block carries no payload: the result header already renders the
+  // note title, so returning a heading as the excerpt spends a retrieval slot on a
+  // line the caller has printed already. Covers ATX ("## Thesis") and setext (a
+  // title underlined with equals signs or hyphens).
+  const isHeadingOnly = (p: string) => {
+    const lines = p.trim().split("\n").filter((l) => l.trim() !== "");
+    if (lines.length === 0) return false;
+    const isAtx = (l: string) => /^\s*#{1,6}\s/.test(l);
+    if (lines.every(isAtx)) return true;
+    return lines.length === 2 && !isAtx(lines[0]!) && /^\s*(=+|-+)\s*$/.test(lines[1]!);
+  };
+
+  let bestIndex = -1;
   let bestDensity = 0;
 
-  for (const para of paragraphs) {
+  for (let i = 0; i < paragraphs.length; i++) {
+    const para = paragraphs[i]!;
     const paraLower = para.toLowerCase();
     let hits = 0;
     for (const term of queryTerms) {
@@ -450,11 +463,27 @@ function extractExcerpt(note: KnowledgeNote, queryTerms: string[]): string {
     const density = hits / para.split(/\s+/).length;
     if (density > bestDensity) {
       bestDensity = density;
-      bestParagraph = para;
+      bestIndex = i;
     }
   }
 
-  return bestParagraph.substring(0, MAX_EXCERPT_CHARS);
+  const firstProse = paragraphs.find((p) => !isHeadingOnly(p));
+
+  // Nothing matched: every density is 0, so the old code returned paragraphs[0] —
+  // the note title for any note opening with a heading over 30 chars. Prefer prose.
+  if (bestIndex === -1) return (firstProse ?? paragraphs[0]!).substring(0, MAX_EXCERPT_CHARS);
+
+  // The match landed on a heading: return the prose that heading introduces, so a
+  // query hitting a section title yields that section rather than an unrelated one.
+  if (isHeadingOnly(paragraphs[bestIndex]!)) {
+    const following = paragraphs.slice(bestIndex + 1).find((p) => !isHeadingOnly(p));
+    if (following) return following.substring(0, MAX_EXCERPT_CHARS);
+    // Nothing follows it (trailing heading, or a note that is all headings). Return
+    // the matched heading rather than reaching back for unrelated earlier prose: it
+    // is thinner, but it tells the reader which section actually matched.
+  }
+
+  return paragraphs[bestIndex]!.substring(0, MAX_EXCERPT_CHARS);
 }
 
 // ============================================================================


### PR DESCRIPTION

## Cause

In `extractExcerpt`, when no priority section matches, the fallback picks the paragraph
with the highest query-term density. If no paragraph contains a query term, every density
is 0, the `density > bestDensity` comparison never fires, and the function returns
`paragraphs[0]`. For any note opening with an H1 longer than 30 characters, that first
block is the title.

This is common in practice: a note can score highly on title, tag and related-slug matches
while none of the query terms appear in its body prose.

## Fix

Three changes, all inside `extractExcerpt`:

1. Recognise heading-only blocks (ATX, and setext titles underlined with `=` or `-`).
2. When nothing matches, return the first prose block instead of `paragraphs[0]`.
3. When the match lands on a heading, return the prose that heading introduces, so a query
   hitting a section title yields that section rather than an unrelated one. If nothing
   follows it, return the matched heading, which is thin but at least names the section
   that matched.

Ranking is untouched. Only excerpt selection changes.

## Measurement

Repo ships no test infrastructure, so this was measured with a throwaway script rather than
a committed test. A "dud" is a returned result whose excerpt is heading-only or duplicates
its own title. Queries are generated mechanically from the corpus, 29 notes, `topK: 5`:

| Query set | Queries | Results | Duds before | Duds after |
|---|---|---|---|---|
| Title-derived (tokens from each note's H1) | 24 | 112 | 59 (52.7%) | 0 |
| Body-derived control (tokens from prose) | 29 | 126 | 29 (23.0%) | 0 |
| Heading-derived (tokens from `##` sections) | 20 | 86 | 17 (19.8%) | 0 |

Result counts are identical before and after in all three sets, confirming ranking did not
move.

Happy to contribute the measurement script as a test if you want test infrastructure in the
repo; left out here to keep the change to one file.

## Known limitations, not addressed

These predate the change and would each widen the diff considerably:

- Paragraph splitting is blank-line-only, so a heading followed immediately by prose with no
  blank line is one block and is not heading-only. Benign, since that block does contain prose.
- The `p.trim().length > 30` filter drops short headings before selection, so a query matching
  a short section heading never reaches the locality path.
- ATX detection requires a space after the hashes, per CommonMark. `#Title` is not treated as  a heading.