### PR TITLE
docs(art,remotion): stop routing work to GPT-Image-2, removed 2026-07-30

### DIFF
--- a/LifeOS/install/skills/Art/SKILL.md
+++ b/LifeOS/install/skills/Art/SKILL.md
@@ -40,11 +40,11 @@ These override default behavior. If the directory does not exist, proceed with s
 
 ## What It Does
 
-Generates static visual content across 20+ formats — blog headers, technical and architecture diagrams, frameworks, taxonomies, timelines, comparisons, stat cards, comics, icons, wallpapers, D3 charts, Mermaid diagrams — using Flux, Nano Banana Pro (Gemini 3 Pro), and GPT-Image-2. Every request routes through a named workflow that encodes the technique and palette, output stages to $LIFEOS_DOWNLOADS_DIR (default ~/Downloads/ when unset) for review first, and blog headers ship both a transparent inline version and an opaque social thumbnail.
+Generates static visual content across 20+ formats — blog headers, technical and architecture diagrams, frameworks, taxonomies, timelines, comparisons, stat cards, comics, icons, wallpapers, D3 charts, Mermaid diagrams — using Flux and Nano Banana Pro (Gemini 3 Pro). Every request routes through a named workflow that encodes the technique and palette, output stages to $LIFEOS_DOWNLOADS_DIR (default ~/Downloads/ when unset) for review first, and blog headers ship both a transparent inline version and an opaque social thumbnail.
 
 ## The Problem
 
-The bare image model produces inconsistent, off-style output when handed a freeform prompt — one session shipped 12 rejected diagrams because the prompt skipped the workflow that holds the composition rules. Different formats need different models (text-heavy cards want GPT-Image-2; editorial headers want Nano Banana Pro), different size formats, and different transparency handling. Without a fixed routing-and-staging discipline, you get wrong sizes, opaque headers that bleed over the page background, and images pushed straight to a repo before anyone looked at them. This skill makes the workflow, the model choice, and the Downloads-first review mandatory in code, not just in markdown.
+The bare image model produces inconsistent, off-style output when handed a freeform prompt — one session shipped 12 rejected diagrams because the prompt skipped the workflow that holds the composition rules. Different formats need different models (text-heavy cards and editorial headers want Nano Banana Pro), different size formats, and different transparency handling. Without a fixed routing-and-staging discipline, you get wrong sizes, opaque headers that bleed over the page background, and images pushed straight to a repo before anyone looked at them. This skill makes the workflow, the model choice, and the Downloads-first review mandatory in code, not just in markdown.
 
 ## How It Works
 

--- a/LifeOS/install/skills/Remotion/Tools/Ref-ai-pipeline.md
+++ b/LifeOS/install/skills/Remotion/Tools/Ref-ai-pipeline.md
@@ -14,7 +14,7 @@ Generate all ingredients (scene images, narration audio, captions) with AI, then
 ```
 Topic/Script
     │
-    ├── Art skill (Nano Banana Pro / GPT-Image-2) ──► scene-N.png in /public
+    ├── Art skill (Nano Banana Pro) ──────────────► scene-N.png in /public
     ├── ElevenLabs TTS ───────────────────────────► narration.mp3 in /public
     └── ElevenLabs STT (on narration.mp3) ────────► Caption[]
             │

--- a/LifeOS/install/skills/Remotion/Workflows/GeneratedContentVideo.md
+++ b/LifeOS/install/skills/Remotion/Workflows/GeneratedContentVideo.md
@@ -19,7 +19,7 @@ End-to-end AI video generation: topic or script → scene images + narration + c
 ## Prerequisites
 
 - `ELEVENLABS_API_KEY` in environment
-- Art skill configured (Nano Banana Pro or GPT-Image-2) <!-- public issue #1760, @jacobo-ortiz -->
+- Art skill configured (Nano Banana Pro) <!-- public issue #1760, @jacobo-ortiz -->
 - Existing Remotion project OR this workflow will create one
 
 ## Execution Steps


### PR DESCRIPTION
Docs only, 3 files, +4/−4. Fixes #2007. No removed model is referenced anywhere after this change (payload-wide sweep), and every replacement names only models `Generate.ts` actually ships (`:94`: `flux | nano-banana | nano-banana-pro`, default `nano-banana-pro`).