### PR TITLE
Docs: the DA migration steps undo the decision made earlier in the same file

### DIFF
--- a/LifeOS/install/LIFEOS/DOCUMENTATION/Pulse/DaSubsystem.md
+++ b/LifeOS/install/LIFEOS/DOCUMENTATION/Pulse/DaSubsystem.md
@@ -1095,6 +1095,12 @@ Tasks:
 
 ## 9. Migration Plan
 
+> **Format note.** This plan was drafted while the schema still lived in a sibling
+> `DA_IDENTITY.yaml`. Section 1 retired that two-file split — the schema is now YAML
+> frontmatter inside `DA_IDENTITY.md` itself. Read the steps below that write or
+> deprecate a `.yaml` as writing the frontmatter of the single file. `MigrateDAIdentity.ts`
+> is not part of the release payload.
+
 ### Step-by-Step Migration for the primary DA
 
 ```


### PR DESCRIPTION
The DA subsystem doc contradicts itself, and anyone following it would undo a decision it already made.

Section 1 says the assistant's identity used to live in two files: a YAML file holding the structured data, and a markdown file generated from it. That was dropped, because keeping the two in sync was a constant hazard. The design now is one file. Markdown, with the structured data in its frontmatter.

Section 9 still walks you through moving to the old two-file setup. Step 2 writes the YAML file and generates the markdown "for backward compat". Step 6 then marks the markdown deprecated in favour of the YAML. It also tells you to run `LIFEOS/TOOLS/MigrateDAIdentity.ts`, which isn't in the release.

This adds one short note at the top of section 9 saying the plan predates that decision, and to read the YAML steps as writing frontmatter in the single file instead. There's already a note in the same shape near the top of the doc covering a similar case, so it should read as familiar.

I left the steps themselves alone, so nothing is lost if the plan gets picked up again later.

Six lines added, nothing removed.