### PR TITLE
fix(install-engine): fail checkSurvivingPlaceholders on a zero-file scan

### DIFF
--- a/LifeOS/Tools/InstallEngine.ts
+++ b/LifeOS/Tools/InstallEngine.ts
@@ -491,14 +491,16 @@ const IDENTITY_PLACEHOLDERS = [
  * or abort.
  */
 export function checkSurvivingPlaceholders(rootDir: string): {
-  passed: boolean; files: Array<{ file: string; placeholder: string; count: number }>; total: number;
+  passed: boolean; files: Array<{ file: string; placeholder: string; count: number }>; total: number; scanned: number;
 } {
   const files: Array<{ file: string; placeholder: string; count: number }> = [];
   let total = 0;
+  let scanned = 0;
   const processFile = (filePath: string): void => {
     if (!TEMPLATE_EXTENSIONS.has(fileExtension(filePath))) return;
     let src: string;
     try { src = readFileSync(filePath, "utf-8"); } catch { return; }
+    scanned++;
     for (const placeholder of IDENTITY_PLACEHOLDERS) {
       const count = src.split(placeholder).length - 1;
       if (count > 0) { files.push({ file: filePath, placeholder, count }); total += count; }
@@ -515,7 +517,9 @@ export function checkSurvivingPlaceholders(rootDir: string): {
   };
   if (existsSync(rootDir) && lstatSync(rootDir).isFile()) processFile(rootDir);
   else walk(rootDir);
-  return { passed: total === 0, files, total };
+  // A scan that reached zero template files cannot vouch for anything: a mis-rooted or
+  // nonexistent rootDir must FAIL the Setup 9(d) gate, not pass it.
+  return { passed: scanned > 0 && total === 0, files, total, scanned };
 }
 
 /**

--- a/LifeOS/install/skills/LifeOS/Tools/InstallEngine.ts
+++ b/LifeOS/install/skills/LifeOS/Tools/InstallEngine.ts
@@ -491,14 +491,16 @@ const IDENTITY_PLACEHOLDERS = [
  * or abort.
  */
 export function checkSurvivingPlaceholders(rootDir: string): {
-  passed: boolean; files: Array<{ file: string; placeholder: string; count: number }>; total: number;
+  passed: boolean; files: Array<{ file: string; placeholder: string; count: number }>; total: number; scanned: number;
 } {
   const files: Array<{ file: string; placeholder: string; count: number }> = [];
   let total = 0;
+  let scanned = 0;
   const processFile = (filePath: string): void => {
     if (!TEMPLATE_EXTENSIONS.has(fileExtension(filePath))) return;
     let src: string;
     try { src = readFileSync(filePath, "utf-8"); } catch { return; }
+    scanned++;
     for (const placeholder of IDENTITY_PLACEHOLDERS) {
       const count = src.split(placeholder).length - 1;
       if (count > 0) { files.push({ file: filePath, placeholder, count }); total += count; }
@@ -515,7 +517,9 @@ export function checkSurvivingPlaceholders(rootDir: string): {
   };
   if (existsSync(rootDir) && lstatSync(rootDir).isFile()) processFile(rootDir);
   else walk(rootDir);
-  return { passed: total === 0, files, total };
+  // A scan that reached zero template files cannot vouch for anything: a mis-rooted or
+  // nonexistent rootDir must FAIL the Setup 9(d) gate, not pass it.
+  return { passed: scanned > 0 && total === 0, files, total, scanned };
 }
 
 /**


### PR DESCRIPTION
Fixes #2058. Version: main @ 5e2f2e8 (also present in 7.40.4). File: `LifeOS/install/skills/LifeOS/Tools/InstallEngine.ts:518`, and its byte-identical sibling `LifeOS/Tools/InstallEngine.ts` (Setup.md step 9(d) runs the outer copy; `Doctor.ts` imports the deployed one; both are patched here).

**Repro against a clean tree** (script imports the shipped function and points it at four temp roots):

```
nonexistent                              -> passed=true  total=0 files=0   <- bug
empty dir                                -> passed=true  total=0 files=0   <- bug
positive control (placeholder present)   -> passed=false total=1 files=1
clean rendered dir                       -> passed=true  total=0 files=0
```

**After this change:**

```
nonexistent                              -> passed=false total=0 files=0
empty dir                                -> passed=false total=0 files=0
positive control (placeholder present)   -> passed=false total=1 files=1
clean rendered dir                       -> passed=true  total=0 files=0
```

**Fix:** count files actually read (`scanned`) and require `scanned > 0 && total === 0`. The return type gains `scanned` for diagnostics. `Doctor.ts` sums `total` and never reads `passed`, so its behavior is unchanged. Setup 9(d) passes the full config root, which always holds `CLAUDE.md` and `settings.json` (both template extensions), so a real install still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvY8QkJKBWyXcZeL2Q2UXc