### PR TITLE
fix: create parent dir before writing state files

### DIFF
--- a/LifeOS/install/LIFEOS/TOOLS/DoctrineReplay.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/DoctrineReplay.ts
@@ -19,8 +19,8 @@
  *   bun DoctrineReplay.ts sample [--n 24] [--out <path>]   # emit manifest JSON
  *   bun DoctrineReplay.ts sample --json                    # manifest to stdout only
  */
-import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { readdirSync, readFileSync, statSync, writeFileSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 
 const WORK_DIR = join(homedir(), ".claude/LIFEOS/MEMORY/WORK");
@@ -147,6 +147,7 @@ function main() {
 
   const json = JSON.stringify(manifest, null, 2);
   if (outIdx >= 0) {
+    mkdirSync(dirname(args[outIdx + 1]), { recursive: true }); // git cannot track an empty dir, so this path is absent on a fresh clone
     writeFileSync(args[outIdx + 1], json, "utf8");
     console.log(`manifest → ${args[outIdx + 1]} (${picked.length}/${n} sampled from ${all.length})`);
   }

--- a/LifeOS/install/LIFEOS/TOOLS/GenerateKnowledgeSchemaDoc.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/GenerateKnowledgeSchemaDoc.ts
@@ -13,8 +13,8 @@
  *   bun GenerateKnowledgeSchemaDoc.ts --stdout   # print, don't write
  */
 
-import { writeFileSync } from "node:fs";
-import { resolve as pathResolve } from "node:path";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { resolve as pathResolve, dirname } from "node:path";
 import { homedir } from "node:os";
 import {
   ENVELOPE, CANONICAL_TYPES, TYPE_TO_DIR, PER_TYPE_REQUIRED,
@@ -111,6 +111,7 @@ export function render(): string {
 function main() {
   const doc = render();
   if (process.argv.includes("--stdout")) { console.log(doc); return; }
+  mkdirSync(dirname(OUT), { recursive: true }); // git cannot track an empty dir, so this path is absent on a fresh clone
   writeFileSync(OUT, doc, "utf8");
   console.log(`✓ wrote ${OUT.replace(homedir(), "~")} (${doc.split("\n").length} lines, generated from KnowledgeSchema.ts)`);
 }

--- a/LifeOS/install/LIFEOS/TOOLS/MemoryRestore.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/MemoryRestore.ts
@@ -12,8 +12,8 @@
  * itself trip the curation guards — it's a recovery path, not a curation write.
  */
 
-import { readdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
-import { resolve as pathResolve } from "node:path";
+import { readdirSync, readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { resolve as pathResolve, dirname } from "node:path";
 import { homedir } from "node:os";
 import { parseMemoryContent } from "./MemoryWriter";
 
@@ -59,6 +59,7 @@ function main(): void {
     if (!existsSync(src)) { console.error(`Snapshot not found: ${arg}`); process.exit(1); }
     const which = arg.startsWith("PRINCIPAL_MEMORY") ? "principal" : "da";
     const content = readFileSync(src, "utf8");
+    mkdirSync(dirname(TARGETS[which]), { recursive: true }); // git cannot track an empty dir, so this path is absent on a fresh clone
     writeFileSync(TARGETS[which], content, "utf8");
     console.log(`Restored ${which} from ${arg} (${countEntries(content)} entries).`);
     return;

--- a/LifeOS/install/LIFEOS/TOOLS/ProposalGC.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/ProposalGC.ts
@@ -47,7 +47,7 @@
  *   bun ProposalGC.ts --route        # advisory: flag hook-, skill-, or project-scoped entries
  *   bun ProposalGC.ts --json
  */
-import { readFileSync, writeFileSync, renameSync, existsSync } from "node:fs";
+import { readFileSync, writeFileSync, renameSync, existsSync, mkdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { classifyScope, loadScopeTables, type ProposalScope, type ScopeTables } from "./ProposalScope";
 
@@ -271,6 +271,7 @@ function countBy(rs: Removal[]): Record<string, number> {
 }
 function appendLog(obj: unknown) {
   const { appendFileSync } = require("node:fs");
+  mkdirSync(dirname(OBS_LOG), { recursive: true }); // git cannot track an empty dir, so this path is absent on a fresh clone
   appendFileSync(OBS_LOG, JSON.stringify(obj) + "\n", "utf8");
 }
 

--- a/LifeOS/install/LIFEOS/TOOLS/SessionProgress.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/SessionProgress.ts
@@ -9,8 +9,8 @@
  *   bun run ~/.claude/LIFEOS/TOOLS/SessionProgress.ts <command> [options]
  */
 
-import { existsSync, readFileSync, writeFileSync, readdirSync } from 'fs';
-import { join } from 'path';
+import { existsSync, readFileSync, writeFileSync, readdirSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
 import { homedir } from "node:os";
 
 interface Decision {
@@ -59,6 +59,7 @@ function loadProgress(project: string): SessionProgress | null {
 
 function saveProgress(progress: SessionProgress): void {
   progress.updated = new Date().toISOString();
+  mkdirSync(dirname(getProgressPath(progress.project)), { recursive: true }); // git cannot track an empty dir, so this path is absent on a fresh clone
   writeFileSync(getProgressPath(progress.project), JSON.stringify(progress, null, 2));
 }
 

--- a/LifeOS/install/LIFEOS/TOOLS/SessionRename.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/SessionRename.ts
@@ -33,8 +33,8 @@
  *   bun SessionRename.ts list                          (show 10 most-recent sessions)
  */
 
-import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
-import { resolve as pathResolve, join as pathJoin } from "node:path";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { resolve as pathResolve, join as pathJoin, dirname } from "node:path";
 import { homedir } from "node:os";
 // Registry access goes through the isa-utils choke point (2026-06-10) — the
 // event-sourced write path. This file previously carried a duplicate
@@ -77,6 +77,9 @@ function loadNames(): Record<string, string> {
 
 function writeNames(names: Record<string, string>): void {
   const tmp = `${SESSION_NAMES_JSON}.tmp`;
+  // MEMORY/STATE may not exist: git cannot track an empty directory, so a fresh
+  // clone or a migration arrives without it and every rename lands nowhere.
+  mkdirSync(dirname(SESSION_NAMES_JSON), { recursive: true });
   writeFileSync(tmp, JSON.stringify(names, null, 2), "utf8");
   renameSync(tmp, SESSION_NAMES_JSON);
 }

--- a/LifeOS/install/LIFEOS/TOOLS/UpdateModels.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/UpdateModels.ts
@@ -21,8 +21,8 @@
  * ============================================================================
  */
 
-import { readFileSync, writeFileSync, appendFileSync, readdirSync } from "fs";
-import { join } from "path";
+import { readFileSync, writeFileSync, appendFileSync, readdirSync, mkdirSync } from "fs";
+import { join, dirname } from "path";
 import { CURRENT, EFFORT_MODEL, CLAUDE_ID_PATTERN, type ClaudeTier } from "./models";
 
 const CLAUDE_DIR = join(import.meta.dir, "..", "..");
@@ -144,6 +144,7 @@ export function emitModelProposal(
     note: "Propose-only. New Claude model ID detected; review, then run the action command to bump the registry.",
   };
   try {
+    mkdirSync(dirname(logPath), { recursive: true }); // git cannot track an empty dir, so this path is absent on a fresh clone
     appendFileSync(logPath, JSON.stringify(row) + "\n");
   } catch {
     writeFileSync(logPath, JSON.stringify(row) + "\n");

--- a/LifeOS/install/LIFEOS/TOOLS/UsageAggregator.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/UsageAggregator.ts
@@ -23,9 +23,9 @@
  *   { date, messages, inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens,
  *     totalTokens, costUsd, models: { <model>: { messages, totalTokens, costUsd } } }
  */
-import { existsSync, readFileSync, readdirSync, writeFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, writeFileSync, statSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
 
 const CLAUDE_DIR = process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
 const OBS_DIR = join(CLAUDE_DIR, "LIFEOS", "MEMORY", "OBSERVABILITY");
@@ -205,6 +205,7 @@ function main() {
     console.log(`[UsageAggregator] --dry-run: not writing ${OUT_PATH}`);
     return;
   }
+  mkdirSync(dirname(OUT_PATH), { recursive: true }); // git cannot track an empty dir, so this path is absent on a fresh clone
   writeFileSync(OUT_PATH, days.map((d) => JSON.stringify(d)).join("\n") + "\n");
   console.log(`[UsageAggregator] wrote ${days.length} day-rows → ${OUT_PATH}`);
 }

--- a/LifeOS/install/hooks/handlers/UpdateCounts.ts
+++ b/LifeOS/install/hooks/handlers/UpdateCounts.ts
@@ -18,8 +18,8 @@
  * not a filesystem-walk cache.
  */
 
-import { readFileSync, writeFileSync } from 'fs';
-import { join } from 'path';
+import { readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
 import { execSync } from 'child_process';
 import { getLifeosDir } from '../lib/paths';
 import { homedir } from "node:os";
@@ -100,6 +100,7 @@ async function refreshUsageCache(paiDir: string): Promise<void> {
       }
     }
 
+    mkdirSync(dirname(usageCachePath), { recursive: true }); // git cannot track an empty dir, so this path is absent on a fresh clone
     writeFileSync(usageCachePath, JSON.stringify(data, null, 2) + '\n');
     console.error(`[UpdateCounts] Usage cache refreshed: 5H=${(data.five_hour as any)?.utilization}% 7D=${(data.seven_day as any)?.utilization}%`);
   } catch {


### PR DESCRIPTION
## Problem

Nine tools and hooks write to paths under `LIFEOS/MEMORY/STATE` and `LIFEOS/OBSERVABILITY` whose parent directory git cannot carry, because git does not track empty directories. On a fresh clone — or any install where the directory has not happened to be created by some other code path first — the write throws `ENOENT` and the feature silently does nothing.

`SessionRename` is the clearest case: every rename lands nowhere because `MEMORY/STATE/` does not exist yet.

## Fix

Each write site calls `mkdirSync(dirname(path), { recursive: true })` immediately before the write. The call is a no-op when the directory already exists, so existing installs see no behaviour change.

## Files

`DoctrineReplay` · `GenerateKnowledgeSchemaDoc` · `MemoryRestore` · `ProposalGC` · `SessionProgress` · `SessionRename` · `UpdateModels` · `UsageAggregator` · `hooks/handlers/UpdateCounts`

## Verification

All nine parse-check clean (`bun build --target=bun`). Imports are merged into each file's existing `fs`/`path` import lines, matching that file's own quote and specifier style rather than adding a second import group.

+28 / -17 across 9 files. No behaviour change beyond the directory creation.
