### PR TITLE
fix: repair four breaks in the autonomic memory loop

### DIFF
--- a/LifeOS/install/LIFEOS/TOOLS/Inference.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/Inference.ts
@@ -353,7 +353,19 @@ async function inferenceAttempt(options: InferenceOptions, modelOverride?: strin
         return;
       }
 
-      const envelope = parsedEnvelope as Record<string, unknown>;
+      // The CLI emits EITHER a single result object OR a JSON array of stream
+      // events whose last `type:"result"` element carries the envelope. Claude
+      // Code 2.1.246 returns the array form; before this, an array fell through
+      // the object check above (arrays are objects), `envelope.result` read
+      // undefined, and every programmatic caller died on "missing result field".
+      // That silently killed the memory reviewer from 2026-08-16 onward.
+      // Select the terminal result element rather than assuming either shape.
+      const envelope = (Array.isArray(parsedEnvelope)
+        ? (parsedEnvelope.filter(
+            (e): e is Record<string, unknown> =>
+              typeof e === 'object' && e !== null && (e as Record<string, unknown>).type === 'result',
+          ).at(-1) ?? parsedEnvelope.at(-1) ?? {})
+        : parsedEnvelope) as Record<string, unknown>;
       const stopReason = envelope.stop_reason;
       const resultText = typeof envelope.result === 'string' ? envelope.result : undefined;
 

--- a/LifeOS/install/LIFEOS/TOOLS/MemoryRetriever.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/MemoryRetriever.ts
@@ -44,6 +44,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { spawnSync } from "child_process";
 import { homedir } from "node:os";
