### PR TITLE
Knowledge schema: enforce every declared select enum, not just type

### DIFF
--- a/LifeOS/install/LIFEOS/TOOLS/GenerateKnowledgeSchemaDoc.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/GenerateKnowledgeSchemaDoc.ts
@@ -88,6 +88,10 @@ export function render(): string {
   L.push("");
   L.push("Bookmarks are NOT a type: an unprocessed saved URL is `status: inbox` + `source_kind: bookmark` on the type it will become; `ingest` promotes it.");
   L.push("");
+  L.push("A `book` note is ABOUT a book — the book itself is the entity you'd look up later; a single insight you took from a book is `type: idea` (or whatever it is), with the book credited in `source_author`/`source_name`.");
+  L.push("");
+  L.push("A `blog` note IS the post — the article's own text archived whole as the artifact; a note capturing what a post taught you is its own type (usually `idea`) with `source_kind: blog` carrying the provenance.");
+  L.push("");
 
   L.push("## Querying");
   L.push("");

--- a/LifeOS/install/LIFEOS/TOOLS/KnowledgeSchema.ts
+++ b/LifeOS/install/LIFEOS/TOOLS/KnowledgeSchema.ts
@@ -476,11 +476,19 @@ export function validate(parsed: ParsedNote, _slug: string, dirType: CanonicalTy
     else if (isEmptyField(f)) v.push({ key, problem: "required field is empty" });
   }
 
-  // type value
-  const t = deq(get("type"));
-  if (t && !(CANONICAL_TYPES as readonly string[]).includes(t)) {
-    v.push({ key: "type", problem: `"${t}" not a canonical type` });
+  // select-field values — EVERY select in the envelope declares a closed enum, so
+  // enforce them all. Checking only `type` left the other `values` lists as
+  // decoration: an off-vocabulary `source_kind` passed a fully clean lint.
+  for (const f of ENVELOPE) {
+    if (f.format !== "select" || !f.values) continue;
+    const val = deq(get(f.key));
+    if (val && !f.values.includes(val)) {
+      v.push({ key: f.key, problem: `"${val}" not a valid ${f.key} (${f.values.join(" | ")})` });
+    }
   }
+
+  // type vs directory
+  const t = deq(get("type"));
   if (t && (CANONICAL_TYPES as readonly string[]).includes(t) && t !== dirType) {
     // type disagrees with directory
     v.push({ key: "type", problem: `type "${t}" ≠ dir type "${dirType}"` });
@@ -634,6 +642,15 @@ Body.
   // #6 quoted/commented enum values pass (no false positive).
   const quoted = parseNote('---\nid: kb_x\ntype: "idea"\ntitle: X\ntags: [a]\nquality: 5\ncreated: 2026-01-01\nupdated: 2026-01-01\nconvention: "kb-v3"\n---\nb\n');
   check("#6 quoted type/convention not false-flagged", !validate(quoted, "x", "idea").some((v) => v.key === "type" || v.key === "convention"));
+
+  // #7 every select enum is enforced, not just `type`. An off-vocabulary
+  // `source_kind` used to pass validate() clean because only `type` was checked.
+  const badKind = parseNote('---\nid: kb_x\ntype: idea\ntitle: X\ntags: [a]\nquality: 5\nsource_kind: external\ncreated: 2026-01-01\nupdated: 2026-01-01\nconvention: kb-v3\n---\nb\n');
+  check("#7 off-vocabulary source_kind flagged", validate(badKind, "x", "idea").some((v) => v.key === "source_kind"));
+  const badStatus = parseNote('---\nid: kb_x\ntype: idea\ntitle: X\ntags: [a]\nquality: 5\nstatus: sprouting\ncreated: 2026-01-01\nupdated: 2026-01-01\nconvention: kb-v3\n---\nb\n');
+  check("#7 off-vocabulary status flagged", validate(badStatus, "x", "idea").some((v) => v.key === "status"));
+  const goodKind = parseNote('---\nid: kb_x\ntype: idea\ntitle: X\ntags: [a]\nquality: 5\nsource_kind: "video"\nstatus: seedling\ncreated: 2026-01-01\nupdated: 2026-01-01\nconvention: kb-v3\n---\nb\n');
+  check("#7 in-vocabulary select values pass", !validate(goodKind, "x", "idea").some((v) => v.key === "source_kind" || v.key === "status"));
 
   console.log(`\n${pass} passed, ${fail} failed`);
   return fail === 0 ? 0 : 1;

--- a/LifeOS/install/skills/Cortex/SKILL.md
+++ b/LifeOS/install/skills/Cortex/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: Cortex
 version: 2.1.2
-description: "Operate Cortex, the LifeOS memory system — the typed Knowledge Archive (People, Companies, Ideas, Research with typed related: links) plus recall of prior work sessions, ISAs, and conversations. Search, add, harvest, develop, ingest, distill, graph-navigate, recall. USE WHEN cortex, knowledge, knowledge base, search knowledge, what do we know about, archive, harvest, knowledge status, develop note, add to knowledge, ingest, contradictions, knowledge graph, retrieve, mine conversations, distill, weekly digest, cortex digest, context search, prior work, recall, remember, previous sessions, context recovery, what did we do, find session, search history, resume, pick up where we left off, cold start, yesterday's work, last week, the one about. NOT FOR published-content semantic search across blog/newsletter/X/LinkedIn, or one-shot URL/YouTube ingestion via the Arbol harvester pipeline."
+description: "Operate Cortex, the LifeOS memory system — the typed Knowledge Archive (People, Companies, Ideas, Research, Books, Blogs with typed related: links) plus recall of prior work sessions, ISAs, and conversations. Search, add, harvest, develop, ingest, distill, graph-navigate, recall. USE WHEN cortex, knowledge, knowledge base, search knowledge, what do we know about, archive, harvest, knowledge status, develop note, add to knowledge, ingest, contradictions, knowledge graph, retrieve, mine conversations, distill, weekly digest, cortex digest, context search, prior work, recall, remember, previous sessions, context recovery, what did we do, find session, search history, resume, pick up where we left off, cold start, yesterday's work, last week, the one about. NOT FOR published-content semantic search across blog/newsletter/X/LinkedIn, or one-shot URL/YouTube ingestion via the Arbol harvester pipeline."
 argument-hint: [search|add|harvest|develop|ingest|distill|recall|contradictions|graph|retrieve|mine|<query>]
 context: fork
 background: false
@@ -34,7 +34,7 @@ Workflows are inline command sections in this file (no Workflows/ dir); each row
 | `/knowledge` (no args) | **status** | Health dashboard |
 | `/knowledge <query>` | **search** | Search for notes matching query |
 | `/knowledge search <query>` | **search** | Explicit search |
-| `/knowledge add <type>` | **add** | Create a new note (People, Companies, or Ideas) |
+| `/knowledge add <type>` | **add** | Create a new note (People, Companies, Ideas, Research, Books, Blogs) |
 | `/knowledge harvest` | **harvest** | Run KnowledgeHarvester on all sources |
 | `/knowledge develop` | **develop** | Surface seedlings and enrich them |
 | `/knowledge ingest <url-or-file>` | **ingest** | Read source, create note, ripple updates to related notes |
@@ -104,7 +104,7 @@ If no results found, say so and suggest checking the full MEMORY/ system or runn
 
 Create a new note manually in the specified entity type.
 
-1. Validate type is one of: People, Companies, Ideas, Research
+1. Validate type is one of: People, Companies, Ideas, Research, Books, Blogs
 2. Ask for a title (or use remaining args after type)
 3. Generate kebab-case filename from title
 4. **MANDATORY: Find 2-3 related notes first.** Before writing the new note, grep existing Knowledge for related entities by topic/tags/name. This becomes the `related:` frontmatter array. No Knowledge note ships without typed links. See Canonical Linking Requirement below.
@@ -124,7 +124,7 @@ bun ~/.claude/LIFEOS/TOOLS/KnowledgeHarvester.ts index
 
 **Every write must include:**
 
-1. **`related:` frontmatter array** — 2-4 typed entries linking to other Knowledge entries (any domain: People, Companies, Ideas, Research)
+1. **`related:` frontmatter array** — 2-4 typed entries linking to other Knowledge entries (any domain: People, Companies, Ideas, Research, Books, Blogs)
 2. **Body wikilinks** — 1-3 `[[slug]]` references woven into the prose where natural (Implications, Evidence, or Context sections)
 
 **9 relationship types** (pick the most accurate, prefer specific over generic):
@@ -226,7 +226,7 @@ Summarize the source in 2-3 sentences. Identify key entities, claims, and insigh
 
 ### Step 2 — Classify and create primary note
 
-Determine entity type (People, Companies, Ideas, or Research) using the classification rules in `_schema.md`. Most ingested sources become Ideas.
+Determine entity type (People, Companies, Ideas, Research, Books, or Blogs) using the classification rules in `_schema.md`. Most ingested sources become Ideas.
 
 Create the primary note using the schema for that type:
 - Generate kebab-case slug from title (max 60 chars)


### PR DESCRIPTION
## The bug

`validate()` in `KnowledgeSchema.ts` checks `CANONICAL_TYPES` by hand and never reads the `values` list declared on the other select fields. So `source_kind`, `status` and `quality_inferred` can hold any string and still lint clean.

I found it because a note in my archive carries `source_kind: external` — not in `SOURCE_KINDS` — and passed a 100%-conformant run.

## The fix

Walk `ENVELOPE` and check every select that declares `values`. Adding a new controlled vocabulary to the envelope is then enforced by construction, instead of needing a matching hand-written branch that nobody remembers to write.

Three regression tests added (`#7`). They fail on current `main` and pass here.

## Evidence

- Smoke suite: **32 passed, 0 failed**. Reverting only the new loop: **30 passed, 2 failed**, and only the two enforcement tests go red.
- `KnowledgeLint` over a 334-note archive: **333/334 → 334/334** envelope-conformant, catching exactly the one off-vocabulary note and nothing else. No false positives across 334 real notes.

## Two smaller things in the same area

- **`_schema.md` now says when `book` and `blog` apply**, next to the existing bookmark rule. `type` and `source_kind` both contain the value `blog` and nothing stated which axis a blog post belongs on. It is `type: idea` + `source_kind: blog`; `type: blog` is the archived post itself. Both lines are descriptive of how the types are already used, not a new policy.
- **The shipped Cortex skill listed four note types in five places.** There are six — `Books` and `Blogs` were missing.

## Scope

No migrations, no vocabulary changes, no behaviour change for conformant notes. A non-conformant note starts reporting the violation it always had.

Related: #1986.