### PR TITLE
fix: detect forked subagents from the hook payload, not env alone

### DIFF
--- a/LifeOS/install/hooks/ConfigEvalFire.hook.ts
+++ b/LifeOS/install/hooks/ConfigEvalFire.hook.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 /**
- * @version 1.0.1
+ * @version 1.1.0
  * ConfigEvalFire — PostToolUse(Write|Edit) hook that fires the {{DA_NAME}} behavioural
  * regression suite when a behaviour-defining file changes.
  *
@@ -41,13 +41,16 @@ function isSentinel(path: string): boolean {
   return /(^|\/)CLAUDE\.md$/.test(path);
 }
 
-function readInput(): { filePath: string | null } {
+function readInput(): { filePath: string | null; agent_id?: unknown; agent_type?: unknown } {
   try {
     const raw = readFileSync(0, 'utf8');
     if (!raw.trim()) return { filePath: null };
     const j = JSON.parse(raw);
     const fp = j?.tool_input?.file_path;
-    return { filePath: typeof fp === 'string' ? fp : null };
+    // agent_id/agent_type are carried through for the subagent test: a fork
+    // editing a sentinel would otherwise spawn the whole behavioural suite,
+    // because the env-only test cannot see a fork.
+    return { filePath: typeof fp === 'string' ? fp : null, agent_id: j?.agent_id, agent_type: j?.agent_type };
   } catch {
     return { filePath: null };
   }
@@ -76,9 +79,10 @@ function saveLastFire(iso: string): void {
 
 function main(): void {
   try {
-    if (isSubagent()) process.exit(0);
+    const input = readInput();
+    if (isSubagent(input)) process.exit(0);
 
-    const { filePath } = readInput();
+    const { filePath } = input;
     if (!filePath || !isSentinel(filePath)) process.exit(0);
     if (minutesSince(loadLastFire()) < DEBOUNCE_MINUTES) process.exit(0);
     if (!existsSync(RUNNER)) process.exit(0);

--- a/LifeOS/install/hooks/ISASync.hook.ts
+++ b/LifeOS/install/hooks/ISASync.hook.ts
@@ -153,7 +153,13 @@ async function main(): Promise<string | null> {
   // without a phase edit. Per-session dedupe file; subagents never emit (their
   // ISA edits would strip-spam their own contexts, which helps nobody).
   let stripDelta: string | null = null;
-  if (input.session_id && fm.slug && !isSubagentContext()) {
+  // Payload-aware: a fork's env carries no subagent marker and shares the
+  // parent's session_id, so the env-only test returned false inside a fork and
+  // this strip was injected into the fork's OWN transcript. Scope note:
+  // syncToWorkJson above is deliberately NOT behind this test and never was — a
+  // fork editing an ISA is real work on the run and its progress should land in
+  // work.json. Only the strip is per-context, so only the strip is gated.
+  if (input.session_id && fm.slug && !isSubagentContext(input)) {
     try {
       const stripDir = join(homedir(), '.claude/LIFEOS/MEMORY/STATE/ascent-strip');
       const stripFile = join(stripDir, `${String(input.session_id).replace(/[^\w-]/g, '')}.json`);

--- a/LifeOS/install/hooks/PostToolObserver.hook.ts
+++ b/LifeOS/install/hooks/PostToolObserver.hook.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 /**
- * @version 1.0.3
+ * @version 1.1.0
  * TRIGGER: PostToolUse (catchall, matcher "") — must stay on the empty matcher so it fires on EVERY tool call.
  * PostToolObserver.hook.ts — the ONE sync catchall PostToolUse hook.
  *
@@ -22,6 +22,7 @@
 import { run as loopDetector } from "./LoopDetector.hook";
 import { run as algorithmNudge } from "./AlgorithmNudge.hook";
 import { run as systemChangeSurface } from "./SystemChangeSurface.hook";
+import { isSubagentContext, type SubagentHookInput } from "./lib/subagent";
 
 /** The ⚙️ line follows the 🧠 contract: computed by the hook, echoed verbatim.
  *  Stating that beside the line is what keeps it from being paraphrased. */
