### PR TITLE
Fix Pulse menu bar installer reporting success on a failed load

### DIFF
--- a/LifeOS/install/LIFEOS/PULSE/MenuBar/install.sh
+++ b/LifeOS/install/LIFEOS/PULSE/MenuBar/install.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 HOME_DIR="$HOME"
 APP_NAME="LifeOS Pulse"
+BINARY_NAME="LifeOS Pulse"
 APP_DIR="$HOME_DIR/Applications"
 APP_DEST="$APP_DIR/$APP_NAME.app"
 OLD_APP="$APP_DIR/PAI Monitor.app"
@@ -70,8 +71,37 @@ echo "  Installed $PLIST_DST"
 # Ensure logs directory exists
 mkdir -p "$HOME_DIR/.claude/LIFEOS/PULSE/logs"
 
-launchctl load "$PLIST_DST"
-echo "  Loaded $PLIST_LABEL"
+# `launchctl load` is the legacy API: it prints "Load failed: N: ..." to stderr
+# but still exits 0, so `set -e` cannot see it. Use the domain-target API, which
+# returns a real exit status, and bootout first so a stale registration of the
+# same label cannot fail the bootstrap with EX 5 (Input/output error).
+DOMAIN="gui/$(id -u)"
+launchctl bootout "$DOMAIN/$PLIST_LABEL" 2>/dev/null || true
+
+if ! launchctl bootstrap "$DOMAIN" "$PLIST_DST"; then
+    echo "  ERROR: launchctl bootstrap failed for $PLIST_LABEL" >&2
+    echo "  The menu bar is NOT installed. Plist: $PLIST_DST" >&2
+    exit 1
+fi
+echo "  Bootstrapped $PLIST_LABEL"
+
+# A successful bootstrap only means launchd accepted the job definition.
+# Confirm the process actually came up before claiming the menu bar is running.
+BINARY_PATH="$APP_DEST/Contents/MacOS/$BINARY_NAME"
+for _ in $(seq 1 10); do
+    if pgrep -f "$BINARY_PATH" >/dev/null 2>&1; then
+        RUNNING=1
+        break
+    fi
+    sleep 0.5
+done
+
+if [ "${RUNNING:-0}" -ne 1 ]; then
+    echo "  ERROR: $PLIST_LABEL was bootstrapped but no process is running." >&2
+    echo "  Check $HOME_DIR/.claude/LIFEOS/PULSE/logs/menubar-stderr.log" >&2
+    launchctl print "$DOMAIN/$PLIST_LABEL" 2>&1 | grep -E "last exit code|state =" >&2 || true
+    exit 1
+fi
 
 echo ""
 echo "=== Installation complete ==="


### PR DESCRIPTION
Fixes #2068.

## What this changes

`LIFEOS/PULSE/MenuBar/install.sh` claimed a successful install whether or not the menu bar started. Step 6 used `launchctl load`, the legacy launchctl API, which writes `Load failed: N: ...` to stderr and still exits `0`. The `set -euo pipefail` on line 5 never fired, so the script printed `Installation complete` and `LifeOS Pulse menu bar is now running` on top of a job that had not started.

## Why the obvious one-line fix is not enough

Checking the exit status of the load call closes only half of it. There are two independent failures here and a probe that catches the first still goes green on the second:

1. **`launchctl load` returns 0 on failure.** Fixed by moving to the domain-target API, `launchctl bootstrap gui/$UID`, which returns a real exit status. A `bootout` runs first so a stale registration of the same label cannot fail the bootstrap with EX 5 (`Input/output error`) on reinstall — which is the case step 4's `launchctl unload` was already trying, and failing, to handle.

2. **A bootstrap can succeed while nothing runs.** launchd accepts a job whose plist names a program that does not exist and returns `0`. That is precisely the failure this started from: the plist pointed at `~/Applications/LifeOS Pulse.app/...` on a machine where the bundle had never been built, launchd respawned and failed with `78` (EX_CONFIG) indefinitely, and the installer had reported success. So the script now polls for the deployed binary and only claims success once a process exists.

The failure path points at `menubar-stderr.log` and prints the job's last exit code, since when the program itself cannot be executed those log files are never created and the obvious next debugging step turns up an empty directory.

## Testing

macOS 15 (Darwin 25.6.0), Apple silicon.

| Case | Setup | Result |
|---|---|---|
| Red | throwaway label, plist names a nonexistent binary | `bootstrap` returns 0, process check fails, script exits **1** |
| Green | throwaway label, plist names a real long-running binary | exits **0** |
| End to end | patched `install.sh` against a live install | no `Load failed` line, exits **0**; `launchctl print` reports `state = running`, `last exit code = (never exited)`, where the same box previously showed `78` |

Both throwaway labels were booted out and their plists removed after the run.

## Notes

- Adds `BINARY_NAME`, which `build.sh` already defines but `install.sh` did not, so the process check has a path to match against rather than a bare app name.
- Behaviour on a healthy install is unchanged apart from `Loaded <label>` becoming `Bootstrapped <label>`.
- No change to `build.sh`, the plist, or the Swift source.