### PR TITLE
fix(isa-utils): function replacer in appendDecisionRow so ISA dollar amounts don't backref-expand

### DIFF
--- a/LifeOS/install/hooks/lib/isa-utils.test.ts
+++ b/LifeOS/install/hooks/lib/isa-utils.test.ts
@@ -1,0 +1,34 @@
+import { test, expect } from 'bun:test';
+import { appendDecisionRow } from './isa-utils';
+
+// Regression (2026-09-01 incident): the auto-rewind appended its Decisions row
+// with a STRING replacement built from the existing Decisions body. That body is
+// full of literal dollar amounts, and String.replace treats `$1`/`$2`/`$&` in a
+// replacement string as regex backreferences — so `$14,000` expanded to
+// `<capture-group-1>4,000`, duplicating the `## Decisions` header and shredding
+// the section. The fix uses a function replacer, whose return value is inserted
+// verbatim with no `$` interpretation.
+test('appendDecisionRow preserves dollar amounts and does not duplicate the section', () => {
+  // Synthetic amounts chosen so their leading digits are `$1`/`$2`/`$3`/`$4` —
+  // exactly the prefixes String.replace would misread as backreferences.
+  const content =
+    '---\nphase: complete\n---\n' +
+    '## Decisions\n' +
+    '- 2026-01-02: inflow +$12,000; net −$23,456.78; item $3,999; total $45,678.90\n' +
+    '## Learning\n- note\n';
+
+  const out = appendDecisionRow(content, '2026-09-01T00:00:00Z', 3);
+
+  // Every dollar amount survives intact (the `$1`/`$2`/`$3` prefixes are the trap).
+  for (const amt of ['$12,000', '$23,456.78', '$3,999', '$45,678.90']) {
+    expect(out).toContain(amt);
+  }
+  // Exactly one Decisions heading — no backref-driven duplication.
+  expect(out.match(/## Decisions/g)?.length).toBe(1);
+  // The auto-rewind row was appended under Decisions, above Learning.
+  expect(out).toContain('- D-auto-2026-09-01T00:00:00Z:');
+  expect(out.indexOf('D-auto-')).toBeLessThan(out.indexOf('## Learning'));
+  // No stray fragment line beginning with the tail of a split amount ($12,000 → 2,000).
+  expect(out).not.toMatch(/^2,000/m);
+  expect(out).not.toMatch(/^## Decisions[^\n]/m);
+});

--- a/LifeOS/install/hooks/lib/isa-utils.ts
+++ b/LifeOS/install/hooks/lib/isa-utils.ts
@@ -41,12 +41,16 @@ export function hashBody(content: string): string {
 /** Append one Decisions row to the body. Inserts under `## Decisions` heading,
  *  creating the section if missing. v6.9.0 invariant: every auto-rewind logs
  *  one row so the principal can audit the rewind inline. */
-function appendDecisionRow(content: string, ts: string, newIteration: number): string {
+export function appendDecisionRow(content: string, ts: string, newIteration: number): string {
   const row = `- D-auto-${ts}: Auto-resumed from complete to learn at ${ts} — iteration ${newIteration}`;
   const decisionsRe = /(\n## Decisions\n)([\s\S]*?)(\n## |\n---\n|$)/;
   const match = content.match(decisionsRe);
   if (match) {
-    return content.replace(decisionsRe, `${match[1]}${match[2].trimEnd()}\n${row}\n${match[3]}`);
+    // Function replacer, not a string: the existing Decisions body (match[2]) is
+    // full of literal dollar amounts, and a string replacement would interpret
+    // `$1`/`$2`/`$&` inside them as regex backreferences — a `$14,000` became
+    // `<group-1>4,000`, duplicating and shredding the section (2026-09-01 incident).
+    return content.replace(decisionsRe, () => `${match[1]}${match[2].trimEnd()}\n${row}\n${match[3]}`);
   }
   // No Decisions section yet — append before the learning-trail section if present
   // (## Learning, or the legacy ## Changelog alias for pre-rename ISAs), else end.


### PR DESCRIPTION
## What

`appendDecisionRow` (in `LifeOS/install/hooks/lib/isa-utils.ts`) appends the auto-rewind Decisions row using a **string** replacement built from the existing Decisions body:

```ts
return content.replace(decisionsRe, `${match[1]}${match[2].trimEnd()}\n${row}\n${match[3]}`);
```

## The bug

That Decisions body routinely contains literal dollar amounts. `String.prototype.replace` interprets `$1`, `$2`, `$&`, etc. in a **replacement string** as regex backreferences — so an amount like `$14,000` is read as *capture group 1* followed by `4,000`. On any resume of a completed ISA, the rewrite expands those into the captured section text, **duplicating the `## Decisions` heading and shredding the section** (a `$14,000` becomes `<group-1>4,000`, with fragment lines and repeated headers).

## The fix

Use a **function replacer**, whose return value is inserted verbatim with no `$` interpretation:

```ts
return content.replace(decisionsRe, () => `${match[1]}${match[2].trimEnd()}\n${row}\n${match[3]}`);
```

One line of behavior change, plus a short explanatory comment. `appendDecisionRow` is exported so it can be unit-tested.

## Test

Adds `isa-utils.test.ts`, a regression test using synthetic `$1`/`$2`/`$3`/`$4`-prefixed amounts. It asserts every amount survives intact, exactly one `## Decisions` heading remains, and the rewind row lands under Decisions. Fails on the old string replacement, passes on the fix.

```
bun test LifeOS/install/hooks/lib/isa-utils.test.ts   # 1 pass
```
