### PR TITLE
fix(satisfaction): stop scoring numbered instructions and menu selections as ratings

### DIFF
--- a/LifeOS/install/hooks/SatisfactionCapture.hook.ts
+++ b/LifeOS/install/hooks/SatisfactionCapture.hook.ts
@@ -127,14 +127,39 @@ const WORD_NUMBERS: Record<string, number> = {
 
 // ── Explicit Rating Detection ──
 
-export function parseExplicitRating(prompt: string): { rating: number; comment?: string } | null {
+// Enumerated-option markers in the previous response. A bare "1" or "2" replying to a
+// response that offered choices is a SELECTION, not a rating.
+const OPTION_MENU_PATTERNS: readonly RegExp[] = [
+  /^\s*(?:\*\*)?\(?[1-9a-e][.)]\s/m,   // "1. ", "1) ", "(a) ", "**2. "
+  /\boption\s+[1-9a-e]\b/i,            // "option 2"
+  /\(\s*[a-e]\s*\)/,                   // inline "(a) ... (b) ..."
+];
+
+function lastResponseOfferedOptions(lastResponse: string): boolean {
+  if (!lastResponse) return false;
+  return OPTION_MENU_PATTERNS.some(re => re.test(lastResponse));
+}
+
+// On one install this parser produced 8 false positives out of 8 explicit ratings ever
+// recorded — zero genuine. Two failure modes, neither covered by the #1670/#1703 guards
+// ("1 commit and push" still parses as 1/10):
+//   1. Numbered instructions — a trailing comment is only honoured on the "N/10" form.
+//   2. Option selections — bare numbers are rejected when the previous response offered a menu.
+// Real ratings still work: "8", "8/10", "8/10 nice catch", "eight".
+export function parseExplicitRating(
+  prompt: string,
+  lastResponse: string = '',
+): { rating: number; comment?: string } | null {
   const trimmed = prompt.trim();
+  const menuOffered = lastResponseOfferedOptions(lastResponse);
 
   // Check word-form ratings first (e.g., "ten", "Eight")
   const lowerTrimmed = trimmed.toLowerCase();
   for (const [word, num] of Object.entries(WORD_NUMBERS)) {
     if (lowerTrimmed === word || lowerTrimmed.startsWith(word + ' ') || lowerTrimmed.startsWith(word + '!')) {
       const rest = trimmed.slice(word.length).trim().replace(/^[!.,]+/, '').trim() || undefined;
+      if (rest) return null;          // "one commit and push" is an instruction
+      if (menuOffered) return null;   // a reply to an offered menu is a selection
       return { rating: num, comment: rest };
     }
   }
@@ -191,6 +216,13 @@ export function parseExplicitRating(prompt: string): { rating: number; comment?:
   // unambiguous rating syntax and are deliberately NOT capped.
   // public PR #1670, @asdf8675309
   if (rest && rest.length > MAX_BARE_DIGIT_COMMENT) return null;
+
+  // A bare number carries no evidence of intent, so anything trailing it is
+  // treated as an instruction ("1 commit and push"), not a rating comment.
+  if (rest) return null;
+
+  // A bare number replying to an offered menu is a selection, not a score.
+  if (menuOffered) return null;
 
   return { rating, comment: rest };
 }
@@ -406,7 +438,8 @@ async function main() {
 
     // ── FAST PATH: Explicit rating (checked BEFORE the length skip so a bare
     // "9"/"10" — length 1-2 — is still captured; #1182). ──
-    const explicitResult = parseExplicitRating(prompt);
+    const lastResponseForParse = getLastResponse();
+    const explicitResult = parseExplicitRating(prompt, lastResponseForParse);
 
     if (!explicitResult && prompt.length < MIN_PROMPT_LENGTH) {
       console.error('[SatisfactionCapture] Prompt too short, skipping');
@@ -415,7 +448,7 @@ async function main() {
 
     if (explicitResult) {
       console.error(`[SatisfactionCapture] Explicit rating: ${explicitResult.rating}`);
-      const lastResponse = getLastResponse();
+      const lastResponse = lastResponseForParse;
       const entry: RatingEntry = {
         timestamp: getISOTimestamp(),
         rating: explicitResult.rating,


### PR DESCRIPTION
## The bug

`parseExplicitRating` treats a leading 1-10 as an explicit satisfaction rating. On one install, **8 of the 8 explicit ratings ever recorded were false** and none were genuine.

Two failure modes, neither covered by the #1670 / #1703 guards:

| input | parsed as |
|---|---|
| `1 commit and push` | rating **1/10**, comment `commit and push` |
| `one commit and push` | rating **1/10**, comment `commit and push` |
| `1` answering a menu the assistant just offered | rating **1/10** |

The last one is common: the assistant offers `1. …  2. …`, the user types `2`, and that becomes a 2/10.

## Why it matters more than a bad number

The damage compounds downstream. Every rating under 5 writes a `LEARNING_low-rating-*.md`, and every rating under 4 fires a full `FailureCapture` with an LLM-written failure title. So a successful session acquires an invented failure. A real example from the affected install:

```
commit-and-push-requested-but-conversation-shows-unresolved-symlink-conflicts
```

Nothing went wrong in that session. The "unresolved conflicts" were an installer correctly refusing to clobber symlinks it did not create. The learning corpus is now carrying a fabricated lesson about a non-event.

## The fix

Two guards:

1. A trailing comment is honoured only on the unambiguous `N/10` form. A bare number carries no evidence of intent, so anything trailing it is an instruction, not a rating comment.
2. A bare number is rejected when the previous response offered enumerated options, because that is a selection. Detected with three patterns: `1. ` / `1) ` / `(a) ` at line start, `option 2`, and inline `(a) … (b) …`.

`parseExplicitRating` takes `lastResponse` as an **optional second parameter defaulting to `''`**, so every existing caller is unaffected.

Real ratings still parse: `8`, `8/10`, `8/10 nice catch`, `eight`.

## Tests

I have a `bun test` file covering all of this — 14 cases across both failure modes plus the still-working forms. The repo ships no `*.test.ts` and no runner, so I left it out rather than bundle a testing convention into a bug fix. Say the word and I will add it here or in a follow-up.