@@ -46,6 +47,12 @@ async function readStdin(): Promise<string> {
   if (!raw.trim()) process.exit(0);
   let input: Record<string, unknown>;
   try { input = JSON.parse(raw); } catch { process.exit(0); }
+
+  // A fork's hook process carries NO subagent env markers and shares the
+  // parent's session_id, so the env-only test returned false and this
+  // composer injected main-session nudges and the ⚙️ SYSTEM line into forks. The
+  // payload's agent_id/agent_type is the only reliable signal; pass it through.
+  if (isSubagentContext(input as SubagentHookInput)) process.exit(0);
 
   const parts: string[] = [];
   try { const m = loopDetector(input as never); if (m) parts.push(m); } catch {}

--- a/LifeOS/install/hooks/lib/subagent.ts
+++ b/LifeOS/install/hooks/lib/subagent.ts
@@ -19,17 +19,37 @@
  * is unset, so the union cannot false-positive there.
  */
 
-/** True when this process is a subagent/delegate rather than the main session. */
-export function isSubagentContext(): boolean {
+/**
+ * Hook payload fields that identify delegated work. PostToolUse carries these
+ * ONLY for subagent calls; they are absent in the main session.
+ */
+export interface SubagentHookInput {
+  agent_id?: unknown;
+  agent_type?: unknown;
+}
+
+/**
+ * True when this process is a subagent/delegate rather than the main session.
+ *
+ * Pass the hook's parsed stdin payload whenever you have it.
+ * The environment union below CANNOT see a fork: measured live,
+ * a fork's PostToolUse hook process had every marker unset — including
+ * CLAUDE_CODE_FORK_SUBAGENT — and shared the parent's session_id byte for byte.
+ * The only signal that distinguished the two was agent_id/agent_type in the
+ * hook payload itself. Env markers are kept because they still identify the
+ * non-fork delegate families and standalone runs, where no payload exists.
+ */
+export function isSubagentContext(hookInput?: SubagentHookInput | null): boolean {
+  if (hookInput && (hookInput.agent_id || hookInput.agent_type)) return true;
   const projectDir = process.env.CLAUDE_PROJECT_DIR || '';
   return Boolean(
     projectDir.includes('/.claude/Agents/') ||
       process.env.CLAUDE_AGENT_TYPE ||
       process.env.CLAUDE_CODE_SUBAGENT_NAME ||
       process.env.CLAUDE_CODE_SUBAGENT_TYPE ||
-      // Forked subagents set ONLY the fork marker — none of the above.
-      // Without it, 8 hook consumers re-inject main-session context into
-      // forks that inherited it via cache. (public issue #1831, @DRAZY)
+      // Kept for any runtime that DOES set this, but insufficient on its own:
+      // a fork was observed with no marker set at all, which is why the
+      // hookInput check above exists. (public issue #1831)
       process.env.CLAUDE_CODE_FORK_SUBAGENT === '1' ||
       process.env.CLAUDE_AGENT_SDK === '1',
   );


### PR DESCRIPTION
## Problem

`isSubagentContext()` tests environment variables only. A forked subagent does not reliably set any of them — including `CLAUDE_CODE_FORK_SUBAGENT` — and it shares the parent's `session_id` byte for byte. Measured live: a fork's `PostToolUse` hook process had every marker in the union unset.

So the test returns `false` inside a fork, and every consumer treats the fork as the main session:

- **PostToolObserver** injected main-session nudges and the SYSTEM line into a fork's own transcript.
- **ISASync** injected the ascent strip there too.
- **ConfigEvalFire** spawned the entire behavioural regression suite when a fork touched a sentinel file.

This is the residual half of #1831: the fork marker was added for exactly this, and on at least some runtimes it is never set.

## Fix

`PostToolUse` carries `agent_id` / `agent_type` for delegated calls and omits them in the main session, which makes the payload the reliable signal.

`isSubagentContext()` now takes the parsed hook input as an optional first argument and returns `true` when either field is present. The environment union is unchanged and still covers the non-fork delegate families and standalone runs, where no payload exists. Existing no-argument callers keep working — the parameter is optional, so this is not a breaking change.

The three consumers above pass their already-parsed `input` through. `ConfigEvalFire.readInput()` is widened to carry the two fields.

## Scope note

In `ISASync`, only the ascent strip is gated. `syncToWorkJson` is deliberately left ungated and never was gated: a fork editing an ISA is real work on the run, and its progress belongs in `work.json`. Only the strip is per-context, so only the strip is gated.

## Verification

All four files parse-check clean (`bun build --target=bun`). `input` is confirmed in scope at each insertion site, and no duplicate imports are introduced.