+import { createHash } from "node:crypto";
 
 // Normalize env path vars that Claude Code injects without shell expansion (LifeOS#1404)
 for (const k of ["LIFEOS_DIR", "LIFEOS_CONFIG_DIR", "PROJECTS_DIR"]) {
@@ -685,7 +686,54 @@ function discoverAllItems(): KnowledgeNote[] {
  *   excerptChars — max excerpt length per result (default 500)
  *   typeFilter   — restrict to one type
  */
+const RETRIEVALS_LOG = path.join(HOME, ".claude/LIFEOS/MEMORY/OBSERVABILITY/memory-retrievals.jsonl");
+
+/**
+ * Append one row of retrieval evidence.
+ *
+ * CortexHealth and MemoryStatus have always READ memory-retrievals.jsonl, and
+ * MemoryHealthCheck warns when no row is fresher than its window. Nothing has
+ * ever written the file: on 2026-08-26 a repo-wide grep found three references,
+ * all readers, and the path did not exist on disk. So the check was correct and
+ * the writer was simply absent — the retriever fired on every turn (the live
+ * payload carried <lifeos-ground> at byte 10,162) and left no trace.
+ *
+ * Schema is fixed by CortexHealth's validRetrievalRow: exactly ts, query_hash,
+ * returned_count, duration_ms, and optional top_score. Extra keys make the row
+ * INVALID, which is a louder failure than a missing one — do not add fields
+ * here without changing that validator first. The query itself is never
+ * written, only a hash: this log is freshness evidence, not a query history.
+ */
+function logRetrieval(startMs: number, query: string, returned: number, topScore?: number): void {
+  try {
+    const row: Record<string, unknown> = {
+      ts: new Date().toISOString(),
+      query_hash: createHash("sha256").update(query).digest("hex").slice(0, 16),
+      returned_count: returned,
+      duration_ms: Math.max(0, Date.now() - startMs),
+    };
+    if (typeof topScore === "number" && Number.isFinite(topScore) && topScore >= 0) row.top_score = topScore;
+    fs.mkdirSync(path.dirname(RETRIEVALS_LOG), { recursive: true });
+    fs.appendFileSync(RETRIEVALS_LOG, JSON.stringify(row) + "\n", "utf8");
+  } catch { /* best-effort — evidence logging never breaks a turn */ }
+}
+
+/**
+ * Public entry point. Times the retrieval, delegates, and records the evidence
+ * row on EVERY call including cache hits: the question the health check asks is
+ * "did retrieval run this turn?", and a cache hit is still a turn that ran it.
+ */
 export function getRelevantContext(
+  query: string,
+  options: { topK?: number; threshold?: number; excerptChars?: number; typeFilter?: string } = {},
+): GetRelevantContextResult {
+  const startedAt = Date.now();
+  const result = computeRelevantContext(query, options);
+  logRetrieval(startedAt, query, result.results.length, result.results[0]?.score);
+  return result;
+}
+
+function computeRelevantContext(
   query: string,
   options: { topK?: number; threshold?: number; excerptChars?: number; typeFilter?: string } = {},
 ): GetRelevantContextResult {

--- a/LifeOS/install/LIFEOS/TOOLS/MemoryReviewer.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/MemoryReviewer.ts
@@ -596,11 +596,43 @@ function tsSlug(): string {
   return new Date().toISOString().replace(/[:.]/g, "-");
 }
 
+const REVIEW_STATE_PATH = pathResolve(CLAUDE_ROOT, "LIFEOS/MEMORY/OBSERVABILITY/review-state.json");
+
+/**
+ * Stamp `last_review_at` when a review actually completes.
+ *
+ * Before this, only MemoryReviewFire.hook.ts wrote that field, and only at the
+ * moment it decided to SPAWN. So a review that ran by any other path — a manual
+ * run, a retry, a recovery after the hook was suppressed — left the field frozen.
+ * Measured 2026-08-26: reviewer-runs.jsonl held two runs from that morning, one
+ * of them fully successful, while review-state.json still read 2026-08-16 and
+ * MemoryHealthCheck reported the autonomic loop stuck for ten days.
+ *
+ * Two things were wrong, not one: the health report was misleading, AND
+ * `min_minutes_between` is computed from this same field, so a completed review
+ * did not count against the rate cap and the hook could immediately spawn a
+ * duplicate. The event "a review finished" is what the field means, so the
+ * reviewer is where it belongs. Skipped runs are not reviews and do not stamp.
+ */
+function stampLastReviewAt(row: Record<string, unknown>): void {
+  if (row.ok !== true || row.skipped === true) return;
+  try {
+    let state: Record<string, unknown> = {};
+    if (existsSync(REVIEW_STATE_PATH)) {
+      try { state = JSON.parse(readFileSync(REVIEW_STATE_PATH, "utf8")) as Record<string, unknown>; } catch { state = {}; }
+    }
+    state.last_review_at = typeof row.ts === "string" ? row.ts : new Date().toISOString();
+    mkdirSync(dirname(REVIEW_STATE_PATH), { recursive: true });
+    writeFileSync(REVIEW_STATE_PATH, JSON.stringify(state, null, 2) + "\n", "utf8");
+  } catch { /* best-effort — never fail a review over its own bookkeeping */ }
+}
+
 function logRunSummary(row: Record<string, unknown>): void {
   try {
     mkdirSync(dirname(RUNS_LOG_PATH), { recursive: true });
     appendFileSync(RUNS_LOG_PATH, JSON.stringify(row) + "\n", "utf8");
   } catch { /* best-effort */ }
+  stampLastReviewAt(row);
 }
 
 function writeRunDebug(runId: string, files: Record<string, string>): void {

--- a/LifeOS/install/hooks/MemoryTurnStart.hook.ts
+++ b/LifeOS/install/hooks/MemoryTurnStart.hook.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 /**
- * @version 1.1.2
+ * @version 1.2.0
  * MemoryTurnStart.hook.ts — the ONE UserPromptSubmit memory hook.
  *
  * Consolidation (2026-07-11, hooks BPE pass): merges the three per-prompt
@@ -9,9 +9,12 @@
  * and concatenates output. Order matches the old registration order:
  *
  *   1. MemoryReviewTrigger.run()  — cadence tick (state only, no output)
- *   2. LoadMemory.run()           — <lifeos-memory> hot-layer injection
- *   3. MemoryDeltaSurface.run()   — <lifeos-memory-health>? + <lifeos-memory-delta>
+ *   2. MemoryDeltaSurface.run()   — <lifeos-memory-health>? + <lifeos-memory-delta>
+ *   3. LoadMemory.run()           — <lifeos-memory> hot-layer injection
  *   4. getRelevantContext(prompt) — <lifeos-ground> task-scoped BM25 retrieval
+ *
+ * Emission order (see below): the two VERBATIM-contract blocks now
+ * precede the unbounded hot layer so a preview truncation cannot drop them.
  *
  * Step 4 (public issue #1573, @christauff): the ranked retriever previously
  * fired only on remote channels (ln), never on the CLI turn path — so prior
@@ -106,12 +109,21 @@ if (isSubagent()) process.exit(0);
   // by construction; a concurrent session's turn must not clear this one's.
   try { clearSystemDelta(sessionId); } catch {}
 
+  // Order is load-bearing. The composed payload runs ~12 KB,
+  // which exceeds the harness inline budget: the whole thing is persisted to a
+  // file and the model sees only a ~2 KB preview. <lifeos-memory-health> and
+  // <lifeos-memory-delta> are the two blocks whose ENTIRE contract is "render
+  // this VERBATIM", and emitting them last put them at byte ~9,776 of 12,226 —
+  // outside every preview. They are short and bounded (one line each), so they
+  // are emitted FIRST and the unbounded hot layer follows. Measured before the
+  // change: delta at 9,776, preview cut at 2,048. Do not reorder these back.
+  const delta = deltaSurface();
+  if (delta) process.stdout.write(delta);
+
   if (shouldInject(sessionId)) {
     const memory = loadMemory();
     if (memory) process.stdout.write(memory);
   }
-  const delta = deltaSurface();
-  if (delta) process.stdout.write(delta);
 
   // Task-scoped retrieval (public issue #1573, @christauff) — CLI parity with
   // the remote-channel ln() path. Empty markdownBlock (below threshold, empty


### PR DESCRIPTION
## Summary

Four independent defects in the path between "memory ran" and "the health check can see that it ran". Each is small. Together they made the autonomic loop report itself broken while it was, in part, genuinely not running.

They are grouped in one PR because they were found as one investigation and two of them mask each other: the missing retrieval writer and the frozen review stamp both surface as the same "loop is stuck" reading. Happy to split if you'd rather review them separately.

## 1. `Inference.ts` — envelope shape

The CLI emits **either** a single result object **or** a JSON array of stream events whose last `type:"result"` element carries the envelope. Only the object shape was handled. An array fell through the object check (arrays are objects), `envelope.result` read `undefined`, and every programmatic caller died on `missing result field`.

Fix selects the terminal `result` element instead of assuming either shape.

## 2. `MemoryRetriever.ts` — the evidence file nothing wrote

`CortexHealth` and `MemoryStatus` have always **read** `memory-retrievals.jsonl`, and `MemoryHealthCheck` warns when no row is fresher than its window. Nothing has ever **written** it. A repo-wide grep found three references, all readers, and the path did not exist on disk. So the check was correct and the writer was simply absent: retrieval fired every turn and left no trace.

Fix adds the writer, honouring `CortexHealth.validRetrievalRow` exactly — `ts`, `query_hash`, `returned_count`, `duration_ms`, optional `top_score`. Extra keys make a row *invalid*, which is a louder failure than a missing one, so the schema is deliberately not extended. Only a hash of the query is stored, never the query text: this is freshness evidence, not a query history.

Rows are written on **every** call including cache hits, because the question the health check asks is "did retrieval run this turn?" and a cache hit is still a turn that ran it.

## 3. `MemoryReviewer.ts` — `last_review_at` only stamped on spawn

The field was written only by `MemoryReviewFire.hook.ts`, and only at the moment it decided to spawn. A review that ran by any other path — a manual run, a retry, a recovery after the hook was suppressed — left it frozen.

Two things were wrong, not one. The health report was misleading, **and** `min_minutes_between` is computed from that same field, so a completed review did not count against the rate cap and the hook could immediately spawn a duplicate.

The event the field names is "a review finished", so the reviewer is where it belongs. Skipped runs are not reviews and do not stamp.

## 4. `MemoryTurnStart.hook.ts` — emission order

The composed payload runs ~12 KB, past the harness inline budget, so the whole thing is persisted to a file and only a ~2 KB preview is seen. The two blocks whose entire contract is *render this verbatim* were emitted last, landing at byte ~9,776 of 12,226 and outside every preview.

They are short and bounded (one line each), so they are now emitted first and the unbounded hot layer follows. No content change, order only.

## Verification

All four parse-check clean (`bun build --target=bun`) against a tree with dependencies installed.
